### PR TITLE
Add or claimId clause to avoid getting a console log.

### DIFF
--- a/src/renderer/component/fileList/view.jsx
+++ b/src/renderer/component/fileList/view.jsx
@@ -168,7 +168,8 @@ class FileList extends React.PureComponent<Props, State> {
       const uri = buildURI(uriParams);
 
       // See https://github.com/lbryio/lbry-app/issues/1327 for discussion around using outpoint as the key
-      content.push(<FileCard key={outpoint} uri={uri} checkPending={checkPending} />);
+      // Outpoint is undefined on this list that's why the `|| claimId` fix the key console log error.
+      content.push(<FileCard key={outpoint || claimId} uri={uri} checkPending={checkPending} />);
     });
 
     return (


### PR DESCRIPTION
Work around to remove the warning log is add an or clause as the outpoint is undefined.
Why outpoint is undefined ? I didn't understand that part.
I've saw a comment referencing issue: #1327 

Anyway, feel free to ask me any changes!