### PR TITLE
Channel page caching

### DIFF
--- a/src/renderer/component/common/busy-indicator.jsx
+++ b/src/renderer/component/common/busy-indicator.jsx
@@ -5,10 +5,20 @@ type Props = {
   message: ?string,
 };
 
-const BusyIndicator = (props: Props) => (
-  <span className="busy-indicator">
-    {props.message} <span className="busy-indicator__loader" />
-  </span>
-);
+class BusyIndicator extends React.PureComponent<Props> {
+  static defaultProps = {
+    message: '',
+  };
+
+  render() {
+    const { message } = this.props;
+
+    return (
+      <span className="busy-indicator">
+        {message} <span className="busy-indicator__loader" />
+      </span>
+    );
+  }
+}
 
 export default BusyIndicator;

--- a/src/renderer/page/channel/view.jsx
+++ b/src/renderer/page/channel/view.jsx
@@ -48,7 +48,7 @@ class ChannelPage extends React.PureComponent<Props> {
     this.props.navigate('/show', newParams);
   }
 
-  paginate(e, totalPages: number) {
+  paginate(e: SyntheticKeyboardEvent<*>, totalPages: number) {
     // Change page if enter was pressed, and the given page is between
     // the first and the last.
     const pageFromInput = Number(e.target.value);
@@ -67,22 +67,21 @@ class ChannelPage extends React.PureComponent<Props> {
     const { fetching, claimsInChannel, claim, page, totalPages } = this.props;
     const { name, permanent_url: permanentUrl, claim_id: claimId } = claim;
     const currentPage = parseInt((page || 1) - 1, 10);
-    let contentList;
-    if (fetching) {
-      contentList = <BusyIndicator message={__('Fetching content')} />;
-    } else {
-      contentList =
-        claimsInChannel && claimsInChannel.length ? (
-          <FileList sortByHeight hideFilter fileInfos={claimsInChannel} />
-        ) : (
-          <span className="empty">{__('No content found.')}</span>
-        );
-    }
+
+    const contentList =
+      claimsInChannel && claimsInChannel.length ? (
+        <FileList sortByHeight hideFilter fileInfos={claimsInChannel} />
+      ) : (
+        !fetching && <span className="empty">{__('No content found.')}</span>
+      );
 
     return (
       <Page notContained>
         <section className="card__channel-info card__channel-info--large">
-          <h1>{name}</h1>
+          <h1>
+            {name}
+            {fetching && <BusyIndicator />}
+          </h1>
           <div className="card__actions card__actions--no-margin">
             <SubscribeButton uri={permanentUrl} channelName={name} />
             <ViewOnWebButton claimId={claimId} claimName={name} />


### PR DESCRIPTION
Issue #1255 

Moves `<BusyIndicator>` to title bar.

Refactors `contentList` to show "No content found" only after fetch is complete; `null` while fetching.

![channel page fetching](https://user-images.githubusercontent.com/34498824/42529216-e106674c-844b-11e8-84db-6e26c3fa2957.png)

There is still some chance that a user will click the wrong tile but the update is very fast and pretty smooth. The best way I see to prevent this is to disable navigation for ~1sec following the update. This could be done by adding a throttle property to the state along with corresponding actions, reducers, and a thunk in doNavigate, or migrating from thunks to middleware, both of which seem well beyond the scope of this issue.