### PR TITLE
lbry-app > lbry-desktop

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ Thanks for reporting an issue to LBRY and helping us improve!
 To make it possible for us to help you, please fill out below information carefully.
 
 Before reporting any issues, please make sure that you're using the latest version.
-- App releases: https://github.com/lbryio/lbry-app/releases
+- App releases: https://github.com/lbryio/lbry-desktop/releases
 - Standalone daemon: https://github.com/lbryio/lbry/releases
 
 We are also available on live chat at https://chat.lbry.io
@@ -48,4 +48,3 @@ Tell us your suggested solutions if you have any.
 
 ## Screenshots
 <!-- If a screenshot would help explain the bug, please include one or two here -->
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [0.22.2] - 2018-07-09
 
 ### Fixed
-  * Fixed 'Get Credits' screen so the app doesn't break when LBC is unavailable on ShapeShift ([#1739](https://github.com/lbryio/lbry-app/pull/1739))
+  * Fixed 'Get Credits' screen so the app doesn't break when LBC is unavailable on ShapeShift ([#1739](https://github.com/lbryio/lbry-desktop/pull/1739))
 
 
 ## [0.22.1] - 2018-07-05
@@ -25,100 +25,100 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 
 ### Fixed
-  * Take previous bid amount into account when determining how much users have available to deposit ([#1725](https://github.com/lbryio/lbry-app/pull/1725))
-  * Sidebar sizing on larger screens ([#1709](https://github.com/lbryio/lbry-app/pull/1709))
-  * Publishing scenario while editing and changing URI ([#1716](https://github.com/lbryio/lbry-app/pull/1716))
-  * Fix can't right click > paste into description on publish ([#1664](https://github.com/lbryio/lbry-app/issues/1664))
-  * Mac/Linux error when starting app up too quickly after shutdown ([#1727](https://github.com/lbryio/lbry-app/pull/1727))
-  * Console errors when multiple downloads for same claim exist ([#1724](https://github.com/lbryio/lbry-app/pull/1724))
-  * App version in dev mode ([#1722](https://github.com/lbryio/lbry-app/pull/1722))
-  * Long URI name displays in transaction list/Help ([#1694](https://github.com/lbryio/lbry-app/pull/1694))/([#1692](https://github.com/lbryio/lbry-app/pull/1692))
+  * Take previous bid amount into account when determining how much users have available to deposit ([#1725](https://github.com/lbryio/lbry-desktop/pull/1725))
+  * Sidebar sizing on larger screens ([#1709](https://github.com/lbryio/lbry-desktop/pull/1709))
+  * Publishing scenario while editing and changing URI ([#1716](https://github.com/lbryio/lbry-desktop/pull/1716))
+  * Fix can't right click > paste into description on publish ([#1664](https://github.com/lbryio/lbry-desktop/issues/1664))
+  * Mac/Linux error when starting app up too quickly after shutdown ([#1727](https://github.com/lbryio/lbry-desktop/pull/1727))
+  * Console errors when multiple downloads for same claim exist ([#1724](https://github.com/lbryio/lbry-desktop/pull/1724))
+  * App version in dev mode ([#1722](https://github.com/lbryio/lbry-desktop/pull/1722))
+  * Long URI name displays in transaction list/Help ([#1694](https://github.com/lbryio/lbry-desktop/pull/1694))/([#1692](https://github.com/lbryio/lbry-desktop/pull/1692))
   * Edit option missing from certain published claims ([#175](https://github.com/lbryio/lbry-desktop/issues/1756))
-  
+
 ### Changed
-  * Show claim name, instead of URI, when loading a channel([#1711](https://github.com/lbryio/lbry-app/pull/1711))
+  * Show claim name, instead of URI, when loading a channel([#1711](https://github.com/lbryio/lbry-desktop/pull/1711))
   * Updated LBRY daemon to 0.20.3 which contains some availability improvements ([v0.20.3](https://github.com/lbryio/lbry/releases/tag/v0.20.3))
 
 ## [0.22.0] - 2018-06-26
 
 ### Added
-   * Ability to upload thumbnails through spee.ch while publishing ([#1248](https://github.com/lbryio/lbry-app/pull/1248))
-   * QR code for wallet address to Send and Receive page ([#1582](https://github.com/lbryio/lbry-app/pull/1582))
-   * "View on Web" button on file/channel pages with spee.ch link ([#1222](https://github.com/lbryio/lbry-app/pull/1222))
-   * Autoplay downloaded and free media along with toggle ([#584](https://github.com/lbryio/lbry-app/pull/1453))
-   * Ability to get latest claims from channel on homepage (currently inactive) ([#1267](https://github.com/lbryio/lbry-app/pull/1267))
-   * Confirmation prompt when sending credits ([#1525](https://github.com/lbryio/lbry-app/pull/1525))
-   * Ability to right click > copy lbry:// hyperlink on tiles ([#1486](https://github.com/lbryio/lbry-app/pull/1486))
-   * Buttons to open log file and log directory on the help page ([#1556](https://github.com/lbryio/lbry-app/issues/1556))
-   * Ability to resend verification email ([#1492](https://github.com/lbryio/lbry-app/issues/1492))
-   * Keyboard shortcut to quit the app on Windows ([#1202](https://github.com/lbryio/lbry-app/pull/1202))
-   * Build for both architectures (x86 and x64) for Windows ([#1262](https://github.com/lbryio/lbry-app/pull/1262))
-   * Referral FAQ to Invites screen ([#1314](https://github.com/lbryio/lbry-app/pull/1314))
-   * Show exact wallet balance on mouse hover over ([#1305](https://github.com/lbryio/lbry-app/pull/1305))
-   * Pre-fill publish URL after clicking "Put something here" link ([#1303](https://github.com/lbryio/lbry-app/pull/1303))
-   * Danger JS to automate code reviews ([#1289](https://github.com/lbryio/lbry-app/pull/1289))
-   * 'Go to page' input on channel pagination ([#1166](https://github.com/lbryio/lbry-app/pull/1166))
+   * Ability to upload thumbnails through spee.ch while publishing ([#1248](https://github.com/lbryio/lbry-desktop/pull/1248))
+   * QR code for wallet address to Send and Receive page ([#1582](https://github.com/lbryio/lbry-desktop/pull/1582))
+   * "View on Web" button on file/channel pages with spee.ch link ([#1222](https://github.com/lbryio/lbry-desktop/pull/1222))
+   * Autoplay downloaded and free media along with toggle ([#584](https://github.com/lbryio/lbry-desktop/pull/1453))
+   * Ability to get latest claims from channel on homepage (currently inactive) ([#1267](https://github.com/lbryio/lbry-desktop/pull/1267))
+   * Confirmation prompt when sending credits ([#1525](https://github.com/lbryio/lbry-desktop/pull/1525))
+   * Ability to right click > copy lbry:// hyperlink on tiles ([#1486](https://github.com/lbryio/lbry-desktop/pull/1486))
+   * Buttons to open log file and log directory on the help page ([#1556](https://github.com/lbryio/lbry-desktop/issues/1556))
+   * Ability to resend verification email ([#1492](https://github.com/lbryio/lbry-desktop/issues/1492))
+   * Keyboard shortcut to quit the app on Windows ([#1202](https://github.com/lbryio/lbry-desktop/pull/1202))
+   * Build for both architectures (x86 and x64) for Windows ([#1262](https://github.com/lbryio/lbry-desktop/pull/1262))
+   * Referral FAQ to Invites screen ([#1314](https://github.com/lbryio/lbry-desktop/pull/1314))
+   * Show exact wallet balance on mouse hover over ([#1305](https://github.com/lbryio/lbry-desktop/pull/1305))
+   * Pre-fill publish URL after clicking "Put something here" link ([#1303](https://github.com/lbryio/lbry-desktop/pull/1303))
+   * Danger JS to automate code reviews ([#1289](https://github.com/lbryio/lbry-desktop/pull/1289))
+   * 'Go to page' input on channel pagination ([#1166](https://github.com/lbryio/lbry-desktop/pull/1166))
 
 ### Changed
-   * LBRY App UI Redesign 5.0 implemented including new theme, layout, and improved search mechanics ([#870](https://github.com/lbryio/lbry-app/pull/870)) and ([#1173](https://github.com/lbryio/lbry-app/pull/1173))
+   * LBRY App UI Redesign 5.0 implemented including new theme, layout, and improved search mechanics ([#870](https://github.com/lbryio/lbry-desktop/pull/870)) and ([#1173](https://github.com/lbryio/lbry-desktop/pull/1173))
    * Updated LBRY daemon to 0.20.2 which improves speed and reliability. ([v0.20.0](https://github.com/lbryio/lbry/releases/tag/v0.20.0), [v0.20.1](https://github.com/lbryio/lbry/releases/tag/v0.20.1), [v0.20.2](https://github.com/lbryio/lbry/releases/tag/v0.20.2))
-   * Adapted dark mode to redesign ([#1269](https://github.com/lbryio/lbry-app/pull/1269))
-   * Show latest claims for across all subscribed channel (no longer grouped by channel) and store sub data in internal database ([#1424](https://github.com/lbryio/lbry-app/pull/1424))
-   * New publishes now show as pending on Publishes screen ([#1040](https://github.com/lbryio/lbry-app/pull/1040))
-   * Enhanced flair to snackbar ([#1313](https://github.com/lbryio/lbry-app/pull/1313))
-   * Made font in price badge larger ([#1420](https://github.com/lbryio/lbry-app/pull/1420))
-   * Move rewards logic to interal api ([#1509](https://github.com/lbryio/lbry-app/pull/1509))
-   * Narrative about Feature Request on Help Page and Report Page ([#1551](https://github.com/lbryio/lbry-app/pull/1551))
+   * Adapted dark mode to redesign ([#1269](https://github.com/lbryio/lbry-desktop/pull/1269))
+   * Show latest claims for across all subscribed channel (no longer grouped by channel) and store sub data in internal database ([#1424](https://github.com/lbryio/lbry-desktop/pull/1424))
+   * New publishes now show as pending on Publishes screen ([#1040](https://github.com/lbryio/lbry-desktop/pull/1040))
+   * Enhanced flair to snackbar ([#1313](https://github.com/lbryio/lbry-desktop/pull/1313))
+   * Made font in price badge larger ([#1420](https://github.com/lbryio/lbry-desktop/pull/1420))
+   * Move rewards logic to interal api ([#1509](https://github.com/lbryio/lbry-desktop/pull/1509))
+   * Narrative about Feature Request on Help Page and Report Page ([#1551](https://github.com/lbryio/lbry-desktop/pull/1551))
 
 
 ### Fixed
-   * Create channel and publish immediately([#1481](https://github.com/lbryio/lbry-app/pull/1481))
-   * Price not updated on tile/file page ([#797](https://github.com/lbryio/lbry-app/issues/797))
-   * Markdown rendering support on show page ([#1179](https://github.com/lbryio/lbry-app/issues/1179))
-   * Content address extending outside of visible area ([#741](https://github.com/lbryio/lbry-app/issues/741))
-   * Content-type not shown correctly in file description ([#863](https://github.com/lbryio/lbry-app/pull/863))
-   * Fix [Flow](https://flow.org/) ([#1197](https://github.com/lbryio/lbry-app/pull/1197))
-   * Black screen on macOS after maximizing LBRY and then closing ([#1235](https://github.com/lbryio/lbry-app/pull/1235))
-   * Download percentage indicator overlay ([#1271](https://github.com/lbryio/lbry-app/issues/1271))
-   * Alternate row shading for transactions on dark theme ([#1355](https://github.com/lbryio/lbry-app/issues/#1355))
-   * Don't allow dark mode with automatic night mode enabled ([#1005](https://github.com/lbryio/lbry-app/issues/1005))
-   * Description box on Publish (dark theme) ([#1356](https://github.com/lbryio/lbry-app/issues/#1356))
-   * Price wrapping in price badge ([#1420](https://github.com/lbryio/lbry-app/pull/1420))
-   * Spacing in search suggestions ([#1422](https://github.com/lbryio/lbry-app/pull/1422))
-   * Text/HTML files don't display correctly in-app anymore ([#1379](https://github.com/lbryio/lbry-app/issues/1379))
-   * Notification modals when reward is claimed ([#1436](https://github.com/lbryio/lbry-app/issues/1436)) and ([#1407](https://github.com/lbryio/lbry-app/issues/1407))
-   * Disabled cards(grayed out) ([#1466](https://github.com/lbryio/lbry-app/issues/1466))
-   * New lines not showing correctly after markdown changes ([#1504](https://github.com/lbryio/lbry-app/issues/1504))
-   * Claim ID being null when reporting a claim that was not previously downloaded ([PR#1530](https://github.com/lbryio/lbry-app/pull/1530))
-   * URI and outpoint not being passed properly to API ([#1494](https://github.com/lbryio/lbry-app/issues/1494))
-   * Incorrect markdown preview on url with parentheses ([#1570](https://github.com/lbryio/lbry-app/issues/1570))
-   * Fix Linux upgrade path and add manual installation note ([#1606](https://github.com/lbryio/lbry-app/issues/1606))
-   * Fix can type in unfocused fields while publishing without selecting file ([#1456](https://github.com/lbryio/lbry-app/issues/1456))
-   * Fix navigation button resulting incorrect page designation ([#1502](https://github.com/lbryio/lbry-app/issues/1502))
-   * Fix shouldn't allow to open multiple export and choose file dialogs ([#1175](https://github.com/lbryio/lbry-app/issues/1175))
+   * Create channel and publish immediately([#1481](https://github.com/lbryio/lbry-desktop/pull/1481))
+   * Price not updated on tile/file page ([#797](https://github.com/lbryio/lbry-desktop/issues/797))
+   * Markdown rendering support on show page ([#1179](https://github.com/lbryio/lbry-desktop/issues/1179))
+   * Content address extending outside of visible area ([#741](https://github.com/lbryio/lbry-desktop/issues/741))
+   * Content-type not shown correctly in file description ([#863](https://github.com/lbryio/lbry-desktop/pull/863))
+   * Fix [Flow](https://flow.org/) ([#1197](https://github.com/lbryio/lbry-desktop/pull/1197))
+   * Black screen on macOS after maximizing LBRY and then closing ([#1235](https://github.com/lbryio/lbry-desktop/pull/1235))
+   * Download percentage indicator overlay ([#1271](https://github.com/lbryio/lbry-desktop/issues/1271))
+   * Alternate row shading for transactions on dark theme ([#1355](https://github.com/lbryio/lbry-desktop/issues/#1355))
+   * Don't allow dark mode with automatic night mode enabled ([#1005](https://github.com/lbryio/lbry-desktop/issues/1005))
+   * Description box on Publish (dark theme) ([#1356](https://github.com/lbryio/lbry-desktop/issues/#1356))
+   * Price wrapping in price badge ([#1420](https://github.com/lbryio/lbry-desktop/pull/1420))
+   * Spacing in search suggestions ([#1422](https://github.com/lbryio/lbry-desktop/pull/1422))
+   * Text/HTML files don't display correctly in-app anymore ([#1379](https://github.com/lbryio/lbry-desktop/issues/1379))
+   * Notification modals when reward is claimed ([#1436](https://github.com/lbryio/lbry-desktop/issues/1436)) and ([#1407](https://github.com/lbryio/lbry-desktop/issues/1407))
+   * Disabled cards(grayed out) ([#1466](https://github.com/lbryio/lbry-desktop/issues/1466))
+   * New lines not showing correctly after markdown changes ([#1504](https://github.com/lbryio/lbry-desktop/issues/1504))
+   * Claim ID being null when reporting a claim that was not previously downloaded ([PR#1530](https://github.com/lbryio/lbry-desktop/pull/1530))
+   * URI and outpoint not being passed properly to API ([#1494](https://github.com/lbryio/lbry-desktop/issues/1494))
+   * Incorrect markdown preview on url with parentheses ([#1570](https://github.com/lbryio/lbry-desktop/issues/1570))
+   * Fix Linux upgrade path and add manual installation note ([#1606](https://github.com/lbryio/lbry-desktop/issues/1606))
+   * Fix can type in unfocused fields while publishing without selecting file ([#1456](https://github.com/lbryio/lbry-desktop/issues/1456))
+   * Fix navigation button resulting incorrect page designation ([#1502](https://github.com/lbryio/lbry-desktop/issues/1502))
+   * Fix shouldn't allow to open multiple export and choose file dialogs ([#1175](https://github.com/lbryio/lbry-desktop/issues/1175))
 
 
 
 ## [0.21.6] - 2018-06-05
 
 ### Fixed
- * Fix page URLs on app cold start ([#1549](https://github.com/lbryio/lbry-app/issues/1549))
- * Fix analytics event ([#1494](https://github.com/lbryio/lbry-app/issues/1494))
+ * Fix page URLs on app cold start ([#1549](https://github.com/lbryio/lbry-desktop/issues/1549))
+ * Fix analytics event ([#1494](https://github.com/lbryio/lbry-desktop/issues/1494))
 
 
 
 ## [0.21.5] - 2018-05-31
 
 ### Added
-  * Ability to navigate to in-app pages via URL ([#1352](https://github.com/lbryio/lbry-app/issues/1352))
+  * Ability to navigate to in-app pages via URL ([#1352](https://github.com/lbryio/lbry-desktop/issues/1352))
 
 ### Fixed
- * Fixed green screen on invalid URL via hyperlink ([#959](https://github.com/lbryio/lbry-app/issues/959))
- * Fixed crash when lbry-app repository is renamed to lbry-desktop ([#1505](https://github.com/lbryio/lbry-app/issues/1505))
- * Fixed rewards not disappearing after claiming ([596](https://github.com/lbryio/lbry-app/issues/596))
+ * Fixed green screen on invalid URL via hyperlink ([#959](https://github.com/lbryio/lbry-desktop/issues/959))
+ * Fixed crash when lbry-desktop repository is renamed to lbry-desktop ([#1505](https://github.com/lbryio/lbry-desktop/issues/1505))
+ * Fixed rewards not disappearing after claiming ([596](https://github.com/lbryio/lbry-desktop/issues/596))
 
 ### Changed
- * Rewards now rely on API data ([#1329](https://github.com/lbryio/lbry-app/issues/1329))
+ * Rewards now rely on API data ([#1329](https://github.com/lbryio/lbry-desktop/issues/1329))
 
 
 
@@ -135,86 +135,86 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [0.21.3] - 2018-04-23
 
 ### Added
- * Block blacklisted content ([#1361](https://github.com/lbryio/lbry-app/pull/1361))
+ * Block blacklisted content ([#1361](https://github.com/lbryio/lbry-desktop/pull/1361))
 
 
 ## [0.21.2] - 2018-03-22
 
 ### Added
-  * Save app state when closing to tray ([#968](https://github.com/lbryio/lbry-app/issues/968))
-  * Added startup-troubleshooting FAQ URL to daemon error ([#1039](https://github.com/lbryio/lbry-app/pull/1039))
-  * Added ability to export wallet transactions to JSON and CSV format ([#976](https://github.com/lbryio/lbry-app/pull/976))
-  * Add Rewards FAQ to LBRY app ([#1041](https://github.com/lbryio/lbry-app/pull/1041))
-  * Notifications when the channel a user subscribes to uploads new content ([#1066](https://github.com/lbryio/lbry-app/pull/1066))
-  * Codacy support for Github contributions ([#1059](https://github.com/lbryio/lbry-app/pull/1059))
-  * App category for Linux ([#877](https://github.com/lbryio/lbry-app/pull/877))
-  * Add YouTube Sync reward ([#1147](https://github.com/lbryio/lbry-app/pull/1147))
-  * Retain previous screen sizing on startup ([#338](https://github.com/lbryio/lbry-app/issues/338))
+  * Save app state when closing to tray ([#968](https://github.com/lbryio/lbry-desktop/issues/968))
+  * Added startup-troubleshooting FAQ URL to daemon error ([#1039](https://github.com/lbryio/lbry-desktop/pull/1039))
+  * Added ability to export wallet transactions to JSON and CSV format ([#976](https://github.com/lbryio/lbry-desktop/pull/976))
+  * Add Rewards FAQ to LBRY app ([#1041](https://github.com/lbryio/lbry-desktop/pull/1041))
+  * Notifications when the channel a user subscribes to uploads new content ([#1066](https://github.com/lbryio/lbry-desktop/pull/1066))
+  * Codacy support for Github contributions ([#1059](https://github.com/lbryio/lbry-desktop/pull/1059))
+  * App category for Linux ([#877](https://github.com/lbryio/lbry-desktop/pull/877))
+  * Add YouTube Sync reward ([#1147](https://github.com/lbryio/lbry-desktop/pull/1147))
+  * Retain previous screen sizing on startup ([#338](https://github.com/lbryio/lbry-desktop/issues/338))
 
 
 ### Changed
   * Update LBRY Protocol to 0.19.1 (See change log for [0.19.0](https://github.com/lbryio/lbry/releases/tag/v0.19.0) and [0.19.1](https://github.com/lbryio/lbry/releases/tag/v0.19.1))
-  * Improved privacy by allowing users to turn off the file view counter and better understand privacy settings ([#1074](https://github.com/lbryio/lbry-app/pull/1074) / [#1116](https://github.com/lbryio/lbry-app/pull/1116))
-  * Disabled auto dark mode if dark mode is selected ([#1006](https://github.com/lbryio/lbry-app/pull/1006))
-  * Refactor Electron's main process ([#951](https://github.com/lbryio/lbry-app/pull/951))
-  * Refactor `lbryuri.js` into separate named exports ([#957](https://github.com/lbryio/lbry-app/pull/957))
-  * Keep node_modules up-to-date when yarn.lock changes due to git ([#955](https://github.com/lbryio/lbry-app/pull/955))
-  * Do not kill an existing daemon, instead check if one exists ([#973](https://github.com/lbryio/lbry-app/pull/973))
-  * Enable play button immediately after user clicks download ([#987](https://github.com/lbryio/lbry-app/pull/987))
-  * Significantly improved search performance ([#1032](https://github.com/lbryio/lbry-app/pull/1032))
-  * Allow editing of claims when bid is greater than current balance ([#1105](https://github.com/lbryio/lbry-app/pull/1105))
+  * Improved privacy by allowing users to turn off the file view counter and better understand privacy settings ([#1074](https://github.com/lbryio/lbry-desktop/pull/1074) / [#1116](https://github.com/lbryio/lbry-desktop/pull/1116))
+  * Disabled auto dark mode if dark mode is selected ([#1006](https://github.com/lbryio/lbry-desktop/pull/1006))
+  * Refactor Electron's main process ([#951](https://github.com/lbryio/lbry-desktop/pull/951))
+  * Refactor `lbryuri.js` into separate named exports ([#957](https://github.com/lbryio/lbry-desktop/pull/957))
+  * Keep node_modules up-to-date when yarn.lock changes due to git ([#955](https://github.com/lbryio/lbry-desktop/pull/955))
+  * Do not kill an existing daemon, instead check if one exists ([#973](https://github.com/lbryio/lbry-desktop/pull/973))
+  * Enable play button immediately after user clicks download ([#987](https://github.com/lbryio/lbry-desktop/pull/987))
+  * Significantly improved search performance ([#1032](https://github.com/lbryio/lbry-desktop/pull/1032))
+  * Allow editing of claims when bid is greater than current balance ([#1105](https://github.com/lbryio/lbry-desktop/pull/1105))
 
 
 ### Fixed
-  * Fixed sort by date of published content ([#986](https://github.com/lbryio/lbry-app/issues/986))
-  * Fix night mode start time, set to 9PM ([#1050](https://github.com/lbryio/lbry-app/issues/1050))
-  * Disable drag and drop of files into the app ([#1045](https://github.com/lbryio/lbry-app/pull/1045))
-  * Fixed uninformative error message ([#1046](https://github.com/lbryio/lbry-app/pull/1046))
-  * Update documentation for DevTools and fix some ESLint warnings ([#911](https://github.com/lbryio/lbry-app/pull/911))
-  * Fix right click bug ([#928](https://github.com/lbryio/lbry-app/pull/928))
-  * Fix Election linting errors ([#929](https://github.com/lbryio/lbry-app/pull/929))
-  * App will no longer reset when minimizing to tray ([#1042](https://github.com/lbryio/lbry-app/pull/1042))
-  * Error when clicking LBRY URLs when app is closed on macOS ([#1119](https://github.com/lbryio/lbry-app/issues/1119))
-  * LBRY URLs not working on Linux ([#1120](https://github.com/lbryio/lbry-app/issues/1120))
-  * Fix Windows notifications not showing ([#1145](https://github.com/lbryio/lbry-app/pull/1145))
-  * Fix export issues ([#1163](https://github.com/lbryio/lbry-app/pull/1163))
+  * Fixed sort by date of published content ([#986](https://github.com/lbryio/lbry-desktop/issues/986))
+  * Fix night mode start time, set to 9PM ([#1050](https://github.com/lbryio/lbry-desktop/issues/1050))
+  * Disable drag and drop of files into the app ([#1045](https://github.com/lbryio/lbry-desktop/pull/1045))
+  * Fixed uninformative error message ([#1046](https://github.com/lbryio/lbry-desktop/pull/1046))
+  * Update documentation for DevTools and fix some ESLint warnings ([#911](https://github.com/lbryio/lbry-desktop/pull/911))
+  * Fix right click bug ([#928](https://github.com/lbryio/lbry-desktop/pull/928))
+  * Fix Election linting errors ([#929](https://github.com/lbryio/lbry-desktop/pull/929))
+  * App will no longer reset when minimizing to tray ([#1042](https://github.com/lbryio/lbry-desktop/pull/1042))
+  * Error when clicking LBRY URLs when app is closed on macOS ([#1119](https://github.com/lbryio/lbry-desktop/issues/1119))
+  * LBRY URLs not working on Linux ([#1120](https://github.com/lbryio/lbry-desktop/issues/1120))
+  * Fix Windows notifications not showing ([#1145](https://github.com/lbryio/lbry-desktop/pull/1145))
+  * Fix export issues ([#1163](https://github.com/lbryio/lbry-desktop/pull/1163))
 
 ## [0.20.0] - 2018-01-30
 
 ### Added
- * Added Automatic Dark Mode ([#950](https://github.com/lbryio/lbry-app/pull/950))
- * Re-introduce build dir / dist dir option for isolated build environments ([#933](https://github.com/lbryio/lbry-app/pull/933))
- * Added sms as a method for reward identity verification ([#946](https://github.com/lbryio/lbry-app/pull/946))
- * Added auto-update ([#808](https://github.com/lbryio/lbry-app/pull/808))
+ * Added Automatic Dark Mode ([#950](https://github.com/lbryio/lbry-desktop/pull/950))
+ * Re-introduce build dir / dist dir option for isolated build environments ([#933](https://github.com/lbryio/lbry-desktop/pull/933))
+ * Added sms as a method for reward identity verification ([#946](https://github.com/lbryio/lbry-desktop/pull/946))
+ * Added auto-update ([#808](https://github.com/lbryio/lbry-desktop/pull/808))
 
 
 ### Changed
- * Refactored Electron's main process ([#951](https://github.com/lbryio/lbry-app/pull/951))
- * Refactored lbryuri.js into separate named exports ([#957](https://github.com/lbryio/lbry-app/pull/957))
- * Upgraded Daemon to [version 18.2](https://github.com/lbryio/lbry/releases/tag/v0.18.2) ([#961](https://github.com/lbryio/lbry-app/pull/961))
- * Upgraded Electron for security patch ([commit](https://github.com/lbryio/lbry-app/commit/48cc82b86d79ea35e3c529b420957d9dd6043209))
+ * Refactored Electron's main process ([#951](https://github.com/lbryio/lbry-desktop/pull/951))
+ * Refactored lbryuri.js into separate named exports ([#957](https://github.com/lbryio/lbry-desktop/pull/957))
+ * Upgraded Daemon to [version 18.2](https://github.com/lbryio/lbry/releases/tag/v0.18.2) ([#961](https://github.com/lbryio/lbry-desktop/pull/961))
+ * Upgraded Electron for security patch ([commit](https://github.com/lbryio/lbry-desktop/commit/48cc82b86d79ea35e3c529b420957d9dd6043209))
 
 
 ### Fixed
- * Fixed issues in documentation ([#945](https://github.com/lbryio/lbry-app/pull/945))
- * Fixed linting errors ([#929](https://github.com/lbryio/lbry-app/pull/929))
+ * Fixed issues in documentation ([#945](https://github.com/lbryio/lbry-desktop/pull/945))
+ * Fixed linting errors ([#929](https://github.com/lbryio/lbry-desktop/pull/929))
 
 
 
 ## [0.19.4] - 2018-01-08
 
 ### Added
- * Video state tracking in redux - developer only ([#890](https://github.com/lbryio/lbry-app/pull/890))
+ * Video state tracking in redux - developer only ([#890](https://github.com/lbryio/lbry-desktop/pull/890))
 
 
 ### Changed
- * Improved text content in app ([#921](https://github.com/lbryio/lbry-app/pull/921))
+ * Improved text content in app ([#921](https://github.com/lbryio/lbry-desktop/pull/921))
 
 
 ### Fixed
- * Right click works in the app again ([#928](https://github.com/lbryio/lbry-app/pull/928))
- * Icons are now the rights size ([#925](https://github.com/lbryio/lbry-app/pull/925))
- * Fixed tip sending error ([#918](https://github.com/lbryio/lbry-app/pull/918))
+ * Right click works in the app again ([#928](https://github.com/lbryio/lbry-desktop/pull/928))
+ * Icons are now the rights size ([#925](https://github.com/lbryio/lbry-desktop/pull/925))
+ * Fixed tip sending error ([#918](https://github.com/lbryio/lbry-desktop/pull/918))
  * Newly created channel immediately available for publishing
 
 
@@ -222,59 +222,59 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [0.19.3] - 2017-12-30
 
 ### Changed
- * Improved internal code structuring by adding linting integration -- developers only ([#891](https://github.com/lbryio/lbry-app/pull/891))
- * Improved developer documentation ([#910](https://github.com/lbryio/lbry-app/pull/910))
+ * Improved internal code structuring by adding linting integration -- developers only ([#891](https://github.com/lbryio/lbry-desktop/pull/891))
+ * Improved developer documentation ([#910](https://github.com/lbryio/lbry-desktop/pull/910))
 
 
 ### Removed
- * Removed email verification reward ([#914](https://github.com/lbryio/lbry-app/pull/921))
+ * Removed email verification reward ([#914](https://github.com/lbryio/lbry-desktop/pull/921))
 
 
 ### Fixed
- * Added snackbar text in place where it was coming up blank ([#902](https://github.com/lbryio/lbry-app/pull/902))
+ * Added snackbar text in place where it was coming up blank ([#902](https://github.com/lbryio/lbry-desktop/pull/902))
 
 
 
 ## [0.19.2] - 2017-12-22
 
 ### Added
- * Added copy address button to the Wallet Address component on Send / Receive ([#875](https://github.com/lbryio/lbry-app/pull/875))
- * Link to creators’ channels on homepage ([#869](https://github.com/lbryio/lbry-app/pull/869))
- * Pause playing video when file is opened ([#880](https://github.com/lbryio/lbry-app/pull/880))
- * Add captcha to verification process ([#897](https://github.com/lbryio/lbry-app/pull/897))
+ * Added copy address button to the Wallet Address component on Send / Receive ([#875](https://github.com/lbryio/lbry-desktop/pull/875))
+ * Link to creators’ channels on homepage ([#869](https://github.com/lbryio/lbry-desktop/pull/869))
+ * Pause playing video when file is opened ([#880](https://github.com/lbryio/lbry-desktop/pull/880))
+ * Add captcha to verification process ([#897](https://github.com/lbryio/lbry-desktop/pull/897))
 
 
 ### Changed
- * Contributor documentation ([#879](https://github.com/lbryio/lbry-app/pull/879))
+ * Contributor documentation ([#879](https://github.com/lbryio/lbry-desktop/pull/879))
 
 
 ### Fixed
- * Linux app categorization ([#877](https://github.com/lbryio/lbry-app/pull/877))
+ * Linux app categorization ([#877](https://github.com/lbryio/lbry-desktop/pull/877))
 
 
 
 ## [0.19.1] - 2017-12-13
 
 ### Added
- * Added empty rewards message on overview page ([#847](https://github.com/lbryio/lbry-app/pull/847))
+ * Added empty rewards message on overview page ([#847](https://github.com/lbryio/lbry-desktop/pull/847))
 
 
 ### Changed
- * Updated developer tools and restructured code ([#861](https://github.com/lbryio/lbry-app/pull/861) / [#862](https://github.com/lbryio/lbry-app/pull/862))
+ * Updated developer tools and restructured code ([#861](https://github.com/lbryio/lbry-desktop/pull/861) / [#862](https://github.com/lbryio/lbry-desktop/pull/862))
 
 
 ### Fixed
- * Fixed typos ([#845](https://github.com/lbryio/lbry-app/pull/845) / [#846](https://github.com/lbryio/lbry-app/pull/846))
- * Fixed theme-related error while running in development ([#865](https://github.com/lbryio/lbry-app/pull/865))
- * Fixed build/signing error on Windows ([#864](https://github.com/lbryio/lbry-app/pull/864))
+ * Fixed typos ([#845](https://github.com/lbryio/lbry-desktop/pull/845) / [#846](https://github.com/lbryio/lbry-desktop/pull/846))
+ * Fixed theme-related error while running in development ([#865](https://github.com/lbryio/lbry-desktop/pull/865))
+ * Fixed build/signing error on Windows ([#864](https://github.com/lbryio/lbry-desktop/pull/864))
 
 
 
 ## [0.19.0] - 2017-12-11
 
 ### Added
- * [Subscriptions](https://github.com/lbryio/lbry-app/issues/715). File and channel pages now show a subscribe button. A new "Subscriptions" tab appears on the homepage shows the most recent content from subscribed channels.
- * [LBC acquisition widget](https://github.com/lbryio/lbry-app/issues/609). Convert other popular cryptos into LBC via a ShapeShift integration.
+ * [Subscriptions](https://github.com/lbryio/lbry-desktop/issues/715). File and channel pages now show a subscribe button. A new "Subscriptions" tab appears on the homepage shows the most recent content from subscribed channels.
+ * [LBC acquisition widget](https://github.com/lbryio/lbry-desktop/issues/609). Convert other popular cryptos into LBC via a ShapeShift integration.
  * [Flow](https://flow.org/) static type checking. This is a dev-only feature, but will make development faster, less error prone, and better for newcomers.
 
 
@@ -285,7 +285,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
  * The macOS docking icon has been improved.
  * The prompt for an insufficient balance is much more user-friendly.
  * The credit balance displayed in the main app navigation displays two decimal places instead of one.
- * Video download error messages are now more understandable.([#328](https://github.com/lbryio/lbry-app/issues/328))
+ * Video download error messages are now more understandable.([#328](https://github.com/lbryio/lbry-desktop/issues/328))
  * Windows path to the daemon/CLI executables changed to: `C:\Program Files (x86)\LBRY\resources\static\daemon`
 
 
@@ -294,13 +294,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 
 ### Fixed
- * Long channel names causing inconsistent thumbnail sizes ([#721](https://github.com/lbryio/lbry-app/issues/721))
- * Channel names in pages are highlighted to indicate them being clickable ([#814](https://github.com/lbryio/lbry-app/issues/814))
- * Fixed the transaction screen not loading for brand new users ([#755](https://github.com/lbryio/lbry-app/issues/755))
- * Fixed issues with scrolling and back and forward navigation ([#729](https://github.com/lbryio/lbry-app/issues/729))
- * Fixed sorting by title for published files ([#614](https://github.com/lbryio/lbry-app/issues/614))
- * App now uses the new `balance_delta` field provided by the LBRY API ([#611](https://github.com/lbryio/lbry-app/issues/611))
- * Abandoning from the claim page now works.([#883](https://github.com/lbryio/lbry-app/issues/833))
+ * Long channel names causing inconsistent thumbnail sizes ([#721](https://github.com/lbryio/lbry-desktop/issues/721))
+ * Channel names in pages are highlighted to indicate them being clickable ([#814](https://github.com/lbryio/lbry-desktop/issues/814))
+ * Fixed the transaction screen not loading for brand new users ([#755](https://github.com/lbryio/lbry-desktop/issues/755))
+ * Fixed issues with scrolling and back and forward navigation ([#729](https://github.com/lbryio/lbry-desktop/issues/729))
+ * Fixed sorting by title for published files ([#614](https://github.com/lbryio/lbry-desktop/issues/614))
+ * App now uses the new `balance_delta` field provided by the LBRY API ([#611](https://github.com/lbryio/lbry-desktop/issues/611))
+ * Abandoning from the claim page now works.([#883](https://github.com/lbryio/lbry-desktop/issues/833))
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ However, for those individuals who want a bit more guidance on the best way to c
 
 ## TL;DR?
 
-* [Here](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee)
+* [Here](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee)
   is a list of help wanted issues.
 * Comment on an issue to let us know if you are going to work on it, don't take an issue that
   someone reserved less than 3 days ago
@@ -26,24 +26,24 @@ receives contributions from individuals outside the core team -- such as yoursel
 To make contributing as easy and rewarding of possible, we have instituted the following system:
 
 * Anyone can view all issues in the system by clicking on the
-  [Issues](https://github.com/lbryio/lbry-app/issues) button at the top of the page. Feel free to
+  [Issues](https://github.com/lbryio/lbry-desktop/issues) button at the top of the page. Feel free to
   add an issue if you think we have missed something (and you might earn some LBC in the process
   because we do tip people for reporting bugs).
-* Once on the [Issues](https://github.com/lbryio/lbry-app/issues) page, a potential contributor can
+* Once on the [Issues](https://github.com/lbryio/lbry-desktop/issues) page, a potential contributor can
   filter issues by the
-  [Help Wanted](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee)
+  [Help Wanted](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee)
   label to see a curated list of suggested issues with which community members can help.
 * Every
-  [Help Wanted](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee)
+  [Help Wanted](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee)
   issue is ranked on a scale from zero to four.
 
 | Level                                                                                                                                            | Description                                                                                        |
 | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| [**level 0**](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+0%22+no%3Aassignee) | Typos and text edits -- a tech-savvy non-programmer can fix these                                  |
-| [**level 1**](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+1%22+no%3Aassignee) | Programming issues that require little knowledge of how the LBRY app works                         |
-| [**level 2**](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+2%22+no%3Aassignee) | Issues of average difficulty that require the developer to dig into how the app works a little bit |
-| [**level 3**](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+3%22+no%3Aassignee) | Issues that are likely too tricky to be level 2 or require more thinking outside of the box        |
-| [**level 4**](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+4%22+no%3Aassignee) | Big features or really hard issues                                                                 |
+| [**level 0**](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+0%22+no%3Aassignee) | Typos and text edits -- a tech-savvy non-programmer can fix these                                  |
+| [**level 1**](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+1%22+no%3Aassignee) | Programming issues that require little knowledge of how the LBRY app works                         |
+| [**level 2**](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+2%22+no%3Aassignee) | Issues of average difficulty that require the developer to dig into how the app works a little bit |
+| [**level 3**](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+3%22+no%3Aassignee) | Issues that are likely too tricky to be level 2 or require more thinking outside of the box        |
+| [**level 4**](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3A%22level%3A+4%22+no%3Aassignee) | Big features or really hard issues                                                                 |
 
 The process of ranking issues is highly subjective. The purpose of sorting issues like this is to
 give contributors a general idea about the type of issues they are looking at. It could very well be
@@ -51,7 +51,7 @@ the case that a level 1 issue is more difficult than a level 2, for instance. Th
 to help you find relevant issues, not to prevent you from working on issues that you otherwise
 would. If these rankings don't work for you, feel free to ignore them.
 
-Although all contributions should have good UX, the [UX label, when applied in conjunction with Help Wanted](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3Aux+no%3Aassignee), indicates that the contributor ought to implement the feature in a creative way that specifically focuses on providing a good user experience. These issues often have no set instruction for how the experience should be and leave it to the contributor to figure out. This may be challenging for people who do not like UX, but also more fun and rewarding for those who do.
+Although all contributions should have good UX, the [UX label, when applied in conjunction with Help Wanted](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+label%3Aux+no%3Aassignee), indicates that the contributor ought to implement the feature in a creative way that specifically focuses on providing a good user experience. These issues often have no set instruction for how the experience should be and leave it to the contributor to figure out. This may be challenging for people who do not like UX, but also more fun and rewarding for those who do.
 
 ## Code Overview
 
@@ -67,7 +67,7 @@ our styling rules and code best practices.
 
 ### lbry-redux
 
-This project uses [lbry-redux](https://github.com/lbryio/lbry-redux) to share Redux code with [lbry-android](https://github.com/lbryio/lbry-android) and other LBRY apps. Over time, more Redux code that is suitable to be shared will be moved into lbry-redux. If modifying Redux code, you may be asked to make some of your changes in lbry-redux rather than lbry-app. The steps to work with lbry-redux locally can be found [here](https://github.com/lbryio/lbry-redux#local-development).
+This project uses [lbry-redux](https://github.com/lbryio/lbry-redux) to share Redux code with [lbry-android](https://github.com/lbryio/lbry-android) and other LBRY apps. Over time, more Redux code that is suitable to be shared will be moved into lbry-redux. If modifying Redux code, you may be asked to make some of your changes in lbry-redux rather than lbry-desktop. The steps to work with lbry-redux locally can be found [here](https://github.com/lbryio/lbry-redux#local-development).
 
 
 ### Flow
@@ -146,8 +146,8 @@ There are a few tools integrated to the project that will ease the process of de
   manner and, therefore, not begin working on anything reserved (or updated) within the last 3 days.
   If someone has been officially assigned an issue via Github's assignment system, it is also not
   available. Contributors are encouraged to ask if they have any questions about issue availability.
-* The [changelog](https://github.com/lbryio/lbry-app/blob/master/CHANGELOG.md) should be updated to 
-  include a reference to the fix/change/addition. See previous entries for format. 
+* The [changelog](https://github.com/lbryio/lbry-desktop/blob/master/CHANGELOG.md) should be updated to
+  include a reference to the fix/change/addition. See previous entries for format.
 * Once the pull request is visible in the LBRY repo, a LBRY team member will review it and make sure
   it is up to our standards. At this point, the contributor may have to change his or her code based
   on our suggestions and comments.
@@ -169,13 +169,13 @@ the issue tracker, but maybe it's a good idea. Do you think the search layout is
 it! We welcome all feedback and suggestions. That said, it may be the case that we do not wish to
 incorporate your change if you don't check with us first (also, please check with us especially if
 you are planning on adding Tor support :P). If you want to add a feature that is not listed in the
-issue tracker, go ahead and [create an issue](https://github.com/lbryio/lbry-app/issues/new), and
+issue tracker, go ahead and [create an issue](https://github.com/lbryio/lbry-desktop/issues/new), and
 say in the description that you would like to try to implement it yourself. This way we can tell you
 in advance if we will accept your changes and we can point you in the right direction.
 
 # Tom's "Voice of the User" Wishlist
 
-[Anything marked with **both** "Help Wanted" and "Tom's 'Voice of the User' Wishlist"](https://github.com/lbryio/lbry-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22Tom%27s+%5C%22Voice+of+the+User%5C%22+Wishlist%22+label%3A%22help+wanted%22+no%3Aassignee)
+[Anything marked with **both** "Help Wanted" and "Tom's 'Voice of the User' Wishlist"](https://github.com/lbryio/lbry-desktop/issues?q=is%3Aopen+is%3Aissue+label%3A%22Tom%27s+%5C%22Voice+of+the+User%5C%22+Wishlist%22+label%3A%22help+wanted%22+no%3Aassignee)
 will earn you an extra 50 LBC on top of what we would otherwise tip you.
 
 # Get in Touch

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # LBRY App
 
-[![Build Status](https://travis-ci.org/lbryio/lbry-app.svg?branch=master)](https://travis-ci.org/lbryio/lbry-app)
-[![Dependencies](https://david-dm.org/lbryio/lbry-app/status.svg)](https://david-dm.org/lbryio/lbry-app)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/78b627d4f5524792adc48719835e1523)](https://www.codacy.com/app/LBRY/lbry-app?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=lbryio/lbry-app&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.org/lbryio/lbry-desktop.svg?branch=master)](https://travis-ci.org/lbryio/lbry-desktop)
+[![Dependencies](https://david-dm.org/lbryio/lbry-deskop/status.svg)](https://david-dm.org/lbryio/lbry-desktop)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/78b627d4f5524792adc48719835e1523)](https://www.codacy.com/app/LBRY/lbry-desktop?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=lbryio/lbry-desktop&amp;utm_campaign=Badge_Grade)
 [![chat on Discord](https://img.shields.io/discord/362322208485277697.svg?logo=discord)](https://chat.lbry.io)
 
 The LBRY app is a graphical browser for the decentralized content marketplace provided by the
@@ -14,26 +14,26 @@ The LBRY app is a graphical browser for the decentralized content marketplace pr
 
 ## Install
 
-We provide installers for Windows, macOS (v10.9 or greater), and Debian-based Linux. See community maintained builds section for alternative Linux installations. 
+We provide installers for Windows, macOS (v10.9 or greater), and Debian-based Linux. See community maintained builds section for alternative Linux installations.
 
 |                       | Windows                                      | macOS                                        | Linux                                        
 | --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
 | Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)
 | Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb)
 
-Our [releases page](https://github.com/lbryio/lbry-app/releases) also contains the latest
+Our [releases page](https://github.com/lbryio/lbry-desktop/releases) also contains the latest
 release, pre-releases, and past builds.   
 *Note: If the deb fails to install using the Ubuntu Software Center, install manually via `sudo dpkg -i <path to deb>`. You'll need to run `sudo apt-get install -f` if this is the first time installing it to install dependencies*
 
 To install from source or make changes to the application, continue to the next section below.   
 
-**Community maintained** builds for Arch Linux and Flatpak are available, see below. These installs will need to be updated manually as the in-app update process only supports deb installs at this time. 
+**Community maintained** builds for Arch Linux and Flatpak are available, see below. These installs will need to be updated manually as the in-app update process only supports deb installs at this time.
 *Note: If coming from a deb install, the directory structure is different and you'll need to [migrate data](https://lbry.io/faq/backup-data).*
 
 |                       | Flatpak                                   | Arch                                                                                            
-| --------------------- | ------------------------------------------| -------------------------------------------- 
+| --------------------- | ------------------------------------------| --------------------------------------------
 | Latest Release        | [FlatHub Page](https://flathub.org/apps/details/io.lbry.lbry-app)   | [AUR Package](https://aur.archlinux.org/packages/lbry-app-bin/)   
-| Maintainers           | [@choofee](https://github.com/choffee)/[@iuyte](https://github.com/iuyte)    | [@kcseb]()/[@TimurKiyivinski](https://github.com/TimurKiyivinski) 
+| Maintainers           | [@choofee](https://github.com/choffee)/[@iuyte](https://github.com/iuyte)    | [@kcseb](https://github.com/kcseb)/[@TimurKiyivinski](https://github.com/TimurKiyivinski)
 
 ## Usage
 Double click the installed application to browse with the LBRY network.
@@ -49,8 +49,8 @@ Double click the installed application to browse with the LBRY network.
 
 #### Steps
 
-1. Clone (or [fork](https://help.github.com/articles/fork-a-repo/)) this repository: `git clone https://github.com/lbryio/lbry-app`
-2. Change directories into the downloaded folder: `cd lbry-app`
+1. Clone (or [fork](https://help.github.com/articles/fork-a-repo/)) this repository: `git clone https://github.com/lbryio/lbry-desktop`
+2. Change directories into the downloaded folder: `cd lbry-desktop`
 3. Install the dependencies: `yarn`
 4. Run the app: `yarn dev`
 
@@ -59,7 +59,7 @@ distributable packages.
 
 #### Resetting your Packages
 
-If the app isn't building, or `yarn xxx` commands aren't working you may need to just reset your `node_modules`. To do so you can run: `rm -r node_modules && yarn` or `del /s /q node_modules && yarn` on Windows. 
+If the app isn't building, or `yarn xxx` commands aren't working you may need to just reset your `node_modules`. To do so you can run: `rm -r node_modules && yarn` or `del /s /q node_modules && yarn` on Windows.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LBRY App
 
 [![Build Status](https://travis-ci.org/lbryio/lbry-desktop.svg?branch=master)](https://travis-ci.org/lbryio/lbry-desktop)
-[![Dependencies](https://david-dm.org/lbryio/lbry-deskop/status.svg)](https://david-dm.org/lbryio/lbry-desktop)
+[![Dependencies](https://david-dm.org/lbryio/lbry-desktop/status.svg)](https://david-dm.org/lbryio/lbry-desktop)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/78b627d4f5524792adc48719835e1523)](https://www.codacy.com/app/LBRY/lbry-desktop?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=lbryio/lbry-desktop&amp;utm_campaign=Badge_Grade)
 [![chat on Discord](https://img.shields.io/discord/362322208485277697.svg?logo=discord)](https://chat.lbry.io)
 

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "license": "MIT",
   "homepage": "https://lbry.io/",
   "bugs": {
-    "url": "https://github.com/lbryio/lbry-app/issues"
+    "url": "https://github.com/lbryio/lbry-desktop/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lbryio/lbry-app"
+    "url": "https://github.com/lbryio/lbry-desktop"
   },
   "author": {
     "name": "LBRY Inc.",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -181,7 +181,7 @@ ipcMain.on('version-info-requested', () => {
   }
 
   const localVersion = pjson.version;
-  const latestReleaseAPIURL = 'https://api.github.com/repos/lbryio/lbry-app/releases/latest';
+  const latestReleaseAPIURL = 'https://api.github.com/repos/lbryio/lbry-desktop/releases/latest';
   const opts = {
     headers: {
       'User-Agent': `LBRY/${localVersion}`,

--- a/src/main/menu/setupBarMenu.js
+++ b/src/main/menu/setupBarMenu.js
@@ -56,7 +56,7 @@ export default () => {
         {
           label: 'Report Issue',
           click: () => {
-            shell.openExternal('https://github.com/lbryio/lbry-app/issues/new');
+            shell.openExternal('https://github.com/lbryio/lbry-desktop/issues/new');
           },
         },
         { type: 'separator' },

--- a/src/renderer/component/fileList/view.jsx
+++ b/src/renderer/component/fileList/view.jsx
@@ -167,7 +167,7 @@ class FileList extends React.PureComponent<Props, State> {
       uriParams.claimId = claimId;
       const uri = buildURI(uriParams);
 
-      // See https://github.com/lbryio/lbry-app/issues/1327 for discussion around using outpoint as the key
+      // See https://github.com/lbryio/lbry-desktop/issues/1327 for discussion around using outpoint as the key
       content.push(<FileCard key={outpoint} uri={uri} checkPending={checkPending} />);
     });
 

--- a/src/renderer/modal/modalAutoUpdateConfirm/view.jsx
+++ b/src/renderer/modal/modalAutoUpdateConfirm/view.jsx
@@ -32,7 +32,7 @@ class ModalAutoUpdateConfirm extends React.PureComponent {
             <Button
               button="link"
               label={__('release notes')}
-              href="https://github.com/lbryio/lbry-app/releases"
+              href="https://github.com/lbryio/lbry-desktop/releases"
             />.
           </p>
         </section>

--- a/src/renderer/modal/modalAutoUpdateDownloaded/view.jsx
+++ b/src/renderer/modal/modalAutoUpdateDownloaded/view.jsx
@@ -35,7 +35,7 @@ class ModalAutoUpdateDownloaded extends React.PureComponent {
             <Button
               button="link"
               label={__('release notes')}
-              href="https://github.com/lbryio/lbry-app/releases"
+              href="https://github.com/lbryio/lbry-desktop/releases"
             />.
           </p>
         </section>

--- a/src/renderer/modal/modalUpgrade/view.jsx
+++ b/src/renderer/modal/modalUpgrade/view.jsx
@@ -27,7 +27,7 @@ class ModalUpgrade extends React.PureComponent {
           <Button
             button="link"
             label={__('release notes')}
-            href="https://github.com/lbryio/lbry-app/releases"
+            href="https://github.com/lbryio/lbry-desktop/releases"
           />.
         </p>
       </Modal>

--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -75,7 +75,7 @@ class FilePage extends React.Component<Props> {
       fetchFileInfo(uri);
     }
 
-    // See https://github.com/lbryio/lbry-app/pull/1563 for discussion
+    // See https://github.com/lbryio/lbry-desktop/pull/1563 for discussion
     fetchCostInfo(uri);
 
     this.checkSubscription(this.props);


### PR DESCRIPTION
Reviewed all instances of lbry-app and changed to lbry-desktop. There are still some that will stay at lbry-app for now (i.e. AUR/Flatpak repo names).
