### PR TITLE
use permanent url instead of uri

### DIFF
--- a/src/renderer/redux/actions/publish.js
+++ b/src/renderer/redux/actions/publish.js
@@ -284,7 +284,7 @@ export const doCheckPendingPublishes = () => (dispatch: Dispatch, getState: GetS
             notif.onclick = () => {
               dispatch(
                 doNavigate('/show', {
-                   uri: claim.name,
+                   uri: claim.permanent_url,
                 })
               );
             };


### PR DESCRIPTION
This ensures that when clicking on the notification, it goes to the correct URL. Before it could have been a different vanity URL.