### PR TITLE
Add support for Clickable channel names on Explore page headings (#1820)

### DIFF
--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -31,6 +31,16 @@ class DiscoverPage extends React.PureComponent<Props> {
     this.clearContinuousFetch();
   }
 
+  getCategoryLinkPartByCategory(category: string) {
+    const channelName = category.substr(category.indexOf('@'));
+    if (!channelName.includes('#')) {
+      return null;
+    }
+    return channelName;
+  }
+
+  continousFetch: ?IntervalID;
+
   clearContinuousFetch() {
     if (this.continousFetch) {
       clearInterval(this.continousFetch);
@@ -38,20 +48,22 @@ class DiscoverPage extends React.PureComponent<Props> {
     }
   }
 
-  continousFetch: ?number;
-
   render() {
     const { featuredUris, fetchingFeaturedUris } = this.props;
     const hasContent = typeof featuredUris === 'object' && Object.keys(featuredUris).length;
     const failedToLoad = !fetchingFeaturedUris && !hasContent;
-
     return (
       <Page noPadding isLoading={!hasContent && fetchingFeaturedUris}>
         {hasContent &&
           Object.keys(featuredUris).map(
             category =>
               featuredUris[category].length ? (
-                <CategoryList key={category} category={category} names={featuredUris[category]} />
+                <CategoryList
+                  key={category}
+                  category={category}
+                  names={featuredUris[category]}
+                  categoryLink={this.getCategoryLinkPartByCategory(category)}
+                />
               ) : (
                 <CategoryList
                   key={category}


### PR DESCRIPTION
Based on this issue:
https://github.com/lbryio/lbry-desktop/issues/1820

I am new to lbryio, but I assume that channel name can be written in two ways:

`@CryptoCandor#9152f3b054f692076a6882d1b58a30e8781cc8e6`
`Crypto Candor | @CryptoCandor#9152f3b054f692076a6882d1b58a30e8781cc8e6`

I assume that channel name would always start with `@`. So I cut the string by `@` signed, check if it has link, and pass that to categorylink. This solution maintain backward compatibility.

I do not know where should I put the new function, but I do not want to clutter the render method. So I separate out as `getCategoryLinkPartByCategory` in this component.