### PR TITLE
Fix table elements padding and spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
  * Paragraph rendering now properly includes a margin for new paragraphs ([#1939](https://github.com/lbryio/lbry-desktop/pull/1939))
  * Alignment of "navigate to page" input next to pagination on channel pages ([#1941](https://github.com/lbryio/lbry-desktop/pull/1941))
+ * Table spacing with claim name in transactions table ([#1942](https://github.com/lbryio/lbry-desktop/pull/1942))
 
 
 ## [0.25.0] - 2018-08-29

--- a/src/renderer/scss/component/_table.scss
+++ b/src/renderer/scss/component/_table.scss
@@ -29,7 +29,7 @@ table.table,
   td {
     font-family: 'metropolis-medium';
     color: var(--color-help);
-    padding: $spacing-vertical * 1/3 $spacing-vertical * 1/3;
+    padding: $spacing-vertical * 1/6 $spacing-vertical * 1/3;
 
     .btn:not(.btn--link) {
       display: inline;

--- a/src/renderer/scss/component/_table.scss
+++ b/src/renderer/scss/component/_table.scss
@@ -15,26 +15,21 @@ table.table,
     padding-right: $spacing-vertical * 2/3;
   }
 
-  thead {
-    color: var(--text-color);
-    border-bottom: var(--table-border);
-  }
-
-  th,
-  td {
+  tr th,
+  tr td {
     font-size: 13px;
-    padding: 8px 0;
   }
 
   th {
     font-family: 'metropolis-semibold';
     border: 0;
+    padding: $spacing-vertical * 2/3 $spacing-vertical * 1/3;
   }
 
   td {
     font-family: 'metropolis-medium';
     color: var(--color-help);
-    padding: $spacing-vertical * 1/6 0;
+    padding: $spacing-vertical * 1/3 $spacing-vertical * 1/3;
 
     .btn:not(.btn--link) {
       display: inline;
@@ -48,6 +43,11 @@ table.table,
 
   .table__item--actionable span + .btn {
     padding-left: $spacing-vertical * 1/3;
+  }
+
+  thead {
+    color: var(--text-color);
+    border-bottom: var(--table-border);
   }
 
   tbody {


### PR DESCRIPTION
### Changes

- Fix claim name positioning too close to transaction id #1849

### Preview
![table](https://user-images.githubusercontent.com/14793624/45200132-92713d00-b22c-11e8-8151-ea73c0371dc3.png)
