### PR TITLE
feat: add thumbnail loading to list of help errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
  * **Wallet -> Get Credits** page now shows correct ShapeShift status when it's avialable ([#1836](https://github.com/lbryio/lbry-desktop/issues/1836))
  * Fix middle click link error ([#1843](https://github.com/lbryio/lbry-desktop/issues/1843)}
  * Problem with search auto-complete menu when scrolling over file viewer ([#1847](https://github.com/lbryio/lbry-desktop/issues/1847))
+ * Show label when publish button is disabled while uploading thumbnail to spee.ch ([#1867](https://github.com/lbryio/lbry-desktop/pull/1867))
 
 
 ## [0.23.0] - 2018-07-25

--- a/src/renderer/component/publishForm/view.jsx
+++ b/src/renderer/component/publishForm/view.jsx
@@ -254,10 +254,11 @@ class PublishForm extends React.PureComponent<Props> {
       editingURI,
       isStillEditing,
       filePath,
+      uploadThumbnailStatus,
     } = this.props;
 
     // If they are editing, they don't need a new file chosen
-    const formValidLessFile = name && !nameError && title && bid && !bidError && tosAccepted;
+    const formValidLessFile = name && !nameError && title && bid && !bidError && tosAccepted && !(uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS);
     return editingURI && !filePath ? isStillEditing && formValidLessFile : formValidLessFile;
   }
 
@@ -272,6 +273,7 @@ class PublishForm extends React.PureComponent<Props> {
       editingURI,
       filePath,
       isStillEditing,
+      uploadThumbnailStatus,
     } = this.props;
 
     const isFormValid = this.checkIsFormValid();
@@ -286,6 +288,8 @@ class PublishForm extends React.PureComponent<Props> {
           {name && nameError && <div>{__('The URL you created is not valid')}</div>}
           {!bid && <div>{__('A bid amount is required')}</div>}
           {!!bid && bidError && <div>{bidError}</div>}
+          {uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS
+          && <div>{__('Please wait for thumbnail to finish uploading')}</div>}
           {!tosAccepted && <div>{__('You must agree to the terms of service')}</div>}
           {!!editingURI &&
             !isStillEditing &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -5651,9 +5651,9 @@ lazy-val@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.3.tgz#bb97b200ef00801d94c317e29dc6ed39e31c5edc"
 
-lbry-redux@lbryio/lbry-redux#03c3354c12f7834e6ed63705ff19487669be32b9:
+lbry-redux@lbryio/lbry-redux#8794a775bf71e7b8b7d1ac44392196bb58a0042a:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/03c3354c12f7834e6ed63705ff19487669be32b9"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/8794a775bf71e7b8b7d1ac44392196bb58a0042a"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
Adds a message at the bottom of the page to let the user know the thumbnail is still uploading. 