### PR TITLE
Add next page cache on channels.

### DIFF
--- a/src/renderer/page/channel/index.js
+++ b/src/renderer/page/channel/index.js
@@ -23,7 +23,7 @@ const select = (state, props) => ({
 });
 
 const perform = dispatch => ({
-  fetchClaims: (uri, page) => dispatch(doFetchClaimsByChannel(uri, page)),
+  fetchClaims: (uri, page) => dispatch(doFetchClaimsByChannel(uri, page, true)),
   fetchClaimCount: uri => dispatch(doFetchClaimCountByChannel(uri)),
   navigate: (path, params) => dispatch(doNavigate(path, params)),
 });


### PR DESCRIPTION
This PR add a prefetch and caches the response when the user visits the channel page.
It should close issue #1851 