### PR TITLE
Fix: Don't show editing mode on publish after clearing cache

### DIFF
--- a/src/renderer/redux/selectors/publish.js
+++ b/src/renderer/redux/selectors/publish.js
@@ -48,6 +48,10 @@ export const selectPendingPublish = uri =>
 export const selectIsStillEditing = createSelector(selectPublishFormValues, publishState => {
   const { editingURI, uri } = publishState;
 
+  if (!editingURI || !uri) {
+    return false;
+  }
+
   const {
     isChannel: currentIsChannel,
     claimName: currentClaimName,


### PR DESCRIPTION
If there is no `uri` or `editingUri` (which are built from the publish form values) we know they can't be editing so return `false` early.