### PR TITLE
Fix paragraphs spacing on markdown render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 ### Fixed
+ * Paragraph rendering now properly includes a margin for new paragraphs ([#1939](https://github.com/lbryio/lbry-desktop/pull/1939))
 
 
 ## [0.25.0] - 2018-08-29

--- a/src/renderer/scss/component/_markdown-preview.scss
+++ b/src/renderer/scss/component/_markdown-preview.scss
@@ -39,7 +39,7 @@
 
   /* Paragraphs */
   p {
-    margin: $spacing-vertical 0;
+    margin: $spacing-vertical * 2/3 0;
     white-space: pre-line;
   }
 

--- a/src/renderer/scss/component/_markdown-preview.scss
+++ b/src/renderer/scss/component/_markdown-preview.scss
@@ -39,6 +39,7 @@
 
   /* Paragraphs */
   p {
+    margin: $spacing-vertical 0;
     white-space: pre-line;
   }
 


### PR DESCRIPTION
### Changes
 - Fixes paragraphs not rendered correctly in markdown #1932