### PR TITLE
Fix: correctly search for daemon process on startup

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -64,7 +64,7 @@ if (isDev) {
 }
 
 app.on('ready', async () => {
-  const processList = await findProcess('name', 'lbrynet');
+  const processList = await findProcess('name', 'lbrynet start');
   const isDaemonRunning = processList.length > 0;
 
   if (!isDaemonRunning) {


### PR DESCRIPTION
When we added the v30 daemon changes, we changed our process search to `lbrynet`, which would return results if you had any `lbrynet` files open (including `lbrynet.log`)

This fixes that issue.