### PR TITLE
adds sortBy default prop to subscriptions and channel pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "formik": "^0.10.4",
     "hast-util-sanitize": "^1.1.2",
     "keytar": "^4.2.1",
-    "lbry-redux": "lbryio/lbry-redux#03aea43da5f12bc01546a92bdf460ebd08681013",
+    "lbry-redux": "lbryio/lbry-redux#ecd1ab156fb755c8bff4d890679399d66f41ad17",
     "lbryinc": "lbryio/lbryinc#3f34af546ee73ff2ee7d8ad05e540b3b0aa658fb",
     "localforage": "^1.7.1",
     "mammoth": "^1.4.6",

--- a/src/renderer/component/fileList/view.jsx
+++ b/src/renderer/component/fileList/view.jsx
@@ -12,13 +12,14 @@ type Props = {
   fileInfos: Array<FileInfo>,
   checkPending?: boolean,
   sortBy: string,
-  page: string,
-  setFileListSort: (string, string) => void,
+  page?: string,
+  setFileListSort: (?string, string) => void,
 };
 
 class FileList extends React.PureComponent<Props> {
   static defaultProps = {
     hideFilter: false,
+    sortBy: SORT_OPTIONS.DATE_NEW,
   };
 
   constructor(props: Props) {

--- a/src/renderer/page/subscriptions/index.js
+++ b/src/renderer/page/subscriptions/index.js
@@ -15,7 +15,6 @@ import {
 } from 'redux/actions/subscriptions';
 import { doSetClientSetting } from 'redux/actions/settings';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
-import { selectFileListSubscriptionSort } from 'lbry-redux';
 import SubscriptionsPage from './view';
 
 const select = state => ({
@@ -26,7 +25,6 @@ const select = state => ({
   autoDownload: makeSelectClientSetting(settings.AUTO_DOWNLOAD)(state),
   allSubscriptions: selectSubscriptionClaims(state),
   unreadSubscriptions: selectUnreadSubscriptions(state),
-  sortBy: selectFileListSubscriptionSort(state),
   viewMode: selectViewMode(state),
 });
 

--- a/src/renderer/page/subscriptions/view.jsx
+++ b/src/renderer/page/subscriptions/view.jsx
@@ -10,7 +10,7 @@ import FileList from 'component/fileList';
 import HiddenNsfwClaims from 'component/hiddenNsfwClaims';
 import { FormField } from 'component/common/form';
 import FileCard from 'component/fileCard';
-import { parseURI, PAGES } from 'lbry-redux';
+import { parseURI } from 'lbry-redux';
 
 type Props = {
   subscribedChannels: Array<string>, // The channels a user is subscribed to
@@ -25,7 +25,6 @@ type Props = {
   doSetViewMode: ViewMode => void,
   doFetchMySubscriptions: () => void,
   doSetClientSetting: (string, boolean) => void,
-  sortBy: string,
 };
 
 export default class extends React.PureComponent<Props> {
@@ -45,19 +44,13 @@ export default class extends React.PureComponent<Props> {
   }
 
   renderSubscriptions() {
-    const { viewMode, unreadSubscriptions, allSubscriptions, sortBy } = this.props;
+    const { viewMode, unreadSubscriptions, allSubscriptions } = this.props;
 
     if (viewMode === VIEW_ALL) {
       return (
         <React.Fragment>
           <div className="card__title">{__('Your subscriptions')}</div>
-          <FileList
-            hideFilter
-            sortByHeight
-            fileInfos={allSubscriptions}
-            sortBy={sortBy}
-            page={PAGES.SUBSCRIPTIONS}
-          />
+          <FileList hideFilter sortByHeight fileInfos={allSubscriptions} />
         </React.Fragment>
       );
     }


### PR DESCRIPTION
Channel page crashes due to missing sortBy. FileList now requires it as a prop.
requires https://github.com/lbryio/lbry-redux/pull/90