### PR TITLE
Reduce unused var warnings. 

### DIFF
--- a/src/renderer/component/cardMedia/index.js
+++ b/src/renderer/component/cardMedia/index.js
@@ -1,8 +1,3 @@
-import React from 'react';
-import { connect } from 'react-redux';
 import CardMedia from './view';
 
-const select = state => ({});
-const perform = dispatch => ({});
-
-export default connect(select, perform)(CardMedia);
+export default CardMedia;

--- a/src/renderer/component/fileListSearch/index.js
+++ b/src/renderer/component/fileListSearch/index.js
@@ -8,9 +8,4 @@ const select = (state, props) => ({
   isSearching: selectIsSearching(state),
 });
 
-const perform = () => ({});
-
-export default connect(
-  select,
-  perform
-)(FileListSearch);
+export default connect(select)(FileListSearch);

--- a/src/renderer/component/formFieldPrice/index.js
+++ b/src/renderer/component/formFieldPrice/index.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { connect } from 'react-redux';
 import FormFieldPrice from './view';
 
-export default connect(null, null)(FormFieldPrice);
+export default FormFieldPrice;

--- a/src/renderer/component/publishForm/index.js
+++ b/src/renderer/component/publishForm/index.js
@@ -1,5 +1,3 @@
-import { connect } from 'react-redux';
-import { selectBalance } from 'lbry-redux';
 import PublishForm from './view';
 
-export default connect(null, null)(PublishForm);
+export default PublishForm;

--- a/src/renderer/component/theme/index.js
+++ b/src/renderer/component/theme/index.js
@@ -1,10 +1,9 @@
-import React from 'react';
 import { connect } from 'react-redux';
-import { selectThemePath } from 'redux/selectors/settings.js';
+import { selectThemePath } from 'redux/selectors/settings';
 import Theme from './view';
 
 const select = state => ({
   themePath: selectThemePath(state),
 });
 
-export default connect(select, null)(Theme);
+export default connect(select)(Theme);

--- a/src/renderer/modal/modalAuthFailure/index.js
+++ b/src/renderer/modal/modalAuthFailure/index.js
@@ -2,10 +2,13 @@ import { connect } from 'react-redux';
 import { doHideNotification } from 'lbry-redux';
 import ModalAuthFailure from './view';
 
-const select = state => ({});
+const select = () => ({});
 
 const perform = dispatch => ({
   close: () => dispatch(doHideNotification()),
 });
 
-export default connect(null, null)(ModalAuthFailure);
+export default connect(
+  select,
+  perform
+)(ModalAuthFailure);

--- a/src/renderer/modal/modalAutoUpdateConfirm/index.js
+++ b/src/renderer/modal/modalAutoUpdateConfirm/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { doAutoUpdateDeclined } from 'redux/actions/app';
 import { doHideNotification } from 'lbry-redux';
@@ -9,4 +8,7 @@ const perform = dispatch => ({
   declineAutoUpdate: () => dispatch(doAutoUpdateDeclined()),
 });
 
-export default connect(null, perform)(ModalAutoUpdateConfirm);
+export default connect(
+  null,
+  perform
+)(ModalAutoUpdateConfirm);

--- a/src/renderer/modal/modalAutoUpdateDownloaded/index.js
+++ b/src/renderer/modal/modalAutoUpdateDownloaded/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { doAutoUpdateDeclined } from 'redux/actions/app';
 import { doHideNotification } from 'lbry-redux';
@@ -9,4 +8,7 @@ const perform = dispatch => ({
   declineAutoUpdate: () => dispatch(doAutoUpdateDeclined()),
 });
 
-export default connect(null, perform)(ModalAutoUpdateDownloaded);
+export default connect(
+  null,
+  perform
+)(ModalAutoUpdateDownloaded);

--- a/src/renderer/modal/modalDownloading/index.js
+++ b/src/renderer/modal/modalDownloading/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { doStartUpgrade, doCancelUpgrade } from 'redux/actions/app';
 import { doHideNotification } from 'lbry-redux';

--- a/src/renderer/modal/modalTransactionFailed/index.js
+++ b/src/renderer/modal/modalTransactionFailed/index.js
@@ -2,10 +2,13 @@ import { connect } from 'react-redux';
 import { doHideNotification } from 'lbry-redux';
 import ModalTransactionFailed from './view';
 
-const select = state => ({});
+const select = () => ({});
 
 const perform = dispatch => ({
   closeModal: () => dispatch(doHideNotification()),
 });
 
-export default connect(select, perform)(ModalTransactionFailed);
+export default connect(
+  select,
+  perform
+)(ModalTransactionFailed);

--- a/src/renderer/page/backup/index.js
+++ b/src/renderer/page/backup/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { selectDaemonSettings } from 'redux/selectors/settings';
 import BackupPage from './view';
@@ -7,4 +6,4 @@ const select = state => ({
   daemonSettings: selectDaemonSettings(state),
 });
 
-export default connect(select, null)(BackupPage);
+export default connect(select)(BackupPage);

--- a/src/renderer/page/getCredits/index.js
+++ b/src/renderer/page/getCredits/index.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { connect } from 'react-redux';
 import GetCreditsPage from './view';
 
-export default connect(null, null)(GetCreditsPage);
+export default GetCreditsPage;

--- a/src/renderer/page/sendCredits/index.js
+++ b/src/renderer/page/sendCredits/index.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { connect } from 'react-redux';
 import SendReceivePage from './view';
 
-export default connect(null, null)(SendReceivePage);
+export default SendReceivePage;

--- a/src/renderer/page/sendCredits/view.jsx
+++ b/src/renderer/page/sendCredits/view.jsx
@@ -3,7 +3,7 @@ import WalletSend from 'component/walletSend';
 import WalletAddress from 'component/walletAddress';
 import Page from 'component/page';
 
-const SendReceivePage = props => (
+const SendReceivePage = () => (
   <Page>
     <WalletSend />
     <WalletAddress />

--- a/src/renderer/page/wallet/index.js
+++ b/src/renderer/page/wallet/index.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { connect } from 'react-redux';
 import WalletPage from './view';
 
-export default connect(null, null)(WalletPage);
+export default WalletPage;


### PR DESCRIPTION
Hey, as a little housekeeping quest, I removed unused vars from components where it was easily doable without triggering more linting errors while committing.
I also removed redux connections where they were not needed.