### PR TITLE
fix: missing fetchRewards

### DIFF
--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -17,7 +17,7 @@ class DiscoverPage extends React.PureComponent<Props> {
   }
 
   componentWillMount() {
-    const { fetchFeaturedUris, fetchRewardedContent } = this.props;
+    const { fetchFeaturedUris, fetchRewardedContent, fetchRewards } = this.props;
     fetchFeaturedUris();
     fetchRewardedContent();
 


### PR DESCRIPTION
This was a patched last week to ensure new rewards are fetched continuously (mostly for LBRYCast) if the app is left open. Forgot to add this statement to the props. Not a big deal as this didn't work previously and a new app startup/refresh/going to rewards fixes it. 