### PR TITLE
remove claims from redux-persist cache

### DIFF
--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -81,7 +81,6 @@ class FilePage extends React.Component<Props> {
     this.checkSubscription(this.props);
 
     setViewed(uri);
-    console.log('claim', this.props.claim);
   }
 
   componentWillReceiveProps(nextProps: Props) {

--- a/src/renderer/redux/selectors/content.js
+++ b/src/renderer/redux/selectors/content.js
@@ -50,20 +50,19 @@ export const makeSelectHistoryForPage = page =>
   createSelector(selectState, selectClaimsByUri, (state, claimsByUri) => {
     const left = page * HISTORY_ITEMS_PER_PAGE;
     const historyItems = state.history.slice(left, left + HISTORY_ITEMS_PER_PAGE);
-    
+
     // See if we have the claim info for the uris in your history
     // If not, it will need to be fetched in the component
-    return historyItems.map((historyItem) => {
+    return historyItems.map(historyItem => {
       const { uri, lastViewed } = historyItem;
       const claimAtUri = claimsByUri[uri];
-      
+
       if (claimAtUri) {
-        return { lastViewed, uri, ...claimAtUri }
+        return { lastViewed, uri, ...claimAtUri };
       } else {
-        console.log("jsut returning item")
         return historyItem;
       }
-    })
+    });
   });
 
 export const makeSelectHistoryForUri = uri =>

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -97,7 +97,10 @@ const store = createStore(
 );
 
 const compressor = createCompressor();
-const saveClaimsFilter = createFilter('claims', ['byId', 'claimsByUri']);
+// Removing claims from redux-persist to see if it solves https://github.com/lbryio/lbry-desktop/issues/1983
+// We were caching so much data the app was locking up
+// We can't add this back until we can perform this in a non-blocking way
+// const saveClaimsFilter = createFilter('claims', ['byId', 'claimsByUri']);
 const subscriptionsFilter = createFilter('subscriptions', ['subscriptions']);
 const contentFilter = createFilter('content', ['positions', 'history']);
 
@@ -105,10 +108,10 @@ const contentFilter = createFilter('content', ['positions', 'history']);
 const walletFilter = createFilter('wallet', ['receiveAddress']);
 
 const persistOptions = {
-  whitelist: ['claims', 'subscriptions', 'publish', 'wallet', 'content'],
+  whitelist: ['subscriptions', 'publish', 'wallet', 'content'],
   // Order is important. Needs to be compressed last or other transforms can't
   // read the data
-  transforms: [saveClaimsFilter, subscriptionsFilter, walletFilter, contentFilter, compressor],
+  transforms: [subscriptionsFilter, walletFilter, contentFilter, compressor],
   debounce: 10000,
   storage: localForage,
 };


### PR DESCRIPTION
Removing claims from cache to fix https://github.com/lbryio/lbry-desktop/issues/1983

If you were viewing a lot of claims (with search/many related videos) the app would lock up when it tried to save to disk. Ideally, this would happen in a nonblocking way.

