### PR TITLE
Proposed: Centralized redux action

### DIFF
--- a/src/renderer/redux/actions/publish.js
+++ b/src/renderer/redux/actions/publish.js
@@ -19,13 +19,11 @@ import { doNavigate } from 'redux/actions/navigation';
 import fs from 'fs';
 import path from 'path';
 import { CC_LICENSES, COPYRIGHT, OTHER } from 'constants/licenses';
+import type { Dispatch, GetState } from 'types/redux';
 
 type Action = UpdatePublishFormAction | { type: ACTIONS.CLEAR_PUBLISH };
-type PromiseAction = Promise<Action>;
-type Dispatch = (action: Action | PromiseAction | Array<Action>) => any;
-type GetState = () => {};
 
-export const doResetThumbnailStatus = () => (dispatch: Dispatch): PromiseAction => {
+export const doResetThumbnailStatus = () => (dispatch: Dispatch<Action>): Promise<Action> => {
   dispatch({
     type: ACTIONS.UPDATE_PUBLISH_FORM,
     data: {
@@ -61,20 +59,22 @@ export const doResetThumbnailStatus = () => (dispatch: Dispatch): PromiseAction 
     );
 };
 
-export const doClearPublish = () => (dispatch: Dispatch): PromiseAction => {
+export const doClearPublish = () => (dispatch: Dispatch<Action>): Promise<Action> => {
   dispatch({ type: ACTIONS.CLEAR_PUBLISH });
   return dispatch(doResetThumbnailStatus());
 };
 
 export const doUpdatePublishForm = (publishFormValue: UpdatePublishFormData) => (
-  dispatch: Dispatch
+  dispatch: Dispatch<Action>
 ): UpdatePublishFormAction =>
   dispatch({
     type: ACTIONS.UPDATE_PUBLISH_FORM,
     data: { ...publishFormValue },
   });
 
-export const doUploadThumbnail = (filePath: string, nsfw: boolean) => (dispatch: Dispatch) => {
+export const doUploadThumbnail = (filePath: string, nsfw: boolean) => (
+  dispatch: Dispatch<Action>
+) => {
   const thumbnail = fs.readFileSync(filePath);
   const fileExt = path.extname(filePath);
   const fileName = path.basename(filePath);
@@ -128,7 +128,7 @@ export const doUploadThumbnail = (filePath: string, nsfw: boolean) => (dispatch:
     .catch(err => uploadError(err.message));
 };
 
-export const doPrepareEdit = (claim: any, uri: string) => (dispatch: Dispatch) => {
+export const doPrepareEdit = (claim: any, uri: string) => (dispatch: Dispatch<Action>) => {
   const {
     name,
     amount,
@@ -189,7 +189,10 @@ export const doPrepareEdit = (claim: any, uri: string) => (dispatch: Dispatch) =
   dispatch({ type: ACTIONS.DO_PREPARE_EDIT, data: publishData });
 };
 
-export const doPublish = (params: PublishParams) => (dispatch: Dispatch, getState: () => {}) => {
+export const doPublish = (params: PublishParams) => (
+  dispatch: Dispatch<Action>,
+  getState: () => {}
+) => {
   const state = getState();
   const myChannels = selectMyChannelClaims(state);
 
@@ -265,7 +268,7 @@ export const doPublish = (params: PublishParams) => (dispatch: Dispatch, getStat
 };
 
 // Calls claim_list_mine until any pending publishes are confirmed
-export const doCheckPendingPublishes = () => (dispatch: Dispatch, getState: GetState) => {
+export const doCheckPendingPublishes = () => (dispatch: Dispatch<Action>, getState: GetState) => {
   const state = getState();
   const pendingPublishes = selectPendingPublishes(state);
 

--- a/src/renderer/redux/actions/shape_shift.js
+++ b/src/renderer/redux/actions/shape_shift.js
@@ -14,6 +14,7 @@ import type {
   GetActiveShiftFail,
 } from 'redux/reducers/shape_shift';
 import type { FormikActions } from 'types/common';
+import type { Dispatch, ThunkAction } from 'types/redux';
 
 // use promise chains instead of callbacks for shapeshift api
 const shapeShift = Promise.promisifyAll(require('shapeshift.io'));
@@ -38,9 +39,6 @@ export type Action =
 // Basic thunk types
 // It would be nice to import these from types/common
 // Not sure how that would work since they rely on the Action type
-type PromiseAction = Promise<Action>;
-export type Dispatch = (action: Action | PromiseAction | Array<Action>) => any;
-type ThunkAction = (dispatch: Dispatch) => any;
 
 // ShapeShift form values
 export type ShapeShiftFormValues = {
@@ -49,7 +47,7 @@ export type ShapeShiftFormValues = {
   receiveAddress: string,
 };
 
-export const getCoinStats = (coin: string) => (dispatch: Dispatch): ThunkAction => {
+export const getCoinStats = (coin: string) => (dispatch: Dispatch<Action>): ThunkAction<Action> => {
   const pair = `${coin.toLowerCase()}_lbc`;
 
   dispatch({ type: ACTIONS.GET_COIN_STATS_START, data: coin });
@@ -60,7 +58,7 @@ export const getCoinStats = (coin: string) => (dispatch: Dispatch): ThunkAction 
     .catch(err => dispatch({ type: ACTIONS.GET_COIN_STATS_FAIL, data: err }));
 };
 
-export const shapeShiftInit = () => (dispatch: Dispatch): ThunkAction => {
+export const shapeShiftInit = () => (dispatch: Dispatch<Action>): ThunkAction<Action> => {
   dispatch({ type: ACTIONS.GET_SUPPORTED_COINS_START });
 
   return shapeShift
@@ -94,8 +92,8 @@ export const shapeShiftInit = () => (dispatch: Dispatch): ThunkAction => {
 };
 
 export const createShapeShift = (values: ShapeShiftFormValues, actions: FormikActions) => (
-  dispatch: Dispatch
-): ThunkAction => {
+  dispatch: Dispatch<Action>
+): ThunkAction<Action> => {
   const { originCoin, returnAddress, receiveAddress: withdrawalAddress } = values;
 
   const pair = `${originCoin.toLowerCase()}_lbc`;
@@ -114,7 +112,9 @@ export const createShapeShift = (values: ShapeShiftFormValues, actions: FormikAc
     });
 };
 
-export const getActiveShift = (depositAddress: string) => (dispatch: Dispatch): ThunkAction => {
+export const getActiveShift = (depositAddress: string) => (
+  dispatch: Dispatch<Action>
+): ThunkAction<Action> => {
   dispatch({ type: ACTIONS.GET_ACTIVE_SHIFT_START });
 
   return shapeShift
@@ -123,5 +123,5 @@ export const getActiveShift = (depositAddress: string) => (dispatch: Dispatch): 
     .catch(err => dispatch({ type: ACTIONS.GET_ACTIVE_SHIFT_FAIL, data: err }));
 };
 
-export const clearShapeShift = () => (dispatch: Dispatch): Action =>
+export const clearShapeShift = () => (dispatch: Dispatch<Action>): Action =>
   dispatch({ type: ACTIONS.CLEAR_SHAPE_SHIFT });

--- a/src/renderer/redux/reducers/subscriptions.js
+++ b/src/renderer/redux/reducers/subscriptions.js
@@ -3,6 +3,7 @@ import * as ACTIONS from 'constants/action_types';
 import * as NOTIFICATION_TYPES from 'constants/notification_types';
 import { handleActions } from 'util/redux-utils';
 import type { Subscription } from 'types/subscription';
+import type { Dispatch as ReduxDispatch } from 'types/redux';
 
 export type NotificationType =
   | NOTIFICATION_TYPES.DOWNLOADING
@@ -79,7 +80,7 @@ export type Action =
   | CheckSubscriptionStarted
   | CheckSubscriptionCompleted
   | Function;
-export type Dispatch = (action: Action) => any;
+export type Dispatch = ReduxDispatch<Action>;
 
 const defaultState = {
   subscriptions: [],

--- a/src/renderer/types/redux.js
+++ b/src/renderer/types/redux.js
@@ -1,0 +1,6 @@
+// @flow
+
+// eslint-disable-next-line no-use-before-define
+export type Dispatch<T> = (action: T | Promise<T> | Array<T> | ThunkAction<T>) => any; // Need to refer to ThunkAction
+export type GetState = () => {};
+export type ThunkAction<T> = (dispatch: Dispatch<T>, getState: GetState) => any;


### PR DESCRIPTION
While I work with flow type, I found that in the codebase there are multiple places that define Redux Dispatching type. 

So I took the liberty to centralised redux dispatch type definition into one single place.

If I break any codebase rules or established pattern, please let me know and you can close this pull request.