### PR TITLE
fix thumbnail height/width

### DIFF
--- a/src/renderer/component/selectThumbnail/view.jsx
+++ b/src/renderer/component/selectThumbnail/view.jsx
@@ -67,7 +67,7 @@ class SelectThumbnail extends React.PureComponent<Props, State> {
         {status === THUMBNAIL_STATUSES.API_DOWN || status === THUMBNAIL_STATUSES.MANUAL ? (
           <div className="column">
             <div
-              className="column__item thumbnail-preview card__media"
+              className="column__item thumbnail-preview"
               style={{ backgroundImage: `url(${thumbnailSrc})` }}
             >
               <img

--- a/src/renderer/scss/_gui.scss
+++ b/src/renderer/scss/_gui.scss
@@ -393,4 +393,7 @@ p {
 .thumbnail-preview {
   height: var(--thumbnail-preview-height);
   width: var(--thumbnail-preview-width);
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
 }


### PR DESCRIPTION
Messed it up when I was refactoring the filecard

The thumbnail component is different from `.card__media` where it is a static height/width