### PR TITLE
hotfix: share is broken; use currently working spee.ch share url

### DIFF
--- a/src/renderer/component/socialShare/view.jsx
+++ b/src/renderer/component/socialShare/view.jsx
@@ -21,12 +21,20 @@ class SocialShare extends React.PureComponent<Props> {
   input: ?HTMLInputElement;
 
   render() {
-    const { claim_id: claimId, name: claimName, channel_name: channelName } = this.props.claim;
+    const {
+      claim_id: claimId,
+      name: claimName,
+      channel_name: channelName,
+      value,
+    } = this.props.claim;
+    const channelClaimId =
+      value && value.publisherSignature && value.publisherSignature.certificateId;
     const { onDone } = this.props;
     const speechPrefix = 'http://spee.ch/';
-    const speechURL = channelName
-      ? `${speechPrefix}${channelName}/${claimName}`
-      : `${speechPrefix}${claimName}#${claimId}`;
+    const speechURL =
+      channelName && channelClaimId
+        ? `${speechPrefix}${channelName}:${channelClaimId}/${claimName}`
+        : `${speechPrefix}${claimName}#${claimId}`;
 
     return (
       <div>


### PR DESCRIPTION
Share on spee.ch urls using channelName need clarification and testing. Revert back to working url without channelName.

Must confirm with spee.ch group how to properly format urls using channelName.
If someone can get a url using channelName to work consistently, I can put that format in.