### PR TITLE
fetch subs fix

### DIFF
--- a/src/renderer/redux/actions/subscriptions.js
+++ b/src/renderer/redux/actions/subscriptions.js
@@ -102,7 +102,7 @@ export const doFetchMySubscriptions = () => (dispatch: ReduxDispatch, getState: 
       });
 
       dispatch(doResolveUris(subscriptions.map(({ uri }) => uri)));
-      subscriptions.forEach(({ uri }) => dispatch(doFetchClaimsByChannel(uri, 1)));
+      dispatch(doCheckSubscriptions());
     })
     .catch(() => {
       dispatch({
@@ -401,7 +401,6 @@ export const doCheckSubscriptionsInit = () => (dispatch: ReduxDispatch) => {
   // setTimeout below is a hack to ensure redux is hydrated when subscriptions are checked
   // this will be replaced with <PersistGate> which reqiures a package upgrade
   setTimeout(() => dispatch(doFetchMySubscriptions()), 5000);
-  setTimeout(() => dispatch(doCheckSubscriptions()), 10000);
   const checkSubscriptionsTimer = setInterval(
     () => dispatch(doCheckSubscriptions()),
     CHECK_SUBSCRIPTIONS_INTERVAL


### PR DESCRIPTION
Instead of calling check subscriptions after fetching them (with a timeout hack), do this directly in the fetch routine instead of calling claim_list_by_channel. This ensures claim_list_by_channel is only called once and the subscriptions are checked after every fetch.

## PR Checklist
Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below


## PR Type
What kind of change does this PR introduce?

<!-- Please check all that apply to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Breaking changes (bugfix or feature that introduces breaking changes)
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: N/A


## What is the current behavior?


## What is the new behavior?


## Other information


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
