### PR TITLE
fix: featured reward claim

### DIFF
--- a/src/renderer/page/discover/index.js
+++ b/src/renderer/page/discover/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { selectFeaturedUris, selectFetchingFeaturedUris, doFetchFeaturedUris } from 'lbry-redux';
-import { doFetchRewardedContent } from 'lbryinc';
+import { doFetchRewardedContent, doRewardList } from 'lbryinc';
 import DiscoverPage from './view';
 
 const select = state => ({
@@ -11,6 +11,7 @@ const select = state => ({
 const perform = dispatch => ({
   fetchFeaturedUris: () => dispatch(doFetchFeaturedUris()),
   fetchRewardedContent: () => dispatch(doFetchRewardedContent()),
+  fetchRewards: () => dispatch(doRewardList()),
 });
 
 export default connect(

--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -24,6 +24,7 @@ class DiscoverPage extends React.PureComponent<Props> {
     this.continousFetch = setInterval(() => {
       fetchFeaturedUris();
       fetchRewardedContent();
+      fetchRewards();
     }, 1000 * 60 * 60);
   }
 


### PR DESCRIPTION
This will fetch new rewards if LBRY is left open on the homepage. We refresh the featured URIs on an interval, but the reward list would not have the newly pushed LBRYCast reward available...so you would not be able to claim this until going to the rewards page.