### PR TITLE
feat: add publish success notification

### DIFF
--- a/src/renderer/redux/actions/publish.js
+++ b/src/renderer/redux/actions/publish.js
@@ -14,6 +14,8 @@ import type {
   UpdatePublishFormAction,
   PublishParams,
 } from 'redux/reducers/publish';
+import { selectosNotificationsEnabled } from 'redux/selectors/settings';
+import { doNavigate } from 'redux/actions/navigation';
 import fs from 'fs';
 import path from 'path';
 
@@ -274,6 +276,19 @@ export const doCheckPendingPublishes = () => (dispatch: Dispatch, getState: GetS
           });
 
           delete pendingPublishMap[claim.name];
+          if (selectosNotificationsEnabled(getState())) {
+            const notif = new window.Notification('LBRY Publish Complete', {
+            body: `${claim.name} has been published successfully, click here to view it.` ,
+            silent: false,
+            });
+            notif.onclick = () => {
+              dispatch(
+                doNavigate('/show', {
+                   uri: claim.name,
+                })
+              );
+            };
+          }
         }
       });
 


### PR DESCRIPTION
When a file is confirmed, create a desktop notification with the claim name and ability to click the notification to view the claim