### PR TITLE
Full Permanent URL Copy Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Show delete button on users own claims ([#2147](https://github.com/lbryio/lbry-desktop/pull/2147))
 - Fix "copy" icon being cutoff for some users ([2167](https://github.com/lbryio/lbry-desktop/pull/2167))
+- Use correct url when copying vanity addresses ([#2168](https://github.com/lbryio/lbry-desktop/pull/2168))
 
 ## [0.26.1] - 2018-12-14
 

--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -99,7 +99,7 @@ class FileCard extends React.PureComponent<Props> {
     const handleContextMenu = event => {
       event.preventDefault();
       event.stopPropagation();
-      openCopyLinkMenu(convertToShareLink(uri), event);
+      openCopyLinkMenu(convertToShareLink(claim.permanent_url), event);
     };
 
     // We should be able to tab through cards


### PR DESCRIPTION
## PR Checklist
Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below


## PR Type
What kind of change does this PR introduce?

<!-- Please check all that apply to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Breaking changes (bugfix or feature that introduces breaking changes)
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: N/A

## What is the current behaviour?
Copying a link only copies the community/vanity link on some claims, such as the Community Top Bid Area.

## What is the new behaviour?
The fix makes sure the full permanent URL is always copied.

## Other information


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
