### PR TITLE
log time to play

### DIFF
--- a/src/renderer/analytics.js
+++ b/src/renderer/analytics.js
@@ -44,13 +44,19 @@ const analytics: Analytics = {
     }
     analyticsEnabled = enabled;
   },
-  apiLogView: (uri: string, outpoint: string, claimId: string): void => {
+  apiLogView: (uri: string, outpoint: string, claimId: string, timeToStart?: number): void => {
     if (analyticsEnabled) {
-      Lbryio.call('file', 'view', {
+      const params = {
         uri,
         outpoint,
         claim_id: claimId,
-      }).catch(() => {});
+      };
+
+      if (timeToStart) {
+        params.time_to_start = timeToStart;
+      }
+
+      Lbryio.call('file', 'view', params).catch(() => {});
     }
   },
 };

--- a/src/renderer/component/fileViewer/internal/player.jsx
+++ b/src/renderer/component/fileViewer/internal/player.jsx
@@ -34,10 +34,21 @@ class VideoPlayer extends React.PureComponent {
 
   componentDidMount() {
     const container = this.media;
-    const { downloadCompleted, contentType, changeVolume, volume, position, claim } = this.props;
+    const {
+      downloadCompleted,
+      contentType,
+      changeVolume,
+      volume,
+      position,
+      claim,
+      startedPlayingCb,
+    } = this.props;
 
     const loadedMetadata = () => {
       this.setState({ hasMetadata: true, startedPlaying: true });
+      if (startedPlayingCb) {
+        startedPlayingCb();
+      }
       this.media.children[0].play();
     };
 


### PR DESCRIPTION
#### Notes
This ended up being a little more complex after realizing we need to reset analytics data when users navigate directly to another file (where the File page won't be re-mounted)

There are three scenarios:
- User has already downloaded a file: do nothing
- User started downloading but navigated away before it started playing: log `file_view` with no `time_to_start`
- User stayed on the page until the file started playing: log `file_view` with `time_to_start`