### PR TITLE
Creates a modal SocialShare component

### DIFF
--- a/src/renderer/component/socialShare/index.js
+++ b/src/renderer/component/socialShare/index.js
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+import { makeSelectClaimForUri } from 'lbry-redux';
+import SocialShare from './view';
+
+const select = (state, props) => ({
+  claim: makeSelectClaimForUri(props.uri)(state),
+});
+
+export default connect(select)(SocialShare);

--- a/src/renderer/component/socialShare/view.jsx
+++ b/src/renderer/component/socialShare/view.jsx
@@ -1,0 +1,30 @@
+// @flow
+import React from 'react';
+import type { Claim } from 'types/claim';
+
+// import Button from 'component/button';
+// import { FormField } from 'component/common/form';
+
+type Props = {
+  claim: Claim,
+};
+
+// the only reason I can think of for <..,State> is to count times shared
+class SocialShare extends React.PureComponent<Props> {
+  render() {
+    const { claim } = this.props;
+    const { claim_id: claimId, name: claimName, channel_name: channelName } = claim;
+    return (
+      <div>
+        <div className="card__title">
+          <h1>{__('Share')}</h1>
+          <h2>claimId:{claimId}</h2>
+          <h2>claimName:{claimName}</h2>
+          <h2>channelName:{channelName}</h2>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SocialShare;

--- a/src/renderer/component/socialShare/view.jsx
+++ b/src/renderer/component/socialShare/view.jsx
@@ -1,19 +1,22 @@
 // @flow
 import React from 'react';
 import type { Claim } from 'types/claim';
+import Button from 'component/button';
 
 // import Button from 'component/button';
 // import { FormField } from 'component/common/form';
 
 type Props = {
   claim: Claim,
+  onDone: () => void,
 };
 
 // the only reason I can think of for <..,State> is to count times shared
 class SocialShare extends React.PureComponent<Props> {
   render() {
-    const { claim } = this.props;
-    const { claim_id: claimId, name: claimName, channel_name: channelName } = claim;
+    const { claim_id: claimId, name: claimName, channel_name: channelName } = this.props.claim;
+    const { onDone } = this.props;
+
     return (
       <div>
         <div className="card__title">
@@ -21,6 +24,10 @@ class SocialShare extends React.PureComponent<Props> {
           <h2>claimId:{claimId}</h2>
           <h2>claimName:{claimName}</h2>
           <h2>channelName:{channelName}</h2>
+          <div className="card__actions">
+            {/* button that shares to facebook */}
+            <Button button="primary" label={__('Done')} onClick={onDone} />
+          </div>
         </div>
       </div>
     );

--- a/src/renderer/component/socialShare/view.jsx
+++ b/src/renderer/component/socialShare/view.jsx
@@ -2,6 +2,10 @@
 import React from 'react';
 import type { Claim } from 'types/claim';
 import Button from 'component/button';
+import { clipboard } from 'electron';
+import { FormRow } from 'component/common/form';
+import * as icons from 'constants/icons';
+import Tooltip from 'component/common/tooltip';
 
 // import Button from 'component/button';
 // import { FormField } from 'component/common/form';
@@ -13,17 +17,81 @@ type Props = {
 
 // the only reason I can think of for <..,State> is to count times shared
 class SocialShare extends React.PureComponent<Props> {
+  constructor(props: Props) {
+    super(props);
+
+    this.input = undefined;
+  }
+
+  input: ?HTMLInputElement;
+
   render() {
     const { claim_id: claimId, name: claimName, channel_name: channelName } = this.props.claim;
     const { onDone } = this.props;
+    const speechPrefix = 'http://spee.ch/';
+    const speechURL = channelName
+      ? `${speechPrefix}${channelName}/${claimName}`
+      : `${speechPrefix}${claimName}#${claimId}`;
 
     return (
       <div>
         <div className="card__title">
-          <h1>{__('Share')}</h1>
-          <h2>claimId:{claimId}</h2>
-          <h2>claimName:{claimName}</h2>
-          <h2>channelName:{channelName}</h2>
+          <h3>{__('Share')}</h3>
+          <div className="card__content">
+            <FormRow verticallyCentered padded stretch>
+              <input
+                className="input-copyable form-field__input"
+                readOnly
+                value={speechURL || ''}
+                ref={input => {
+                  this.input = input;
+                }}
+                onFocus={() => {
+                  if (this.input) {
+                    this.input.select();
+                  }
+                }}
+              />
+              <Button
+                noPadding
+                button="secondary"
+                icon={icons.CLIPBOARD}
+                onClick={() => {
+                  clipboard.writeText(speechURL);
+                }}
+              />
+            </FormRow>
+          </div>
+          <div className="card__content">
+            <Tooltip onComponent body={__('Post on Facebook')}>
+              <Button
+                className="btn"
+                icon={icons.FACEBOOK}
+                button="alt"
+                label={__('')}
+                href={`https://facebook.com/sharer/sharer.php?u=${speechURL}`}
+              />
+            </Tooltip>
+            <Tooltip onComponent body={__('Tweet on Twitter')}>
+              <Button
+                icon={icons.TWITTER}
+                button="alt"
+                label={__('')}
+                href={`https://twitter.com/home?status=${speechURL}`}
+              />
+            </Tooltip>
+            <Tooltip onComponent body={__('Post on Google Plus')}>
+              <Button
+                icon={icons.GOOGLE_PLUS}
+                button="alt"
+                label={__('')}
+                href={`https://plus.google.com/share?url=${speechURL}`}
+              />
+            </Tooltip>
+            <Tooltip onComponent body={__('View on Spee.ch')}>
+              <Button icon={icons.GLOBE} button="alt" label={__('')} href={`${speechURL}`} />
+            </Tooltip>
+          </div>
           <div className="card__actions">
             {/* button that shares to facebook */}
             <Button button="primary" label={__('Done')} onClick={onDone} />

--- a/src/renderer/constants/icons.js
+++ b/src/renderer/constants/icons.js
@@ -30,3 +30,6 @@ export const EXTERNAL_LINK = 'ExternalLink';
 export const GIFT = 'Gift';
 export const EYE = 'Eye';
 export const PLAY = 'Play';
+export const FACEBOOK = 'Facebook';
+export const TWITTER = 'Twitter';
+export const GOOGLE_PLUS = 'PlusCircle';

--- a/src/renderer/modal/modalRouter/view.jsx
+++ b/src/renderer/modal/modalRouter/view.jsx
@@ -19,9 +19,10 @@ import ModalEmailCollection from 'modal/modalEmailCollection';
 import ModalPhoneCollection from 'modal/modalPhoneCollection';
 import ModalFirstSubscription from 'modal/modalFirstSubscription';
 import ModalConfirmTransaction from 'modal/modalConfirmTransaction';
-import ModalSendTip from '../modalSendTip';
-import ModalPublish from '../modalPublish';
-import ModalOpenExternalLink from '../modalOpenExternalLink';
+import ModalSocialShare from 'modal/modalSocialShare';
+import ModalSendTip from 'modal/modalSendTip';
+import ModalPublish from 'modal/modalPublish';
+import ModalOpenExternalLink from 'modal/modalOpenExternalLink';
 import ModalConfirmThumbnailUpload from 'modal/modalConfirmThumbnailUpload';
 import ModalWalletEncrypt from 'modal/modalWalletEncrypt';
 import ModalWalletDecrypt from 'modal/modalWalletDecrypt';
@@ -160,6 +161,8 @@ class ModalRouter extends React.PureComponent<Props> {
         return <ModalFirstSubscription {...notificationProps} />;
       case MODALS.SEND_TIP:
         return <ModalSendTip {...notificationProps} />;
+      case MODALS.SOCIAL_SHARE:
+        return <ModalSocialShare {...notificationProps} />;
       case MODALS.PUBLISH:
         return <ModalPublish {...notificationProps} />;
       case MODALS.CONFIRM_EXTERNAL_LINK:

--- a/src/renderer/modal/modalSocialShare/index.js
+++ b/src/renderer/modal/modalSocialShare/index.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import { doHideNotification } from 'lbry-redux';
+import ModalSocialShare from './view';
+
+const perform = dispatch => ({
+  closeModal: () => dispatch(doHideNotification()),
+});
+
+export default connect(
+  null,
+  perform
+)(ModalSocialShare);

--- a/src/renderer/modal/modalSocialShare/view.jsx
+++ b/src/renderer/modal/modalSocialShare/view.jsx
@@ -1,0 +1,23 @@
+// @flow
+import React from 'react';
+import { Modal } from 'modal/modal';
+import SocialShare from 'component/socialShare';
+
+type Props = {
+  closeModal: () => void,
+  uri: string,
+};
+
+class ModalSocialShare extends React.PureComponent<Props> {
+  render() {
+    const { closeModal, uri } = this.props;
+
+    return (
+      <Modal isOpen type="custom">
+        <SocialShare uri={uri} onDone={closeModal} />
+      </Modal>
+    );
+  }
+}
+
+export default ModalSocialShare;

--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -218,6 +218,14 @@ class FilePage extends React.Component<Props> {
                     onClick={() => openModal({ id: MODALS.SEND_TIP }, { uri })}
                   />
                 )}
+                {
+                  <Button
+                    button="alt"
+                    icon={icons.GLOBE}
+                    label={__('Share Modal')}
+                    onClick={() => openModal({ id: MODALS.SOCIAL_SHARE }, { uri })}
+                  />
+                }
                 {speechSharable && (
                   <ViewOnWebButton claimId={claim.claim_id} claimName={claim.name} />
                 )}

--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -13,7 +13,6 @@ import DateTime from 'component/dateTime';
 import * as icons from 'constants/icons';
 import Button from 'component/button';
 import SubscribeButton from 'component/subscribeButton';
-import ViewOnWebButton from 'component/viewOnWebButton';
 import Page from 'component/page';
 import type { Claim } from 'types/claim';
 import type { Subscription } from 'types/subscription';
@@ -218,16 +217,13 @@ class FilePage extends React.Component<Props> {
                     onClick={() => openModal({ id: MODALS.SEND_TIP }, { uri })}
                   />
                 )}
-                {
+                {speechSharable && (
                   <Button
                     button="alt"
                     icon={icons.GLOBE}
-                    label={__('Share Modal')}
+                    label={__('Share')}
                     onClick={() => openModal({ id: MODALS.SOCIAL_SHARE }, { uri })}
                   />
-                }
-                {speechSharable && (
-                  <ViewOnWebButton claimId={claim.claim_id} claimName={claim.name} />
                 )}
               </div>
 


### PR DESCRIPTION
This was closely modeled after the modalSendTip and walletSendTip components.
Daovist pointed out it should share both anonymous and channel based content - it seemed to do both when that content could be located.
It continues to only be available if the content meets shareable criteria.
It uses share urls from http://www.sharelinkgenerator.com/ to share to Facebook, Twitter, and Google Plus.
There are some improvements that could be made:
- feathericons has no actual google-plus icon, I think
- it could share a tinyurl-ified version
- the formatting and spacing could be better
- the mouseover tooltips could be more responsive: they seem to give up sometimes - ideas?
- the link could come preselected, rather than wait for a click in the text field
- the modal could give feedback that the link copy was successful: 'link copied to clipboard'
- it could close the modal when clicking the background or pressing esc

Finally, the ViewOnWeb component is apparently no longer in use.

I look forward to more guidance in these areas.