### PR TITLE
Add download percentage to file card

### DIFF
--- a/src/renderer/component/cardMedia/view.jsx
+++ b/src/renderer/component/cardMedia/view.jsx
@@ -4,17 +4,19 @@ import classnames from 'classnames';
 
 type Props = {
   thumbnail: ?string, // externally sourced image
+  opaque?: boolean,
 };
 
 class CardMedia extends React.PureComponent<Props> {
   render() {
-    const { thumbnail } = this.props;
+    const { thumbnail, opaque } = this.props;
 
     return (
       <div
         style={thumbnail ? { backgroundImage: `url('${thumbnail}')` } : {}}
         className={classnames('card__media', {
           'card__media--no-img': !thumbnail,
+          'card__media--opaque': opaque,
         })}
       >
         {!thumbnail && <span className="card__media-text">LBRY</span>}

--- a/src/renderer/component/common/tooltip.jsx
+++ b/src/renderer/component/common/tooltip.jsx
@@ -20,9 +20,8 @@ class ToolTip extends React.PureComponent<Props, State> {
     direction: 'bottom',
   };
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
-    this.tooltip = React.createRef();
     this.state = {
       direction: this.props.direction,
     };
@@ -33,7 +32,15 @@ class ToolTip extends React.PureComponent<Props, State> {
   }
 
   getVisibility = () => {
-    const node = this.tooltip.current;
+    const node = this.tooltip;
+    if (!node) {
+      return {
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      };
+    }
     const rect = node.getBoundingClientRect();
 
     // Get parent-container
@@ -51,6 +58,8 @@ class ToolTip extends React.PureComponent<Props, State> {
 
     return visibility;
   };
+
+  tooltip: ?HTMLSpanElement;
 
   invertDirection = () => {
     // Get current direction
@@ -105,7 +114,7 @@ class ToolTip extends React.PureComponent<Props, State> {
       >
         {tooltipContent}
         <span
-          ref={this.tooltip}
+          ref={ref => (this.tooltip = ref)}
           className={classnames('tooltip__body', {
             'tooltip__body--short': isShortDescription,
           })}

--- a/src/renderer/component/fileActions/view.jsx
+++ b/src/renderer/component/fileActions/view.jsx
@@ -4,10 +4,7 @@ import Button from 'component/button';
 import { MODALS } from 'lbry-redux';
 import * as icons from 'constants/icons';
 import Tooltip from 'component/common/tooltip';
-
-type FileInfo = {
-  claim_id: string,
-};
+import type { FileInfo } from 'types/file_info';
 
 type Props = {
   uri: string,

--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -11,11 +11,12 @@ import classnames from 'classnames';
 import FilePrice from 'component/filePrice';
 import { openCopyLinkMenu } from 'util/contextMenu';
 import DateTime from 'component/dateTime';
+import type { FileInfo } from 'types/file_info';
 
 type Props = {
   uri: string,
   claim: ?Claim,
-  fileInfo: ?{},
+  fileInfo: FileInfo,
   metadata: ?Metadata,
   navigate: (string, ?{}) => void,
   rewardedContentClaimIds: Array<string>,

--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -57,7 +57,7 @@ class FileCard extends React.PureComponent<Props> {
       return null;
     }
     const progress = calculateDownloadProgress(this.props.fileInfo).toFixed(0);
-    return <span> ({progress}%)</span>;
+    return <div>{progress}%</div>;
   };
 
   render() {
@@ -117,7 +117,7 @@ class FileCard extends React.PureComponent<Props> {
         <div className="card__title card__title--file-card">
           <TruncatedText text={title} lines={2} />
         </div>
-        <div className="card__subtitle">
+        <div className="card__subtitle card--space-between">
           {pending ? <div>Pending...</div> : <UriIndicator uri={uri} link />}
           {this.renderPercentageDownload()}
         </div>

--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -46,6 +46,8 @@ class FileCard extends React.PureComponent<Props> {
     }
   };
 
+  renderPercentageDownload = () => <span>(10%)</span>;
+
   render() {
     const {
       claim,
@@ -105,6 +107,7 @@ class FileCard extends React.PureComponent<Props> {
         </div>
         <div className="card__subtitle">
           {pending ? <div>Pending...</div> : <UriIndicator uri={uri} link />}
+          {this.renderPercentageDownload()}
         </div>
         <div className="card__subtitle card--space-between">
           <DateTime timeAgo block={height} />

--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -12,6 +12,7 @@ import FilePrice from 'component/filePrice';
 import { openCopyLinkMenu } from 'util/contextMenu';
 import DateTime from 'component/dateTime';
 import type { FileInfo } from 'types/file_info';
+import { calculateDownloadProgress } from 'util/file_info';
 
 type Props = {
   uri: string,
@@ -47,7 +48,17 @@ class FileCard extends React.PureComponent<Props> {
     }
   };
 
-  renderPercentageDownload = () => <span>(10%)</span>;
+  renderPercentageDownload = () => {
+    const { fileInfo } = this.props;
+    if (!fileInfo) {
+      return null;
+    }
+    if (fileInfo.completed) {
+      return null;
+    }
+    const progress = calculateDownloadProgress(this.props.fileInfo).toFixed(0);
+    return <span> ({progress}%)</span>;
+  };
 
   render() {
     const {

--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -24,6 +24,7 @@ type Props = {
   obscureNsfw: boolean,
   claimIsMine: boolean,
   pending?: boolean,
+  opaqueDownloading?: boolean,
   /* eslint-disable react/no-unused-prop-types */
   resolveUri: string => void,
   isResolvingUri: boolean,
@@ -40,6 +41,17 @@ class FileCard extends React.PureComponent<Props> {
     this.resolve(nextProps);
   }
 
+  isDownloading() {
+    const { fileInfo } = this.props;
+    if (!fileInfo) {
+      return false;
+    }
+    if (fileInfo.completed) {
+      return false;
+    }
+    return true;
+  }
+
   resolve = (props: Props) => {
     const { isResolvingUri, resolveUri, claim, uri, pending } = props;
 
@@ -49,11 +61,7 @@ class FileCard extends React.PureComponent<Props> {
   };
 
   renderPercentageDownload = () => {
-    const { fileInfo } = this.props;
-    if (!fileInfo) {
-      return null;
-    }
-    if (fileInfo.completed) {
+    if (!this.isDownloading()) {
       return null;
     }
     const progress = calculateDownloadProgress(this.props.fileInfo).toFixed(0);
@@ -71,6 +79,7 @@ class FileCard extends React.PureComponent<Props> {
       claimIsMine,
       pending,
       isSubscribed,
+      opaqueDownloading,
     } = this.props;
 
     if (!claim && !pending) {
@@ -99,7 +108,7 @@ class FileCard extends React.PureComponent<Props> {
       event.stopPropagation();
       openCopyLinkMenu(convertToShareLink(uri), event);
     };
-
+    const opaque = this.isDownloading() && opaqueDownloading;
     // We should be able to tab through cards
     /* eslint-disable jsx-a11y/click-events-have-key-events */
     return (
@@ -113,7 +122,7 @@ class FileCard extends React.PureComponent<Props> {
         })}
         onContextMenu={handleContextMenu}
       >
-        <CardMedia thumbnail={thumbnail} />
+        <CardMedia thumbnail={thumbnail} opaque={opaque} />
         <div className="card__title card__title--file-card">
           <TruncatedText text={title} lines={2} />
         </div>

--- a/src/renderer/component/fileDownloadLink/view.jsx
+++ b/src/renderer/component/fileDownloadLink/view.jsx
@@ -5,21 +5,17 @@ import * as icons from 'constants/icons';
 import ToolTip from 'component/common/tooltip';
 import analytics from 'analytics';
 import type { Claim } from 'types/claim';
+import type { FileInfo } from 'types/file_info';
+import { calculateDownloadProgress } from 'util/file_info';
 
 type Props = {
   claim: Claim,
   uri: string,
   downloading: boolean,
-  fileInfo: ?{
-    written_bytes: number,
-    total_bytes: number,
-    outpoint: number,
-    download_path: string,
-    completed: boolean,
-  },
+  fileInfo: FileInfo,
   loading: boolean,
   costInfo: ?{},
-  restartDownload: (string, number) => void,
+  restartDownload: (string, string) => void,
   openInShell: string => void,
   purchaseUri: string => void,
   pause: () => void,
@@ -62,10 +58,7 @@ class FileDownloadLink extends React.PureComponent<Props> {
     };
 
     if (loading || downloading) {
-      const progress =
-        fileInfo && fileInfo.written_bytes
-          ? (fileInfo.written_bytes / fileInfo.total_bytes) * 100
-          : 0;
+      const progress = fileInfo ? calculateDownloadProgress(fileInfo) : 0;
       const label = fileInfo
         ? __('Downloading: ') + progress.toFixed(0) + __('% complete')
         : __('Connecting...');

--- a/src/renderer/component/fileList/view.jsx
+++ b/src/renderer/component/fileList/view.jsx
@@ -11,6 +11,7 @@ type Props = {
   claimsById: Array<{}>,
   fileInfos: Array<FileInfo>,
   checkPending?: boolean,
+  opaqueDownloading?: boolean,
 };
 
 type State = {
@@ -132,7 +133,7 @@ class FileList extends React.PureComponent<Props, State> {
   sortFunctions: {};
 
   render() {
-    const { fileInfos, hideFilter, checkPending } = this.props;
+    const { fileInfos, hideFilter, checkPending, opaqueDownloading } = this.props;
     const { sortBy } = this.state;
     const content = [];
 
@@ -159,7 +160,14 @@ class FileList extends React.PureComponent<Props, State> {
       const outpoint = `${txid}:${nout}`;
 
       // See https://github.com/lbryio/lbry-desktop/issues/1327 for discussion around using outpoint as the key
-      content.push(<FileCard key={outpoint} uri={uri} checkPending={checkPending} />);
+      content.push(
+        <FileCard
+          key={outpoint}
+          uri={uri}
+          checkPending={checkPending}
+          opaqueDownloading={opaqueDownloading}
+        />
+      );
     });
 
     return (

--- a/src/renderer/page/fileListDownloaded/view.jsx
+++ b/src/renderer/page/fileListDownloaded/view.jsx
@@ -18,7 +18,7 @@ class FileListDownloaded extends React.PureComponent<Props> {
     return (
       <Page notContained loading={fetching}>
         {hasDownloads ? (
-          <FileList fileInfos={fileInfos} />
+          <FileList fileInfos={fileInfos} opaqueDownloading />
         ) : (
           <div className="page__empty">
             {__("You haven't downloaded anything from LBRY yet.")}

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -26,6 +26,8 @@ import { makeSelectClientSetting, selectosNotificationsEnabled } from 'redux/sel
 import setBadge from 'util/setBadge';
 import setProgressBar from 'util/setProgressBar';
 import analytics from 'analytics';
+import { calculateDownloadProgress } from 'util/file_info';
+import type { FileInfo } from 'types/file_info';
 
 const DOWNLOAD_POLL_INTERVAL = 250;
 
@@ -43,7 +45,7 @@ export function doUpdateLoadStatus(uri: string, outpoint: string) {
     Lbry.file_list({
       outpoint,
       full_status: true,
-    }).then(([fileInfo]) => {
+    }).then(([fileInfo: ?FileInfo]) => {
       if (!fileInfo || fileInfo.written_bytes === 0) {
         // download hasn't started yet
         setNextStatusUpdate();
@@ -114,8 +116,7 @@ export function doUpdateLoadStatus(uri: string, outpoint: string) {
         }
       } else {
         // ready to play
-        const { total_bytes: totalBytes, written_bytes: writtenBytes } = fileInfo;
-        const progress = (writtenBytes / totalBytes) * 100;
+        const progress = calculateDownloadProgress(fileInfo);
 
         dispatch({
           type: ACTIONS.DOWNLOADING_PROGRESSED,

--- a/src/renderer/redux/selectors/app.js
+++ b/src/renderer/redux/selectors/app.js
@@ -213,14 +213,14 @@ export const selectNavLinks = createSelector(
           icon: 'CreditCard',
           subLinks: walletSubLinks,
           path: isCurrentlyWalletPage ? '/wallet' : getActiveSublink('wallet'),
-          active: isWalletPage(currentPage),
+          active: isCurrentlyWalletPage,
         },
         {
           label: 'My LBRY',
           icon: 'Folder',
           subLinks: myLbrySubLinks,
           path: isCurrentlyMyLbryPage ? '/downloaded' : getActiveSublink('myLbry'),
-          active: isMyLbryPage(currentPage),
+          active: isCurrentlyMyLbryPage,
         },
         {
           label: 'Publish',

--- a/src/renderer/scss/component/_card.scss
+++ b/src/renderer/scss/component/_card.scss
@@ -45,6 +45,10 @@
   position: relative;
 }
 
+.card__media--opaque {
+  opacity: 0.5;
+}
+
 .card__media--nsfw {
   background-color: var(--color-error);
 }

--- a/src/renderer/types/file_info.js
+++ b/src/renderer/types/file_info.js
@@ -16,4 +16,10 @@ export type FileInfo = {
       certificateId: string,
     },
   },
+  outpoint: string,
+  file_name: string,
+  written_bytes: number,
+  download_path: string,
+  completed: boolean,
+  claim_id: string,
 };

--- a/src/renderer/types/file_info.js
+++ b/src/renderer/types/file_info.js
@@ -19,6 +19,7 @@ export type FileInfo = {
   outpoint: string,
   file_name: string,
   written_bytes: number,
+  total_bytes: number,
   download_path: string,
   completed: boolean,
   claim_id: string,

--- a/src/renderer/util/file_info.js
+++ b/src/renderer/util/file_info.js
@@ -1,0 +1,7 @@
+// @flow
+
+import type { FileInfo } from 'types/file_info';
+
+export function calculateDownloadProgress(fileInfo: FileInfo) {
+  return fileInfo.written_bytes ? (fileInfo.written_bytes / fileInfo.total_bytes) * 100 : 0;
+}


### PR DESCRIPTION
Based on this [issue](https://github.com/lbryio/lbry-desktop/issues/1933):

Add percentage download to file card in case of downloading file
<img width="713" alt="screen shot 2561-10-15 at 17 18 51" src="https://user-images.githubusercontent.com/5057288/46946336-969d3f80-d0a1-11e8-9160-afcdcf7919ae.png">

I wonder if we should have new icon for these downloading files? Using LOCAL icon for downloading content may mislead user and a little bit confused in term of user interface.

Also:
- Since we have places that need file progress calulcation, I created function `calculateDownloadProgress` and let all logic refer to there.
- Add flowtype for `common/tooltip.jsx`
- Add flowtype for `FileInfo`. We have a lot of components using `FileInfo` type