### PR TITLE
modalSendTip closes on esc/click outside

### DIFF
--- a/src/renderer/modal/modalSendTip/view.jsx
+++ b/src/renderer/modal/modalSendTip/view.jsx
@@ -13,7 +13,7 @@ class ModalSendTip extends React.PureComponent<Props> {
     const { closeModal, uri } = this.props;
 
     return (
-      <Modal isOpen type="custom">
+      <Modal onAborted={closeModal} isOpen type="custom">
         <SendTip uri={uri} onCancel={closeModal} sendTipCallback={closeModal} />
       </Modal>
     );


### PR DESCRIPTION
clicking off of send tip now closes the modal. 