### PR TITLE
Added options for Arch Linux in the download options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The LBRY app is a graphical browser for the decentralized content marketplace pr
 
 We provide installers for Windows, macOS (v10.9 or greater), and Debian-based Linux.
 
-|                       | Windows                                      | macOS                                        | Linux                                        |
-| --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
-| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)     |
-| Latest Pre-release     | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb) |
+|                       | Windows                                      | macOS                                        | Linux                                        | Alt. Linux Build
+| --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | --------------------------------------------
+| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)     | [Download]https://aur.archlinux.org/packages/lbry-app-release/) 
+| Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb) | [Download](https://aur.archlinux.org/packages/lbry-app-release/) 
 
 Our [releases page](https://github.com/lbryio/lbry-app/releases) also contains the latest
 release, pre-releases, and past builds.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ We provide installers for Windows, macOS (v10.9 or greater), Arch-based Linux, a
 
 |                       | Windows                                      | macOS                                        | Linux                                        | Alt. Linux Build
 | --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
-| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)     | [Download](https://aur.archlinux.org/packages/lbry-app-release/) 
-| Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb) | [Download](https://aur.archlinux.org/packages/lbry-app-release/) 
+| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)     | [Download](https://aur.archlinux.org/packages/lbry-app-bin/) 
+| Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb) | [Download](https://aur.archlinux.org/packages/lbry-app-bin/) 
 
 Our [releases page](https://github.com/lbryio/lbry-app/releases) also contains the latest
 release, pre-releases, and past builds.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The LBRY app is a graphical browser for the decentralized content marketplace pr
 We provide installers for Windows, macOS (v10.9 or greater), and Debian-based Linux.
 
 |                       | Windows                                      | macOS                                        | Linux                                        | Alt. Linux Build
-| --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | --------------------------------------------
-| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)     | [Download]https://aur.archlinux.org/packages/lbry-app-release/) 
+| --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
+| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)     | [Download](https://aur.archlinux.org/packages/lbry-app-release/) 
 | Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb) | [Download](https://aur.archlinux.org/packages/lbry-app-release/) 
 
 Our [releases page](https://github.com/lbryio/lbry-app/releases) also contains the latest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The LBRY app is a graphical browser for the decentralized content marketplace pr
 
 ## Install
 
-We provide installers for Windows, macOS (v10.9 or greater), and Debian-based Linux.
+We provide installers for Windows, macOS (v10.9 or greater), Arch-based Linux, and Debian-based Linux.
 
 |                       | Windows                                      | macOS                                        | Linux                                        | Alt. Linux Build
 | --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -14,17 +14,25 @@ The LBRY app is a graphical browser for the decentralized content marketplace pr
 
 ## Install
 
-We provide installers for Windows, macOS (v10.9 or greater), Arch-based Linux, and Debian-based Linux.
+We provide installers for Windows, macOS (v10.9 or greater), and Debian-based Linux. See community maintained builds section for alternative Linux installations. 
 
-|                       | Windows                                      | macOS                                        | Linux                                        | Alt. Linux Build
-| --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
-| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)     | [Download](https://aur.archlinux.org/packages/lbry-app-bin/) 
-| Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb) | [Download](https://aur.archlinux.org/packages/lbry-app-bin/) 
+|                       | Windows                                      | macOS                                        | Linux                                        
+| --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
+| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)
+| Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb)
 
 Our [releases page](https://github.com/lbryio/lbry-app/releases) also contains the latest
 release, pre-releases, and past builds.
 
-To install from source or make changes to the application, continue reading below.
+To install from source or make changes to the application, continue to the next section below.   
+
+**Community maintained** builds for Arch Linux and Flatpak are available, see below. These installs will need to be updated manually as the in-app update process only supports deb installs at this time. 
+*Note: If coming from a deb install, the directory structure is different and you'll need to [migrate data](https://lbry.io/faq/backup-data).*
+
+|                       | Flatpak                                | Arch                                                                                            
+| --------------------- | ------------------------------------------| -------------------------------------------- 
+| Latest Release        | [FlatHub Page](https://flathub.org/apps/details/io.lbry.lbry-app)   | [AUR Package](https://aur.archlinux.org/packages/lbry-app-bin/)   
+| Maintainers            | [@choofee](https://github.com/choffee)/[@iuyte](https://github.com/iuyte)    | [@kcseb]()/[@TimurKiyivinski](https://github.com/TimurKiyivinski) 
 
 ## Usage
 Double click the installed application to browse with the LBRY network.


### PR DESCRIPTION
Added the AUR URLs to the default download options under "Alt. Linux Build"

Before - http://hfimg.pw/i/g4py9.png
After - http://hfimg.pw/i/ohzrm.png