### PR TITLE
Fix to open folder containing the log file rather than roaming folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  * Satisfy console warnings in publishForm and validation messaging ([#2010](https://github.com/lbryio/lbry-desktop/pull/2010))
  * App crashing if invalid characters entered in LBRY URL ([#2026])(https://github.com/lbryio/lbry-desktop/pull/2026))
  * Fix issue file_list call continues indefinitely if a file is removed while downloading ([#2042])(https://github.com/lbryio/lbry-desktop/pull/2042))
+ * Fix to open folder containing log file when Open Log File button is clicked ([#2078])(https://github.com/lbryio/lbry-desktop/pull/2078))
 
 ## [0.25.1] - 2018-09-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  * Satisfy console warnings in publishForm and validation messaging ([#2010](https://github.com/lbryio/lbry-desktop/pull/2010))
  * App crashing if invalid characters entered in LBRY URL ([#2026])(https://github.com/lbryio/lbry-desktop/pull/2026))
  * Fix issue file_list call continues indefinitely if a file is removed while downloading ([#2042])(https://github.com/lbryio/lbry-desktop/pull/2042))
- * Fix to open folder containing log file when Open Log File button is clicked ([#2078])(https://github.com/lbryio/lbry-desktop/pull/2078))
+ * Fix to open folder containing log file when Open Log File button is clicked ([#2078](https://github.com/lbryio/lbry-desktop/pull/2078))
 
 ## [0.25.1] - 2018-09-18
 

--- a/src/renderer/page/help/view.jsx
+++ b/src/renderer/page/help/view.jsx
@@ -165,7 +165,7 @@ class HelpPage extends React.PureComponent<Props, State> {
               button="primary"
               label={__('Open Log Folder')}
               icon={icons.REPORT}
-              onClick={() => shell.showItemInFolder(dataDirectory)}
+              onClick={() => shell.openItem(dataDirectory)}
             />
           </div>
         </section>


### PR DESCRIPTION
## PR Checklist
Please check all that apply to this PR using "x":

- [ x ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ x ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below


## PR Type
What kind of change does this PR introduce?

<!-- Please check all that apply to this PR using "x". -->

- [ x ] Bugfix
- [ ] Feature
- [ ] Breaking changes (bugfix or feature that introduces breaking changes)
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #1600 


## What is the current behavior?
Clicking "Open Log Folder" will open the "lbry" folder with "lbrynet" highlighted, rather than opening the "lbrynet" folder which contains the log file.

## What is the new behavior?
Clicking "Open Log Folder" will open the "lbrynet" folder that contains the log file.

## Other information


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
