### PR TITLE
Upgrade to 0.30.4 sdk, allow running with incompatible sdk version, improve flow support

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "yarn": "^1.3"
   },
   "lbrySettings": {
-    "lbrynetDaemonVersion": "0.30.1",
+    "lbrynetDaemonVersion": "0.30.4",
     "lbrynetDaemonUrlTemplate": "https://github.com/lbryio/lbry/releases/download/vDAEMONVER/lbrynet-OSNAME.zip",
     "lbrynetDaemonDir": "static/daemon",
     "lbrynetDaemonFileName": "lbrynet"

--- a/src/renderer/component/splash/index.js
+++ b/src/renderer/component/splash/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { selectDaemonVersionMatched, selectModal } from 'redux/selectors/app';
-import { doCheckDaemonVersion, doNotifyUnlockWallet } from 'redux/actions/app';
+import { doCheckDaemonVersion, doNotifyUnlockWallet, doHideModal } from 'redux/actions/app';
 import SplashScreen from './view';
 
 const select = state => ({
@@ -11,6 +11,7 @@ const select = state => ({
 const perform = dispatch => ({
   checkDaemonVersion: () => dispatch(doCheckDaemonVersion()),
   notifyUnlockWallet: () => dispatch(doNotifyUnlockWallet()),
+  hideModal: () => dispatch(doHideModal()),
 });
 
 export default connect(

--- a/src/renderer/modal/modal.jsx
+++ b/src/renderer/modal/modal.jsx
@@ -23,7 +23,7 @@ type ModalProps = {
   expandButtonLabel?: string,
   hideButtonLabel?: string,
   fullScreen: boolean,
-  title: string,
+  title?: string | React.Node,
 };
 
 export class Modal extends React.PureComponent<ModalProps> {

--- a/src/renderer/modal/modalIncompatibleDaemon/index.js
+++ b/src/renderer/modal/modalIncompatibleDaemon/index.js
@@ -1,9 +1,8 @@
 import { connect } from 'react-redux';
-import { doQuit, doQuitAnyDaemon } from 'redux/actions/app';
+import { doQuitAnyDaemon } from 'redux/actions/app';
 import ModalIncompatibleDaemon from './view';
 
 const perform = dispatch => ({
-  quit: () => dispatch(doQuit()),
   quitAnyDaemon: () => dispatch(doQuitAnyDaemon()),
 });
 

--- a/src/renderer/modal/modalIncompatibleDaemon/view.jsx
+++ b/src/renderer/modal/modalIncompatibleDaemon/view.jsx
@@ -4,13 +4,13 @@ import { Modal } from 'modal/modal';
 import Button from 'component/button';
 
 type Props = {
-  quit: () => void,
+  onContinueAnyway: () => void,
   quitAnyDaemon: () => void,
 };
 
 class ModalIncompatibleDaemon extends React.PureComponent<Props> {
   render() {
-    const { quit, quitAnyDaemon } = this.props;
+    const { onContinueAnyway, quitAnyDaemon } = this.props;
 
     return (
       <Modal
@@ -18,21 +18,23 @@ class ModalIncompatibleDaemon extends React.PureComponent<Props> {
         title={__('Incompatible Daemon')}
         contentLabel={__('Incompatible daemon running')}
         type="confirm"
-        confirmButtonLabel={__('Close LBRY and daemon')}
-        abortButtonLabel={__('Do nothing')}
+        confirmButtonLabel={__('Close App and LBRY Processes')}
+        abortButtonLabel={__('Continue Anyway')}
         onConfirmed={quitAnyDaemon}
-        onAborted={quit}
+        onAborted={onContinueAnyway}
       >
-        <p>
-          {__(
-            'This browser is running with an incompatible version of the LBRY protocol, please close the LBRY app and rerun the installation package to repair it. '
-          )}
-        </p>
-        <Button
-          button="link"
-          label={__('Learn more')}
-          href="https://lbry.io/faq/incompatible-protocol-version"
-        />
+        <div className="card__content">
+          <p>
+            {__(
+              'This app is running with an incompatible version of the LBRY protocol. You can still use it, but there may be issues. Re-run the installation package for best results.'
+            )}
+          </p>
+          <Button
+            button="link"
+            label={__('Learn more')}
+            href="https://lbry.io/faq/incompatible-protocol-version"
+          />.
+        </div>
       </Modal>
     );
   }

--- a/src/renderer/modal/modalRevokeClaim/view.jsx
+++ b/src/renderer/modal/modalRevokeClaim/view.jsx
@@ -1,4 +1,5 @@
 // @flow
+import type { Transaction } from 'types/transaction';
 import React from 'react';
 import { Modal } from 'modal/modal';
 import * as txnTypes from 'constants/transaction_types';
@@ -8,6 +9,7 @@ type Props = {
   abandonClaim: (string, number) => void,
   txid: string,
   nout: number,
+  transactionItems: Array<Transaction>,
 };
 
 class ModalRevokeClaim extends React.PureComponent<Props> {
@@ -17,14 +19,14 @@ class ModalRevokeClaim extends React.PureComponent<Props> {
     (this: any).revokeClaim = this.revokeClaim.bind(this);
   }
 
-  getButtonLabel(type) {
+  getButtonLabel(type: string) {
     if (type === txnTypes.TIP) {
       return 'Confirm Tip Unlock';
     }
     return 'Confirm Claim Revoke';
   }
 
-  getMsgBody(type) {
+  getMsgBody(type: string) {
     if (type === txnTypes.TIP) {
       return (
         <React.Fragment>
@@ -58,7 +60,13 @@ class ModalRevokeClaim extends React.PureComponent<Props> {
 
   render() {
     const { transactionItems, txid, nout, closeModal } = this.props;
-    const { type } = transactionItems.find(claim => claim.txid == txid && claim.nout == nout);
+    const { type } =
+      transactionItems.find(claim => claim.txid === txid && claim.nout === nout) || {};
+
+    if (!type) {
+      console.error('Tried to render modalRevokeClaim but no matching tx type found.');
+      return null;
+    }
 
     return (
       <Modal

--- a/src/renderer/modal/modalRouter/view.jsx
+++ b/src/renderer/modal/modalRouter/view.jsx
@@ -32,10 +32,28 @@ import ModalRewardCode from 'modal/modalRewardCode';
 
 type Props = {
   modal: { id: string, modalProps: {} },
-  error: string | { message: string },
+  error: { message: string },
+  openModal: string => void,
+  page: string,
+  isWelcomeAcknowledged: boolean,
+  isEmailCollectionAcknowledged: boolean,
+  isVerificationCandidate: boolean,
+  isCreditIntroAcknowledged: boolean,
+  balance: number,
+  showPageCost: number,
+  user: {
+    is_reward_approved: boolean,
+    is_identity_verified: boolean,
+    has_verified_email: boolean,
+  },
 };
 
-class ModalRouter extends React.PureComponent<Props> {
+type State = {
+  lastTransitionModal: ?string,
+  lastTransitionPage: ?string,
+};
+
+class ModalRouter extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -49,11 +67,11 @@ class ModalRouter extends React.PureComponent<Props> {
     this.showTransitionModals(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     this.showTransitionModals(nextProps);
   }
 
-  showTransitionModals(props) {
+  showTransitionModals(props: Props) {
     const { modal, openModal, page } = props;
 
     if (modal) {
@@ -78,7 +96,7 @@ class ModalRouter extends React.PureComponent<Props> {
     }
   }
 
-  checkShowWelcome(props) {
+  checkShowWelcome(props: Props) {
     const { isWelcomeAcknowledged, user } = props;
 
     if (!isWelcomeAcknowledged && user && !user.is_reward_approved && !user.is_identity_verified) {
@@ -88,7 +106,7 @@ class ModalRouter extends React.PureComponent<Props> {
     return undefined;
   }
 
-  checkShowEmail(props) {
+  checkShowEmail(props: Props) {
     const { isEmailCollectionAcknowledged, isVerificationCandidate, user } = props;
     if (
       !isEmailCollectionAcknowledged &&
@@ -102,7 +120,7 @@ class ModalRouter extends React.PureComponent<Props> {
     return undefined;
   }
 
-  checkShowCreditIntro(props) {
+  checkShowCreditIntro(props: Props) {
     const { balance, page, isCreditIntroAcknowledged } = props;
 
     if (
@@ -116,7 +134,7 @@ class ModalRouter extends React.PureComponent<Props> {
     return undefined;
   }
 
-  isPaidShowPage(props) {
+  isPaidShowPage(props: Props) {
     const { page, showPageCost } = props;
     return page === 'show' && showPageCost > 0;
   }

--- a/src/renderer/page/backup/view.jsx
+++ b/src/renderer/page/backup/view.jsx
@@ -5,14 +5,14 @@ import Page from 'component/page';
 
 type Props = {
   daemonSettings: {
-    lbryum_wallet_dir: ?string,
+    wallet_dir: ?string,
   },
 };
 
 class BackupPage extends React.PureComponent<Props> {
   render() {
     const { daemonSettings } = this.props;
-    const { lbryum_wallet_dir: lbryumWalletDir } = daemonSettings;
+    const { wallet_dir: lbryumWalletDir } = daemonSettings;
 
     const noDaemonSettings = Object.keys(daemonSettings).length === 0;
 

--- a/src/renderer/redux/actions/app.js
+++ b/src/renderer/redux/actions/app.js
@@ -258,7 +258,7 @@ export function doCheckDaemonVersion() {
     Lbry.version().then(({ lbrynet_version: lbrynetVersion }) => {
       // Avoid the incompatible daemon modal if running in dev mode
       // Lets you run a different daemon than the one specified in package.json
-      if (isDev || config.lbrynetDaemonVersion === lbrynetVersion) {
+      if (config.lbrynetDaemonVersion === lbrynetVersion) {
         return dispatch({
           type: ACTIONS.DAEMON_VERSION_MATCH,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5683,9 +5683,9 @@ lbry-redux@lbryio/lbry-redux#84b7d396934d57a37802aadbef71db91230a9404:
     reselect "^3.0.0"
     uuid "^3.3.2"
 
-lbryinc@lbryio/lbryinc#cee70d482cf352f2e66215fa109f4178406228ca:
+lbryinc@lbryio/lbryinc#b3bb8c67745235ef54baea95accaedaa4bb86d4d:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/cee70d482cf352f2e66215fa109f4178406228ca"
+  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/b3bb8c67745235ef54baea95accaedaa4bb86d4d"
   dependencies:
     lbry-redux lbryio/lbry-redux#84b7d396934d57a37802aadbef71db91230a9404
     reselect "^3.0.0"


### PR DESCRIPTION
### Changes
- Before users couldn't run the app if they had a different version of the sdk running than the one specified in the package.json.
- To help with this we just disabled that check in dev mode. 
- Now you can just click "Use Anyway"

- Also fixed flow errors.