### PR TITLE
remove copyright from publish form state and fix other license edit

### DIFF
--- a/src/renderer/component/publishForm/internal/license-type.jsx
+++ b/src/renderer/component/publishForm/internal/license-type.jsx
@@ -5,13 +5,11 @@ import { CC_LICENSES, COPYRIGHT, OTHER, PUBLIC_DOMAIN, NONE } from 'constants/li
 
 type Props = {
   licenseType: string,
-  copyrightNotice: ?string,
   licenseUrl: ?string,
   otherLicenseDescription: ?string,
   handleLicenseChange: (string, string) => void,
   handleLicenseDescriptionChange: (SyntheticInputEvent<*>) => void,
   handleLicenseUrlChange: (SyntheticInputEvent<*>) => void,
-  handleCopyrightNoticeChange: (SyntheticInputEvent<*>) => void,
 };
 
 class LicenseType extends React.PureComponent<Props> {
@@ -38,11 +36,8 @@ class LicenseType extends React.PureComponent<Props> {
       licenseType,
       otherLicenseDescription,
       licenseUrl,
-      copyrightNotice,
-      handleLicenseChange,
       handleLicenseDescriptionChange,
       handleLicenseUrlChange,
-      handleCopyrightNoticeChange,
     } = this.props;
 
     return (
@@ -72,8 +67,8 @@ class LicenseType extends React.PureComponent<Props> {
               label={__('Copyright notice')}
               type="text"
               name="copyright-notice"
-              value={copyrightNotice}
-              onChange={handleCopyrightNoticeChange}
+              value={otherLicenseDescription}
+              onChange={handleLicenseDescriptionChange}
             />
           </FormRow>
         )}

--- a/src/renderer/component/publishForm/view.jsx
+++ b/src/renderer/component/publishForm/view.jsx
@@ -45,7 +45,6 @@ type Props = {
   licenseType: string,
   otherLicenseDescription: ?string,
   licenseUrl: ?string,
-  copyrightNotice: ?string,
   uri: ?string,
   bidError: ?string,
   publishing: boolean,
@@ -200,7 +199,6 @@ class PublishForm extends React.PureComponent<Props> {
   handlePublish() {
     const {
       filePath,
-      copyrightNotice,
       licenseType,
       licenseUrl,
       otherLicenseDescription,
@@ -211,8 +209,6 @@ class PublishForm extends React.PureComponent<Props> {
     let publishingLicense;
     switch (licenseType) {
       case COPYRIGHT:
-        publishingLicense = copyrightNotice;
-        break;
       case OTHER:
         publishingLicense = otherLicenseDescription;
         break;
@@ -233,7 +229,6 @@ class PublishForm extends React.PureComponent<Props> {
       license: publishingLicense,
       licenseUrl: publishingLicenseUrl,
       otherLicenseDescription,
-      copyrightNotice,
       name: this.props.name,
       contentIsFree: this.props.contentIsFree,
       price: this.props.price,
@@ -339,7 +334,6 @@ class PublishForm extends React.PureComponent<Props> {
       licenseType,
       otherLicenseDescription,
       licenseUrl,
-      copyrightNotice,
       uri,
       bidError,
       publishing,
@@ -585,7 +579,6 @@ class PublishForm extends React.PureComponent<Props> {
               licenseType={licenseType}
               otherLicenseDescription={otherLicenseDescription}
               licenseUrl={licenseUrl}
-              copyrightNotice={copyrightNotice}
               handleLicenseChange={(newLicenseType, newLicenseUrl) =>
                 updatePublishForm({
                   licenseType: newLicenseType,
@@ -599,9 +592,6 @@ class PublishForm extends React.PureComponent<Props> {
               }
               handleLicenseUrlChange={event =>
                 updatePublishForm({ licenseUrl: event.target.value })
-              }
-              handleCopyrightNoticeChange={event =>
-                updatePublishForm({ copyrightNotice: event.target.value })
               }
             />
           </section>

--- a/src/renderer/redux/actions/publish.js
+++ b/src/renderer/redux/actions/publish.js
@@ -18,24 +18,12 @@ import { selectosNotificationsEnabled } from 'redux/selectors/settings';
 import { doNavigate } from 'redux/actions/navigation';
 import fs from 'fs';
 import path from 'path';
+import { CC_LICENSES, COPYRIGHT, OTHER } from 'constants/licenses';
 
 type Action = UpdatePublishFormAction | { type: ACTIONS.CLEAR_PUBLISH };
 type PromiseAction = Promise<Action>;
 type Dispatch = (action: Action | PromiseAction | Array<Action>) => any;
 type GetState = () => {};
-
-export const doClearPublish = () => (dispatch: Dispatch): PromiseAction => {
-  dispatch({ type: ACTIONS.CLEAR_PUBLISH });
-  return dispatch(doResetThumbnailStatus());
-};
-
-export const doUpdatePublishForm = (publishFormValue: UpdatePublishFormData) => (
-  dispatch: Dispatch
-): UpdatePublishFormAction =>
-  dispatch({
-    type: ACTIONS.UPDATE_PUBLISH_FORM,
-    data: { ...publishFormValue },
-  });
 
 export const doResetThumbnailStatus = () => (dispatch: Dispatch): PromiseAction => {
   dispatch({
@@ -72,6 +60,19 @@ export const doResetThumbnailStatus = () => (dispatch: Dispatch): PromiseAction 
       })
     );
 };
+
+export const doClearPublish = () => (dispatch: Dispatch): PromiseAction => {
+  dispatch({ type: ACTIONS.CLEAR_PUBLISH });
+  return dispatch(doResetThumbnailStatus());
+};
+
+export const doUpdatePublishForm = (publishFormValue: UpdatePublishFormData) => (
+  dispatch: Dispatch
+): UpdatePublishFormAction =>
+  dispatch({
+    type: ACTIONS.UPDATE_PUBLISH_FORM,
+    data: { ...publishFormValue },
+  });
 
 export const doUploadThumbnail = (filePath: string, nsfw: boolean) => (dispatch: Dispatch) => {
   const thumbnail = fs.readFileSync(filePath);
@@ -164,14 +165,26 @@ export const doPrepareEdit = (claim: any, uri: string) => (dispatch: Dispatch) =
     description,
     fee,
     language,
-    licenseType: license,
-    licenseUrl,
     nsfw,
     thumbnail,
     title,
     uri,
     uploadThumbnailStatus: thumbnail ? THUMBNAIL_STATUSES.MANUAL : undefined,
+    licenseUrl,
   };
+
+  // Make sure custom liscence's are mapped properly
+  if (!CC_LICENSES.some(({ value }) => value === license)) {
+    if (!licenseUrl) {
+      publishData.licenseType = COPYRIGHT;
+    } else {
+      publishData.licenseType = OTHER;
+    }
+
+    publishData.otherLicenseDescription = license;
+  } else {
+    publishData.licenseType = license;
+  }
 
   dispatch({ type: ACTIONS.DO_PREPARE_EDIT, data: publishData });
 };

--- a/src/renderer/redux/reducers/publish.js
+++ b/src/renderer/redux/reducers/publish.js
@@ -28,7 +28,6 @@ type PublishState = {
   bidError: ?string,
   otherLicenseDescription: string,
   licenseUrl: string,
-  copyrightNotice: string,
   pendingPublishes: Array<any>,
 };
 
@@ -54,7 +53,6 @@ export type UpdatePublishFormData = {
   bidError?: string,
   otherLicenseDescription?: string,
   licenseUrl?: string,
-  copyrightNotice?: string,
 };
 
 export type UpdatePublishFormAction = {
@@ -114,9 +112,8 @@ const defaultState: PublishState = {
   bid: 0.1,
   bidError: undefined,
   licenseType: 'None',
-  otherLicenseDescription: '',
+  otherLicenseDescription: 'All rights reserved',
   licenseUrl: '',
-  copyrightNotice: 'All rights reserved',
   publishing: false,
   publishSuccess: false,
   publishError: undefined,


### PR DESCRIPTION
Before we were treating a custom license type and copyright different. This caused a lot of additional logic. Since copyright can be a custom entry, we can use the same variable for both. This also makes populating data on edit simpler.

Fixes #1975 