### PR TITLE
Better messaging for takeover amounts on publish page

### DIFF
--- a/src/renderer/component/publishForm/internal/bid-help-text.jsx
+++ b/src/renderer/component/publishForm/internal/bid-help-text.jsx
@@ -20,7 +20,9 @@ class BidHelpText extends React.PureComponent<Props> {
       } else {
         bidHelpText = `${__('If you bid more than')} ${amountNeededForTakeover} LBC, ${__(
           'when someone navigates to'
-        )} ${uri} ${__('it will load your published content')}.`;
+        )} ${uri} ${__('it will load your published content')}. ${__(
+          'However, you can get a longer version of this URL for any bid'
+        )}.`;
       }
     }
 

--- a/src/renderer/component/publishForm/internal/bid-help-text.jsx
+++ b/src/renderer/component/publishForm/internal/bid-help-text.jsx
@@ -19,7 +19,7 @@ class BidHelpText extends React.PureComponent<Props> {
         bidHelpText = __('Any amount will give you the winning bid.');
       } else {
         bidHelpText = `${__('If you bid more than')} ${amountNeededForTakeover} LBC, ${__(
-          'when somone navigates to'
+          'when someone navigates to'
         )} ${uri} ${__('it will load your published content')}.`;
       }
     }

--- a/src/renderer/component/publishForm/internal/bid-help-text.jsx
+++ b/src/renderer/component/publishForm/internal/bid-help-text.jsx
@@ -1,72 +1,34 @@
 // @flow
 import * as React from 'react';
-import Button from 'component/button';
-import { buildURI } from 'lbry-redux';
-import type { Claim } from 'types/claim';
 
 type Props = {
   uri: ?string,
   isResolvingUri: boolean,
-  winningBidForClaimUri: ?number,
-  myClaimForUri: ?Claim,
-  isStillEditing: boolean,
-  onEditMyClaim: (any, string) => void,
+  amountNeededForTakeover: ?number,
 };
 
 class BidHelpText extends React.PureComponent<Props> {
   render() {
-    const {
-      uri,
-      isResolvingUri,
-      winningBidForClaimUri,
-      myClaimForUri,
-      onEditMyClaim,
-      isStillEditing,
-    } = this.props;
+    const { uri, isResolvingUri, amountNeededForTakeover } = this.props;
+    let bidHelpText;
 
-    if (!uri) {
-      return __('Create a URL for this content.');
+    if (uri) {
+      if (isResolvingUri) {
+        bidHelpText = __('Checking the winning claim amount...');
+      } else if (!amountNeededForTakeover) {
+        bidHelpText = __('Any amount will give you the winning bid.');
+      } else {
+        bidHelpText = `${__('If you bid more than')} ${amountNeededForTakeover} LBC, ${__(
+          'when somone navigates to'
+        )} ${uri} ${__('it will load your published content')}.`;
+      }
     }
 
-    if (isStillEditing) {
-      return __(
-        'You are currently editing this claim. If you change the URL, you will need to reselect a file.'
-      );
-    }
-
-    if (isResolvingUri) {
-      return __('Checking the winning claim amount...');
-    }
-
-    if (myClaimForUri) {
-      const editUri = buildURI({
-        contentName: myClaimForUri.name,
-        claimId: myClaimForUri.claim_id,
-      });
-
-      return (
-        <React.Fragment>
-          {__('You already have a claim at')}
-          {` ${uri} `}
-          <Button
-            button="link"
-            label="Edit it"
-            onClick={() => onEditMyClaim(myClaimForUri, editUri)}
-          />
-          <br />
-          {__('Publishing will update your existing claim.')}
-        </React.Fragment>
-      );
-    }
-
-    return winningBidForClaimUri ? (
+    return (
       <React.Fragment>
-        {__('A deposit greater than')} {winningBidForClaimUri} {__('is needed to win')}
-        {` ${uri}. `}
-        {__('However, you can still get this URL for any amount.')}
+        {__('This LBC remains yours and the deposit can be undone at any time.')}
+        <div>{bidHelpText}</div>
       </React.Fragment>
-    ) : (
-      __('Any amount will give you the winning bid.')
     );
   }
 }

--- a/src/renderer/component/publishForm/internal/name-help-text.jsx
+++ b/src/renderer/component/publishForm/internal/name-help-text.jsx
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react';
+import Button from 'component/button';
+import { buildURI } from 'lbry-redux';
+import type { Claim } from 'types/claim';
+
+type Props = {
+  uri: ?string,
+  myClaimForUri: ?Claim,
+  isStillEditing: boolean,
+  onEditMyClaim: (any, string) => void,
+};
+
+class NameHelpText extends React.PureComponent<Props> {
+  render() {
+    const { uri, myClaimForUri, onEditMyClaim, isStillEditing } = this.props;
+
+    let nameHelpText;
+
+    if (isStillEditing) {
+      nameHelpText = __(
+        'You are currently editing this claim. If you change the URL, you will need to reselect a file.'
+      );
+    } else if (uri && myClaimForUri) {
+      const editUri = buildURI({
+        contentName: myClaimForUri.name,
+        claimId: myClaimForUri.claim_id,
+      });
+
+      nameHelpText = (
+        <React.Fragment>
+          {__('You already have a claim at')}
+          {` ${uri} `}
+          <Button
+            button="link"
+            label="Edit it"
+            onClick={() => onEditMyClaim(myClaimForUri, editUri)}
+          />
+          <br />
+          {__('Publishing will update your existing claim.')}
+        </React.Fragment>
+      );
+    }
+
+    return <React.Fragment>{nameHelpText || __('Create a URL for this content.')}</React.Fragment>;
+  }
+}
+
+export default NameHelpText;

--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -81,6 +81,7 @@ class FilePage extends React.Component<Props> {
     this.checkSubscription(this.props);
 
     setViewed(uri);
+    console.log('claim', this.props.claim);
   }
 
   componentWillReceiveProps(nextProps: Props) {

--- a/src/renderer/page/publish/index.js
+++ b/src/renderer/page/publish/index.js
@@ -1,10 +1,12 @@
 import { connect } from 'react-redux';
-import { doResolveUri, selectClaimsByUri, selectResolvingUris, selectBalance } from 'lbry-redux';
+import { doResolveUri, selectBalance } from 'lbry-redux';
 import { doNavigate } from 'redux/actions/navigation';
 import {
   selectPublishFormValues,
   selectIsStillEditing,
   selectMyClaimForUri,
+  selectIsResolvingPublishUris,
+  selectTakeOverAmount,
 } from 'redux/selectors/publish';
 import {
   doResetThumbnailStatus,
@@ -15,43 +17,18 @@ import {
 } from 'redux/actions/publish';
 import PublishPage from './view';
 
-const select = state => {
-  const isStillEditing = selectIsStillEditing(state);
-  const myClaimForUri = selectMyClaimForUri(state);
-  const publishState = selectPublishFormValues(state);
-  const { uri } = publishState;
-
-  const resolvingUris = selectResolvingUris(state);
-  let isResolvingUri = false;
-  if (uri) {
-    isResolvingUri = resolvingUris.includes(uri);
-  }
-
-  let claimForUri;
-  let winningBidForClaimUri;
-  if (!myClaimForUri) {
-    // if the uri isn't from a users claim, find the winning bid needed for the vanity url
-    // in the future we may want to display this on users claims
-    // ex: "you own this, for 5 more lbc you will win this claim"
-    const claimsByUri = selectClaimsByUri(state);
-    claimForUri = claimsByUri[uri];
-    winningBidForClaimUri = claimForUri ? claimForUri.effective_amount : null;
-  }
-
-  return {
-    ...publishState,
-    isResolvingUri,
-    // The winning claim for a short lbry uri
-    claimForUri,
-    winningBidForClaimUri,
-    // My previously published claims under this short lbry uri
-    myClaimForUri,
-    // If I clicked the "edit" button, have I changed the uri?
-    // Need this to make it easier to find the source on previously published content
-    isStillEditing,
-    balance: selectBalance(state),
-  };
-};
+const select = state => ({
+  ...selectPublishFormValues(state),
+  // The winning claim for a short lbry uri
+  amountNeededForTakeover: selectTakeOverAmount(state),
+  // My previously published claims under this short lbry uri
+  myClaimForUri: selectMyClaimForUri(state),
+  // If I clicked the "edit" button, have I changed the uri?
+  // Need this to make it easier to find the source on previously published content
+  isStillEditing: selectIsStillEditing(state),
+  balance: selectBalance(state),
+  isResolvingUri: selectIsResolvingPublishUris(state),
+});
 
 const perform = dispatch => ({
   updatePublishForm: value => dispatch(doUpdatePublishForm(value)),

--- a/src/renderer/redux/reducers/navigation.js
+++ b/src/renderer/redux/reducers/navigation.js
@@ -3,7 +3,7 @@ import * as ACTIONS from 'constants/action_types';
 const getCurrentPath = () => {
   const { hash } = document.location;
   if (hash !== '') return hash.replace(/^#/, '');
-  return '/discover';
+  return '/publish';
 };
 
 const reducers = {};

--- a/src/renderer/redux/reducers/navigation.js
+++ b/src/renderer/redux/reducers/navigation.js
@@ -3,7 +3,7 @@ import * as ACTIONS from 'constants/action_types';
 const getCurrentPath = () => {
   const { hash } = document.location;
   if (hash !== '') return hash.replace(/^#/, '');
-  return '/publish';
+  return '/discover';
 };
 
 const reducers = {};

--- a/src/renderer/scss/component/_form-field.scss
+++ b/src/renderer/scss/component/_form-field.scss
@@ -97,7 +97,7 @@
 
 .form-field__help {
   color: var(--color-help);
-  padding-top: $spacing-vertical * 2/3;
+  padding-top: $spacing-vertical * 1/3;
 }
 
 .form-field__error {


### PR DESCRIPTION
More clarity for takeover amounts on claims

Show amount needed to win a claim when editing. Ex: "You have a claim at xxx, for 5 more LBC you will control it"

### Changes
I created a new component `NameHelpText` for variable help text under the name input. I moved `BidHelpText` under the bid input (which is probably where it should have been in the first place)

#### Before
<img width="400" alt="screen shot 2018-09-24 at 8 24 53 pm" src="https://user-images.githubusercontent.com/16882830/45986181-ec00a680-c037-11e8-839e-41da36a50682.png">

#### After
<img width="400" alt="screen shot 2018-09-24 at 8 23 39 pm" src="https://user-images.githubusercontent.com/16882830/45986164-c96e8d80-c037-11e8-866a-00b1fd8d6852.png">
