### PR TITLE
Fix subscriptions page when subscribed to a channel with 0 claims/abandoned

### DIFF
--- a/src/renderer/page/subscriptions/index.js
+++ b/src/renderer/page/subscriptions/index.js
@@ -6,7 +6,6 @@ import {
   selectIsFetchingSubscriptions,
   selectNotifications,
 } from 'redux/selectors/subscriptions';
-import { doFetchClaimsByChannel } from 'redux/actions/content';
 import { setSubscriptionNotifications, doFetchMySubscriptions } from 'redux/actions/subscriptions';
 import SubscriptionsPage from './view';
 
@@ -14,7 +13,6 @@ const select = state => ({
   loading:
     selectIsFetchingSubscriptions(state) ||
     Boolean(Object.keys(selectSubscriptionsBeingFetched(state)).length),
-  subscriptionsBeingFetched: selectSubscriptionsBeingFetched(state),
   subscriptions: selectSubscriptions(state),
   subscriptionClaims: selectSubscriptionClaims(state),
   notifications: selectNotifications(state),
@@ -23,7 +21,6 @@ const select = state => ({
 export default connect(
   select,
   {
-    doFetchClaimsByChannel,
     setSubscriptionNotifications,
     doFetchMySubscriptions,
   }

--- a/src/renderer/page/subscriptions/view.jsx
+++ b/src/renderer/page/subscriptions/view.jsx
@@ -6,16 +6,13 @@ import * as NOTIFICATION_TYPES from 'constants/notification_types';
 import Button from 'component/button';
 import FileList from 'component/fileList';
 import type { Claim } from 'types/claim';
-import isDev from 'electron-is-dev';
 import HiddenNsfwClaims from 'component/hiddenNsfwClaims';
 
 type Props = {
-  doFetchClaimsByChannel: (string, number) => void,
   doFetchMySubscriptions: () => void,
   setSubscriptionNotifications: ({}) => void,
   subscriptions: Array<Subscription>,
   subscriptionClaims: Array<{ uri: string, claims: Array<Claim> }>,
-  subscriptionsBeingFetched: {},
   notifications: {},
   loading: boolean,
 };
@@ -35,41 +32,6 @@ export default class extends React.PureComponent<Props> {
       }
     });
     setSubscriptionNotifications(newNotifications);
-  }
-
-  componentDidUpdate() {
-    const {
-      subscriptions,
-      subscriptionClaims,
-      doFetchClaimsByChannel,
-      subscriptionsBeingFetched,
-    } = this.props;
-
-    const subscriptionClaimMap = {};
-    subscriptionClaims.forEach(claim => {
-      /*
-      This check added 6/20/18 to fix function receiving empty claims unexpectedly.
-      The better fix is ensuring channels aren't added to byId if there are no associated claims
-      We are adding this now with the redesign release to ensure users see the correct subscriptions
-      */
-      if (claim.claims.length) {
-        subscriptionClaimMap[claim.uri] = 1;
-      } else if (isDev) {
-        // eslint-disable no-console
-        console.error(
-          `Claim for ${
-            claim.uri
-          } was added to byId in redux but there are no loaded fetched claims. This shouldn't happen because a subscription should have claims attached to it.`
-        );
-        // eslint-enable no-console
-      }
-    });
-
-    subscriptions.forEach(sub => {
-      if (!subscriptionClaimMap[sub.uri] && !subscriptionsBeingFetched[sub.uri]) {
-        doFetchClaimsByChannel(sub.uri, 1);
-      }
-    });
   }
 
   render() {

--- a/src/renderer/redux/actions/subscriptions.js
+++ b/src/renderer/redux/actions/subscriptions.js
@@ -8,7 +8,7 @@ import type { Subscription } from 'types/subscription';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { Lbry, buildURI, parseURI } from 'lbry-redux';
-import { doPurchaseUri } from 'redux/actions/content';
+import { doPurchaseUri, doFetchClaimsByChannel } from 'redux/actions/content';
 import { doClaimRewardType } from 'redux/actions/rewards';
 import Promise from 'bluebird';
 import Lbryio from 'lbryio';
@@ -91,6 +91,8 @@ export const doFetchMySubscriptions = () => (dispatch: Dispatch, getState: () =>
         type: ACTIONS.FETCH_SUBSCRIPTIONS_SUCCESS,
         data: subscriptions,
       });
+
+      subscriptions.forEach(({ uri }) => dispatch(doFetchClaimsByChannel(uri)));
     })
     .catch(() => {
       dispatch({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5651,9 +5651,9 @@ lazy-val@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.3.tgz#bb97b200ef00801d94c317e29dc6ed39e31c5edc"
 
-lbry-redux@lbryio/lbry-redux#ada4880c5d0758c7973aff9d443a87874d98b320:
+lbry-redux@lbryio/lbry-redux#31f7afa8a37f5741dac01fc1ecdf153f3bed95dc:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/ada4880c5d0758c7973aff9d443a87874d98b320"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/31f7afa8a37f5741dac01fc1ecdf153f3bed95dc"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
Not really sure what was going through my head when I first wrote this. There isn't any reason to pass the subscriptions into the component and call the `channel_list` command from there. Just call it immediately after we get them from the api.