### PR TITLE
fetch rewards on page load

### DIFF
--- a/src/renderer/page/rewards/index.js
+++ b/src/renderer/page/rewards/index.js
@@ -1,15 +1,20 @@
 import { connect } from 'react-redux';
-import { selectFetchingRewards, selectUnclaimedRewards } from 'redux/selectors/rewards';
+import {
+  selectFetchingRewards,
+  selectUnclaimedRewards,
+  selectClaimedRewards,
+} from 'redux/selectors/rewards';
 import { selectUser } from 'redux/selectors/user';
 import { doAuthNavigate, doNavigate } from 'redux/actions/navigation';
 import { doRewardList } from 'redux/actions/rewards';
 import { selectDaemonSettings } from 'redux/selectors/settings';
 import RewardsPage from './view';
 
-const select = (state, props) => ({
+const select = state => ({
   daemonSettings: selectDaemonSettings(state),
   fetching: selectFetchingRewards(state),
   rewards: selectUnclaimedRewards(state),
+  claimed: selectClaimedRewards(state),
   user: selectUser(state),
 });
 
@@ -21,4 +26,7 @@ const perform = dispatch => ({
   },
 });
 
-export default connect(select, perform)(RewardsPage);
+export default connect(
+  select,
+  perform
+)(RewardsPage);

--- a/src/renderer/page/rewards/view.jsx
+++ b/src/renderer/page/rewards/view.jsx
@@ -28,11 +28,7 @@ type Props = {
 
 class RewardsPage extends React.PureComponent<Props> {
   componentDidMount() {
-    const { fetching, rewards, fetchRewards } = this.props;
-
-    if (!fetching && (!rewards || !rewards.length)) {
-      fetchRewards();
-    }
+    this.props.fetchRewards();
   }
 
   renderPageHeader() {

--- a/src/renderer/page/rewards/view.jsx
+++ b/src/renderer/page/rewards/view.jsx
@@ -117,7 +117,7 @@ class RewardsPage extends React.PureComponent<Props> {
     } else if (!rewards || rewards.length <= 0) {
       return (
         <div className="card__content">
-          {claimed && Object.keys(claimed).length
+          {claimed && claimed.length
             ? __(
                 "You have claimed all available rewards! We're regularly adding more so be sure to check back later."
               )

--- a/src/renderer/page/rewards/view.jsx
+++ b/src/renderer/page/rewards/view.jsx
@@ -6,12 +6,15 @@ import RewardTile from 'component/rewardTile';
 import Button from 'component/button';
 import Page from 'component/page';
 import classnames from 'classnames';
+import type { Reward } from 'types/reward';
 
 type Props = {
   doAuth: () => void,
+  fetchRewards: () => void,
   navigate: string => void,
   fetching: boolean,
-  rewards: Array<{ reward_type: boolean }>,
+  rewards: Array<Reward>,
+  claimed: Array<Reward>,
   user: ?{
     is_identity_verified: boolean,
     is_reward_approved: boolean,
@@ -24,27 +27,13 @@ type Props = {
 };
 
 class RewardsPage extends React.PureComponent<Props> {
-  /*
-    Below is broken for users who have claimed all rewards.
+  componentDidMount() {
+    const { fetching, rewards, fetchRewards } = this.props;
 
-    It can safely be disabled since we fetch all rewards after authentication, but should be re-enabled once fixed.
-
-   */
-  // componentDidMount() {
-  //   this.fetchRewards(this.props);
-  // }
-  //
-  // componentWillReceiveProps(nextProps) {
-  //   this.fetchRewards(nextProps);
-  // }
-  //
-  // fetchRewards(props) {
-  //   const { fetching, rewards, fetchRewards } = props;
-  //
-  //   if (!fetching && (!rewards || !rewards.length)) {
-  //     fetchRewards();
-  //   }
-  // }
+    if (!fetching && (!rewards || !rewards.length)) {
+      fetchRewards();
+    }
+  }
 
   renderPageHeader() {
     const { doAuth, navigate, user, daemonSettings } = this.props;
@@ -96,7 +85,7 @@ class RewardsPage extends React.PureComponent<Props> {
   }
 
   renderUnclaimedRewards() {
-    const { fetching, rewards, user, daemonSettings, navigate } = this.props;
+    const { fetching, rewards, user, daemonSettings, navigate, claimed } = this.props;
 
     if (daemonSettings && !daemonSettings.share_usage_data) {
       return (
@@ -128,7 +117,11 @@ class RewardsPage extends React.PureComponent<Props> {
     } else if (!rewards || rewards.length <= 0) {
       return (
         <div className="card__content">
-          {__('There are no rewards available at this time, please check back later.')}
+          {claimed && Object.keys(claimed).length
+            ? __(
+                "You have claimed all available rewards! We're regularly adding more so be sure to check back later."
+              )
+            : __('There are no rewards available at this time, please check back later.')}
         </div>
       );
     }

--- a/src/renderer/types/reward.js
+++ b/src/renderer/types/reward.js
@@ -1,0 +1,14 @@
+// @flow
+
+export type Reward = {
+  created_at: string,
+  id: number,
+  reward_amount: number,
+  reward_description: string,
+  reward_notification: string,
+  reward_title: string,
+  reward_type: string,
+  reward_version: ?string,
+  transaction_id: ?string,
+  updated_at: ?string,
+};


### PR DESCRIPTION
#1572 

Removes the `componentDidReceiveProps` hook from the `<RewardsPage>` component, which was firing repeatedly.

Passes in claimed rewards through the container to differentiate between "none available" and "you claimed them all".