### PR TITLE
Fix daemon startup on Windows if daemon running already

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "yarn": "^1.3"
   },
   "lbrySettings": {
-    "lbrynetDaemonVersion": "0.30.0",
+    "lbrynetDaemonVersion": "0.30.1rc1",
     "lbrynetDaemonUrlTemplate": "https://github.com/lbryio/lbry/releases/download/vDAEMONVER/lbrynet-OSNAME.zip",
     "lbrynetDaemonDir": "static/daemon",
     "lbrynetDaemonFileName": "lbrynet"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LBRY",
-  "version": "0.25.1",
+  "version": "0.26.0-rc.4",
   "description": "A browser for the LBRY network, a digital marketplace controlled by its users.",
   "keywords": [
     "lbry"

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -64,7 +64,9 @@ if (isDev) {
 }
 
 app.on('ready', async () => {
-  const processList = await findProcess('name', 'lbrynet start');
+  const processListArgs = process.platform === 'win32' ? 'lbrynet' : 'lbrynet start';
+  const processList = await findProcess('name', processListArgs);
+
   const isDaemonRunning = processList.length > 0;
 
   if (!isDaemonRunning) {


### PR DESCRIPTION
If daemon is already running, windows app startup would fail. Argument is not required