### PR TITLE
Update electron-builder.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ The LBRY app is a graphical browser for the decentralized content marketplace pr
 ## Install
 
 We provide installers for Raspberry Pi 3
-| Linux                                        
-| -------------------------------------------- |
+| Rasbian OS                                        
 | [Download](https://lbry.io/get/lbry.deb)
 
 Our [releases page](https://github.com/lbryio/lbry-desktop/releases) also contains the latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LBRY App
+# LBRY Pi TV
 
 [![Build Status](https://travis-ci.org/lbryio/lbry-desktop.svg?branch=master)](https://travis-ci.org/lbryio/lbry-desktop)
 [![Dependencies](https://david-dm.org/lbryio/lbry-desktop/status.svg)](https://david-dm.org/lbryio/lbry-desktop)
@@ -16,27 +16,16 @@ The LBRY app is a graphical browser for the decentralized content marketplace pr
 
 ## Install
 
-We provide installers for Windows, macOS (v10.9 or greater), and Debian-based Linux. See community maintained builds section for alternative Linux installations.
-
-|                       | Windows                                      | macOS                                        | Linux                                        
-| --------------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
-| Latest Stable Release | [Download](https://lbry.io/get/lbry.exe)     | [Download](https://lbry.io/get/lbry.dmg)     | [Download](https://lbry.io/get/lbry.deb)
-| Latest Pre-release    | [Download](https://lbry.io/get/lbry.pre.exe) | [Download](https://lbry.io/get/lbry.pre.dmg) | [Download](https://lbry.io/get/lbry.pre.deb)
+We provide installers for Raspberry Pi 3
+| Linux                                        
+| -------------------------------------------- |
+| [Download](https://lbry.io/get/lbry.deb)
 
 Our [releases page](https://github.com/lbryio/lbry-desktop/releases) also contains the latest
 release, pre-releases, and past builds.   
 *Note: If the deb fails to install using the Ubuntu Software Center, install manually via `sudo dpkg -i <path to deb>`. You'll need to run `sudo apt-get install -f` if this is the first time installing it to install dependencies*
 
 To install from source or make changes to the application, continue to the next section below.   
-
-**Community maintained** builds for Arch Linux and Flatpak are available, see below. These installs will need to be updated manually as the in-app update process only supports deb installs at this time.
-*Note: If coming from a deb install, the directory structure is different and you'll need to [migrate data](https://lbry.io/faq/backup-data).*
-
-|                       | Flatpak                                   | Arch                                                                                            
-| --------------------- | ------------------------------------------| --------------------------------------------
-| Latest Release        | [FlatHub Page](https://flathub.org/apps/details/io.lbry.lbry-app)   | [AUR Package](https://aur.archlinux.org/packages/lbry-app-bin/)   
-| Maintainers           | [@choofee](https://github.com/choffee)/[@iuyte](https://github.com/iuyte)    | [@kcseb](https://github.com/kcseb)/[@TimurKiyivinski](https://github.com/TimurKiyivinski)
-
 ## Usage
 Double click the installed application to browse with the LBRY network.
 
@@ -51,8 +40,8 @@ Double click the installed application to browse with the LBRY network.
 
 #### Steps
 
-1. Clone (or [fork](https://help.github.com/articles/fork-a-repo/)) this repository: `git clone https://github.com/lbryio/lbry-desktop`
-2. Change directories into the downloaded folder: `cd lbry-desktop`
+1. Clone (or [fork](https://help.github.com/articles/fork-a-repo/)) this repository: `git clone https://github.com/kodxana/LBRY-Pi-TV`
+2. Change directories into the downloaded folder: `cd LBRY-Pi-TV`
 3. Install the dependencies: `yarn`
 4. Run the app: `yarn dev`
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -59,6 +59,7 @@
       "libxtst6",
       "libnss3",
       "libsecret-1-0"
+      "libsecret-1-dev"
     ]
   },
   "nsis": {

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -58,7 +58,7 @@
       "libappindicator1",
       "libxtst6",
       "libnss3",
-      "libsecret-1-dev"
+      "libsecret-1-0"
     ]
   },
   "nsis": {

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -58,7 +58,7 @@
       "libappindicator1",
       "libxtst6",
       "libnss3",
-      "libsecret-1-0"
+      "libsecret-1-dev"
     ]
   },
   "nsis": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "find-process": "^1.1.0",
     "formik": "^0.10.4",
     "hast-util-sanitize": "^1.1.2",
-    "keytar": "^4.2.1",
+    "keytar": "kodxana/node-keytar",
     "lbry-redux": "lbryio/lbry-redux#e0909b08647a790d155f3189b9f9bf0b3e55bd17",
     "localforage": "^1.7.1",
     "mime": "^2.3.1",


### PR DESCRIPTION
Fixed error when building keytar
gyp: Call to 'pkg-config --libs-only-l libsecret-1' returned exit status 127 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1