### PR TITLE
Fix middle-click open link event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
  * **Wallet -> Get Credits** page now shows correct ShapeShift status when it's avialable ([#1836](https://github.com/lbryio/lbry-desktop/issue))
+ * Fix middle click link error ([#1843](https://github.com/lbryio/lbry-desktop/issues/1843)}
 
 ## [0.23.0] - 2018-07-25
 

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, screen } from 'electron';
+import { app, BrowserWindow, dialog, shell, screen } from 'electron';
 import isDev from 'electron-is-dev';
 import windowStateKeeper from 'electron-window-state';
 
@@ -122,6 +122,11 @@ export default appState => {
 
   window.webContents.on('crashed', () => {
     window = null;
+  });
+  
+  window.webContents.on('new-window', (event, url) => {
+    event.preventDefault();
+    shell.openExternal(url);
   });
 
   return window;


### PR DESCRIPTION
### Fixes
- Middle Click Link Error #1843

  > When someone middle-clicks on links within the app, it opens them up in an app window with incorrect formatting and also doesn't support the Shapeshift site.