### PR TITLE
updated the url for successful thumbnail publishes

### DIFF
--- a/src/renderer/redux/actions/publish.js
+++ b/src/renderer/redux/actions/publish.js
@@ -117,7 +117,7 @@ export const doUploadThumbnail = (filePath: string, nsfw: boolean) => (dispatch:
               type: ACTIONS.UPDATE_PUBLISH_FORM,
               data: {
                 uploadThumbnailStatus: THUMBNAIL_STATUSES.COMPLETE,
-                thumbnail: `${json.data.url}${fileExt}`,
+                thumbnail: `${json.data.embedUrl}`,
               },
             })
           : uploadError('Upload failed')


### PR DESCRIPTION
This is an update for the app to use a static embed url for successful thumbnails published via spee.ch.
This is dependent upon merging the following PR on spee.ch: https://github.com/lbryio/spee.ch/pull/529