### PR TITLE
add app icon (256x256)

### DIFF
--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -24,11 +24,9 @@ export default appState => {
     // Create the window using the state information.
     x: windowState.x,
     y: windowState.y,
-
     // If state is undefined, create window as maximized.
     width: windowState.width === undefined ? width : windowState.width,
     height: windowState.height === undefined ? height : windowState.height,
-
     webPreferences: {
       // Disable renderer process's webSecurity on development to enable CORS.
       webSecurity: !isDev,

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -20,9 +20,11 @@ export default appState => {
     minHeight: 600,
     autoHideMenuBar: true,
     show: false,
+    icon: 'build/icons/48x48.png',
     // Create the window using the state information.
     x: windowState.x,
     y: windowState.y,
+
     // If state is undefined, create window as maximized.
     width: windowState.width === undefined ? width : windowState.width,
     height: windowState.height === undefined ? height : windowState.height,
@@ -123,7 +125,7 @@ export default appState => {
   window.webContents.on('crashed', () => {
     window = null;
   });
-  
+
   window.webContents.on('new-window', (event, url) => {
     event.preventDefault();
     shell.openExternal(url);

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -27,6 +27,7 @@ export default appState => {
     // If state is undefined, create window as maximized.
     width: windowState.width === undefined ? width : windowState.width,
     height: windowState.height === undefined ? height : windowState.height,
+
     webPreferences: {
       // Disable renderer process's webSecurity on development to enable CORS.
       webSecurity: !isDev,

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -20,7 +20,7 @@ export default appState => {
     minHeight: 600,
     autoHideMenuBar: true,
     show: false,
-    icon: 'build/icons/48x48.png',
+    icon: 'build/icons/256x256.png',
     // Create the window using the state information.
     x: windowState.x,
     y: windowState.y,


### PR DESCRIPTION
On launching either the .deb production package or the dev package, the boring default app icon appears in OS window.
I chose to add the 256x256 icon, and it works in linux.
This seems like low hanging fruit, perhaps it was removed from before? My fix didn't work when I tested on mac: mac displays the default electron icon instead of the icon provided. 
I will test on windows later tonight.