### PR TITLE
fix: checks tip input re:#1889

### DIFF
--- a/src/renderer/component/walletSendTip/view.jsx
+++ b/src/renderer/component/walletSendTip/view.jsx
@@ -50,6 +50,9 @@ class WalletSendTip extends React.PureComponent<Props, State> {
     const { balance } = this.props;
     const tipAmount = parseFloat(event.target.value);
     let newTipError;
+    if (!String(tipAmount).match(/^(\d*([.]\d{0,8})?)$/)) {
+      newTipError = __('Tip must be a valid number with no more than 8 decimal places');
+    }
     if (tipAmount === balance) {
       newTipError = __('Please decrease your tip to account for transaction fees');
     } else if (tipAmount > balance) {


### PR DESCRIPTION
Issue #1889 mentions the tip input allowing any number of decimal places, far beyond one satoshi.
This should do it. I'm looking for input on the Error message, though.

I also noticed that the field would fail to complain about 5.5.5.5 as an input. That's a bit better now, though not perfect. 5.5. slips by for some reason, but 5.5.5 throws an error.