### PR TITLE
Fix issue file_list call continues indefinitely if a file is removed while downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  * Credit card verification messaging ([#2025](https://github.com/lbryio/lbry-desktop/pull/2025))
  * Reverse Order & Use System/Location Time/Date ([#2036]https://github.com/lbryio/lbry-desktop/pull/2036)
  * Limit file type can be uploaded as thumbnail for publishing ([#2034](https://github.com/lbryio/lbry-desktop/pull/2034))
- * Change snackbar notification postion to bottom-left ([#2040](https://github.com/lbryio/lbry-desktop/pull/2040)) 
+ * Change snackbar notification postion to bottom-left ([#2040](https://github.com/lbryio/lbry-desktop/pull/2040))
 
 
 ### Fixed
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  * History styling on large screens and link issue with claims ([#1999](https://github.com/lbryio/lbry-desktop/pull/1999))
  * Satisfy console warnings in publishForm and validation messaging ([#2010](https://github.com/lbryio/lbry-desktop/pull/2010))
  * App crashing if invalid characters entered in LBRY URL ([#2026])(https://github.com/lbryio/lbry-desktop/pull/2026))
+ * Fix issue file_list call continues indefinitely if a file is removed while downloading ([#2042])(https://github.com/lbryio/lbry-desktop/pull/2042))
 
 ## [0.25.1] - 2018-09-18
 

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -33,6 +33,8 @@ export function doUpdateLoadStatus(uri: string, outpoint: string) {
   return (dispatch, getState) => {
     const setNextStatusUpdate = () =>
       setTimeout(() => {
+        // We need to check if outpoint still exists first because user are able to delete file (outpoint) while downloading.
+        // If fiel is already deleted, no point to still try update load status
         const byOutpoint = selectFileInfosByOutpoint(getState());
         if (byOutpoint[outpoint]) {
           dispatch(doUpdateLoadStatus(uri, outpoint));

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -34,7 +34,7 @@ export function doUpdateLoadStatus(uri: string, outpoint: string) {
     const setNextStatusUpdate = () =>
       setTimeout(() => {
         // We need to check if outpoint still exists first because user are able to delete file (outpoint) while downloading.
-        // If fiel is already deleted, no point to still try update load status
+        // If a file is already deleted, no point to still try update load status
         const byOutpoint = selectFileInfosByOutpoint(getState());
         if (byOutpoint[outpoint]) {
           dispatch(doUpdateLoadStatus(uri, outpoint));


### PR DESCRIPTION
Based on this [issue](https://github.com/lbryio/lbry-desktop/issues/1860)

Since when ACTIONS.FILE_DELETE dispatch in `lbry-redux`, we actually remove the outpoint from store. So in order to update status, it makes sense to check if the outpoint still exists first before we dispatch update.

Also, centralized the update interval function.