### PR TITLE
Update _card.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 * Make tooltip smarter ([#1979](https://github.com/lbryio/lbry-desktop/pull/1979))
 
 ### Fixed
+* Invite table cutoff with large number of invites ([#1985](https://github.com/lbryio/lbry-desktop/pull/1985))
 
 
 ## [0.25.1] - 2018-09-18

--- a/src/renderer/scss/component/_card.scss
+++ b/src/renderer/scss/component/_card.scss
@@ -4,7 +4,6 @@
   border-radius: var(--card-radius);
   user-select: text;
   display: flex;
-  position: relative;
   flex-direction: column;
   max-width: var(--card-max-width);
 }


### PR DESCRIPTION
Invites section doesn't expand past a certain height
https://media.discordapp.net/attachments/363087331475062785/493920826505035776/unknown.png?width=693&height=428
Displays correctly when position is set from relative to initial in the CSS. 