### PR TITLE
fetch new rewards and properly call reward claim after view event has been fired

### DIFF
--- a/src/renderer/analytics.js
+++ b/src/renderer/analytics.js
@@ -44,7 +44,13 @@ const analytics: Analytics = {
     }
     analyticsEnabled = enabled;
   },
-  apiLogView: (uri: string, outpoint: string, claimId: string, timeToStart?: number): void => {
+  apiLogView: (
+    uri: string,
+    outpoint: string,
+    claimId: string,
+    timeToStart?: number,
+    onSuccessCb: ?() => void
+  ): void => {
     if (analyticsEnabled) {
       const params = {
         uri,
@@ -56,7 +62,13 @@ const analytics: Analytics = {
         params.time_to_start = timeToStart;
       }
 
-      Lbryio.call('file', 'view', params).catch(() => {});
+      Lbryio.call('file', 'view', params)
+        .then(() => {
+          if (onSuccessCb) {
+            onSuccessCb();
+          }
+        })
+        .catch(() => {});
     }
   },
 };

--- a/src/renderer/component/fileViewer/index.js
+++ b/src/renderer/component/fileViewer/index.js
@@ -4,6 +4,7 @@ import { doChangeVolume } from 'redux/actions/app';
 import { selectVolume } from 'redux/selectors/app';
 import { doPlayUri, doSetPlayingUri } from 'redux/actions/content';
 import { doPlay, doPause, savePosition } from 'redux/actions/media';
+import { doClaimEligiblePurchaseRewards } from 'redux/actions/rewards';
 import {
   makeSelectMetadataForUri,
   makeSelectContentTypeForUri,
@@ -35,7 +36,7 @@ const select = (state, props) => ({
   mediaPosition: makeSelectMediaPositionForUri(props.uri)(state),
   autoplay: makeSelectClientSetting(settings.AUTOPLAY)(state),
   searchBarFocused: selectSearchBarFocused(state),
-  fileInfoErrors: selectFileInfoErrors(state)
+  fileInfoErrors: selectFileInfoErrors(state),
 });
 
 const perform = dispatch => ({
@@ -45,6 +46,7 @@ const perform = dispatch => ({
   doPlay: () => dispatch(doPlay()),
   doPause: () => dispatch(doPause()),
   savePosition: (claimId, position) => dispatch(savePosition(claimId, position)),
+  claimRewards: () => dispatch(doClaimEligiblePurchaseRewards()),
 });
 
 export default connect(

--- a/src/renderer/component/fileViewer/view.jsx
+++ b/src/renderer/component/fileViewer/view.jsx
@@ -44,6 +44,7 @@ type Props = {
   play: string => void,
   searchBarFocused: boolean,
   mediaType: string,
+  claimRewards: () => void,
 };
 
 class FileViewer extends React.PureComponent<Props> {
@@ -169,7 +170,8 @@ class FileViewer extends React.PureComponent<Props> {
     }
   }
 
-  fireAnalyticsEvent = (claim, startTime, playTime) => {
+  fireAnalyticsEvent(claim, startTime, playTime) {
+    const { claimRewards } = this.props;
     const { name, claim_id: claimId, txid, nout } = claim;
 
     // ideally outpoint would exist inside of claim information
@@ -181,8 +183,8 @@ class FileViewer extends React.PureComponent<Props> {
       timeToStart = playTime - startTime;
     }
 
-    analytics.apiLogView(`${name}#${claimId}`, outpoint, claimId, timeToStart);
-  };
+    analytics.apiLogView(`${name}#${claimId}`, outpoint, claimId, timeToStart, claimRewards);
+  }
 
   startedPlayingCb: ?() => void;
   startTime: ?number;

--- a/src/renderer/component/rewardSummary/index.js
+++ b/src/renderer/component/rewardSummary/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { selectUnclaimedRewardValue, selectFetchingRewards } from 'redux/selectors/rewards';
 import { doRewardList } from 'redux/actions/rewards';
+import { doFetchRewardedContent } from 'redux/actions/content';
 import RewardSummary from './view';
 
 const select = state => ({
@@ -10,6 +11,7 @@ const select = state => ({
 
 const perform = dispatch => ({
   fetchRewards: () => dispatch(doRewardList()),
+  fetchRewardedContent: () => dispatch(doFetchRewardedContent()),
 });
 
 export default connect(

--- a/src/renderer/component/rewardSummary/view.jsx
+++ b/src/renderer/component/rewardSummary/view.jsx
@@ -8,11 +8,13 @@ type Props = {
   unclaimedRewardAmount: number,
   fetching: boolean,
   fetchRewards: () => void,
+  fetchRewardedContent: () => void,
 };
 
 class RewardSummary extends React.Component<Props> {
   componentDidMount() {
     this.props.fetchRewards();
+    this.props.fetchRewardedContent();
   }
 
   render() {

--- a/src/renderer/page/discover/index.js
+++ b/src/renderer/page/discover/index.js
@@ -1,7 +1,6 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { doFetchFeaturedUris } from 'redux/actions/content';
-import { selectFeaturedUris, selectFetchingFeaturedUris } from 'redux/selectors/content';
+import { selectFeaturedUris, selectFetchingFeaturedUris, doFetchRewardedContent } from 'redux/selectors/content';
 import DiscoverPage from './view';
 
 const select = state => ({
@@ -11,6 +10,10 @@ const select = state => ({
 
 const perform = dispatch => ({
   fetchFeaturedUris: () => dispatch(doFetchFeaturedUris()),
+  fetchRewards: () => dispatch(doFetchRewardedContent()),
 });
 
-export default connect(select, perform)(DiscoverPage);
+export default connect(
+  select,
+  perform
+)(DiscoverPage);

--- a/src/renderer/page/discover/index.js
+++ b/src/renderer/page/discover/index.js
@@ -10,7 +10,7 @@ const select = state => ({
 
 const perform = dispatch => ({
   fetchFeaturedUris: () => dispatch(doFetchFeaturedUris()),
-  fetchRewards: () => dispatch(doFetchRewardedContent()),
+  fetchRewardedContent: () => dispatch(doFetchRewardedContent()),
 });
 
 export default connect(

--- a/src/renderer/page/discover/index.js
+++ b/src/renderer/page/discover/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
-import { doFetchFeaturedUris } from 'redux/actions/content';
-import { selectFeaturedUris, selectFetchingFeaturedUris, doFetchRewardedContent } from 'redux/selectors/content';
+import { doFetchFeaturedUris, doFetchRewardedContent } from 'redux/actions/content';
+import { selectFeaturedUris, selectFetchingFeaturedUris } from 'redux/selectors/content';
 import DiscoverPage from './view';
 
 const select = state => ({

--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -5,6 +5,7 @@ import CategoryList from 'component/categoryList';
 
 type Props = {
   fetchFeaturedUris: () => void,
+  fetchRewards: () => void,
   fetchingFeaturedUris: boolean,
   featuredUris: {},
 };
@@ -16,9 +17,14 @@ class DiscoverPage extends React.PureComponent<Props> {
   }
 
   componentWillMount() {
-    const { fetchFeaturedUris } = this.props;
+    const { fetchFeaturedUris, fetchRewards } = this.props;
     fetchFeaturedUris();
-    this.continousFetch = setInterval(fetchFeaturedUris, 1000 * 60 * 60);
+    fetchRewards();
+
+    this.continousFetch = setInterval(() => {
+      fetchFeaturedUris();
+      fetchRewards();
+    }, 1000 * 60 * 60);
   }
 
   componentWillUnmount() {

--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -5,7 +5,7 @@ import CategoryList from 'component/categoryList';
 
 type Props = {
   fetchFeaturedUris: () => void,
-  fetchRewards: () => void,
+  fetchRewardedContent: () => void,
   fetchingFeaturedUris: boolean,
   featuredUris: {},
 };
@@ -17,13 +17,13 @@ class DiscoverPage extends React.PureComponent<Props> {
   }
 
   componentWillMount() {
-    const { fetchFeaturedUris, fetchRewards } = this.props;
+    const { fetchFeaturedUris, fetchRewardedContent } = this.props;
     fetchFeaturedUris();
-    fetchRewards();
+    fetchRewardedContent();
 
     this.continousFetch = setInterval(() => {
       fetchFeaturedUris();
-      fetchRewards();
+      fetchRewardedContent();
     }, 1000 * 60 * 60);
   }
 

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -2,7 +2,6 @@ import * as NOTIFICATION_TYPES from 'constants/notification_types';
 import { ipcRenderer } from 'electron';
 import Lbryio from 'lbryio';
 import { doAlertError } from 'redux/actions/app';
-import { doClaimEligiblePurchaseRewards } from 'redux/actions/rewards';
 import { doNavigate } from 'redux/actions/navigation';
 import {
   setSubscriptionLatest,
@@ -230,7 +229,6 @@ export function doStartDownload(uri, outpoint) {
 export function doDownloadFile(uri, streamInfo) {
   return dispatch => {
     dispatch(doStartDownload(uri, streamInfo.outpoint));
-    dispatch(doClaimEligiblePurchaseRewards());
   };
 }
 


### PR DESCRIPTION
#### Changes
Refresh rewarded content when navigating to the discover page, and the wallet overview
Make sure to try and claim rewards _after_ we call the `file/view` https://github.com/lbryio/lbry-desktop/issues/1916