### PR TITLE
stop loader timeout if not loading

### DIFF
--- a/src/renderer/component/page/view.jsx
+++ b/src/renderer/component/page/view.jsx
@@ -41,6 +41,8 @@ class Page extends React.PureComponent<Props, State> {
     const { loading } = this.props;
     if (!this.loaderTimeout && !prevProps.loading && loading) {
       this.beginLoadingTimeout();
+    } else if (!loading && this.loaderTimeout) {
+      clearTimeout(this.loaderTimeout);
     }
   }
 

--- a/src/renderer/page/subscriptions/index.js
+++ b/src/renderer/page/subscriptions/index.js
@@ -13,7 +13,7 @@ import SubscriptionsPage from './view';
 const select = state => ({
   loading:
     selectIsFetchingSubscriptions(state) ||
-    Object.keys(selectSubscriptionsBeingFetched(state)).length,
+    Boolean(Object.keys(selectSubscriptionsBeingFetched(state)).length),
   subscriptionsBeingFetched: selectSubscriptionsBeingFetched(state),
   subscriptions: selectSubscriptions(state),
   subscriptionClaims: selectSubscriptionClaims(state),


### PR DESCRIPTION
We weren't stopping the loader timeout if the `loading` prop was passed in as `false` after it is rendered. This was causing the loading indicator to be rendered indefinitely on the subscriptions page.