### PR TITLE
Re: Issue 1810: creates facebook share and moves social to fileActions

### DIFF
--- a/src/renderer/component/fileActions/view.jsx
+++ b/src/renderer/component/fileActions/view.jsx
@@ -4,6 +4,8 @@ import Button from 'component/button';
 import { MODALS } from 'lbry-redux';
 import * as icons from 'constants/icons';
 import Tooltip from 'component/common/tooltip';
+import ViewOnWebButton from 'component/viewOnWebButton';
+import ShareOnFacebook from 'component/shareOnFacebook';
 
 type FileInfo = {
   claim_id: string,
@@ -12,6 +14,8 @@ type FileInfo = {
 type Props = {
   uri: string,
   claimId: string,
+  claimName: string,
+  speechSharable: boolean,
   openModal: ({ id: string }, { uri: string }) => void,
   claimIsMine: boolean,
   fileInfo: FileInfo,
@@ -19,11 +23,27 @@ type Props = {
 
 class FileActions extends React.PureComponent<Props> {
   render() {
-    const { fileInfo, uri, openModal, claimIsMine, claimId } = this.props;
+    const {
+      fileInfo,
+      uri,
+      openModal,
+      claimIsMine,
+      claimId,
+      claimName,
+      speechSharable,
+    } = this.props;
     const showDelete = fileInfo && Object.keys(fileInfo).length > 0;
 
     return (
       <React.Fragment>
+        {claimId &&
+          claimName &&
+          speechSharable && (
+            <div>
+              <ViewOnWebButton claimId={claimId} claimName={claimName} />
+              <ShareOnFacebook claimId={claimId} claimName={claimName} />
+            </div>
+          )}
         {showDelete && (
           <Tooltip onComponent body={__('Delete this file')}>
             <Button

--- a/src/renderer/component/shareOnFacebook/index.js
+++ b/src/renderer/component/shareOnFacebook/index.js
@@ -1,0 +1,3 @@
+import ShareOnFacebook from './view';
+
+export default ShareOnFacebook;

--- a/src/renderer/component/shareOnFacebook/view.jsx
+++ b/src/renderer/component/shareOnFacebook/view.jsx
@@ -16,8 +16,13 @@ export default (props: Props) => {
     : `${claimId}/${claimName}`;
 
   return claimId && claimName ? (
-    <Tooltip onComponent body={__('View on Spee.ch')}>
-      <Button icon={icons.GLOBE} button="alt" label={__('')} href={`http://spee.ch/${speechURL}`} />
+    <Tooltip onComponent body={__('Post on Facebook')}>
+      <Button
+        icon={icons.FACEBOOK}
+        button="alt"
+        label={__('')}
+        href={`https://facebook.com/sharer/sharer.php?u=http://spee.ch/${speechURL}`}
+      />
     </Tooltip>
   ) : null;
 };

--- a/src/renderer/constants/icons.js
+++ b/src/renderer/constants/icons.js
@@ -30,3 +30,4 @@ export const EXTERNAL_LINK = 'ExternalLink';
 export const GIFT = 'Gift';
 export const EYE = 'Eye';
 export const PLAY = 'Play';
+export const FACEBOOK = 'Facebook';

--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -13,7 +13,6 @@ import DateTime from 'component/dateTime';
 import * as icons from 'constants/icons';
 import Button from 'component/button';
 import SubscribeButton from 'component/subscribeButton';
-import ViewOnWebButton from 'component/viewOnWebButton';
 import Page from 'component/page';
 import type { Claim } from 'types/claim';
 import type { Subscription } from 'types/subscription';
@@ -218,14 +217,16 @@ class FilePage extends React.Component<Props> {
                     onClick={() => openModal({ id: MODALS.SEND_TIP }, { uri })}
                   />
                 )}
-                {speechSharable && (
-                  <ViewOnWebButton claimId={claim.claim_id} claimName={claim.name} />
-                )}
               </div>
 
               <div className="card__actions">
-                <FileDownloadLink uri={uri} />
-                <FileActions uri={uri} claimId={claim.claim_id} />
+                <FileDownloadLink uri={uri} />&nbsp;
+                <FileActions
+                  uri={uri}
+                  claimId={claim.claim_id}
+                  claimName={claim.name}
+                  speechSharable={speechSharable}
+                />
               </div>
             </div>
             <FormRow padded>


### PR DESCRIPTION
Re: Issue 1810
The facebook link facilitates posting the associated spee.ch link.
I like the idea of grouping channel-specific actions away from file-specific action.
Alternately, socialActions could be a component parallel to fileActions.
However, the best solution may be to do social sharing in a modal, as the real estate under the viewer is going to get crowded.
Feedback would be appreciated.
![social](https://user-images.githubusercontent.com/36554050/44952204-a3ded180-ae47-11e8-8610-0d1faf0a9506.png)

Re: linting and flow: Fixed all errors except an unrelated unused subscription prop in page/file/view.jsx
