### PR TITLE
Fix: show delete button for own claims, not only downloaded ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+ * Show delete button on users own claims ([#2147](https://github.com/lbryio/lbry-desktop/pull/2147))
+
+
+## [0.26.1] - 2018-12-14
+
+### Fixed
  * Channel subscribe button on search page ([#2146](https://github.com/lbryio/lbry-desktop/pull/2146))
  * Close modal after redeeming reward code ([#2146](https://github.com/lbryio/lbry-desktop/pull/2146))
  * Update Electron to prevent segfault on Ubuntu@18.10 ([#2146](https://github.com/lbryio/lbry-desktop/pull/2146))

--- a/src/renderer/component/fileActions/view.jsx
+++ b/src/renderer/component/fileActions/view.jsx
@@ -20,7 +20,7 @@ type Props = {
 class FileActions extends React.PureComponent<Props> {
   render() {
     const { fileInfo, uri, openModal, claimIsMine, claimId } = this.props;
-    const showDelete = fileInfo && Object.keys(fileInfo).length > 0;
+    const showDelete = (claimIsMine || (fileInfo && Object.keys(fileInfo).length > 0)) ;
 
     return (
       <React.Fragment>


### PR DESCRIPTION
We should show the delete button for own claims as well, not only if downloaded.. Thanks to Brendon, a community member, who reminded me of this one. 