### PR TITLE
update: use 'home' icon for 'explore' tab on side bar

### DIFF
--- a/src/renderer/redux/selectors/app.js
+++ b/src/renderer/redux/selectors/app.js
@@ -198,7 +198,7 @@ export const selectNavLinks = createSelector(
           label: 'Explore',
           path: '/discover',
           active: currentPage === 'discover',
-          icon: icons.COMPASS,
+          icon: icons.HOME,
         },
         {
           label: 'Subscriptions',


### PR DESCRIPTION
<img width="446" alt="screen shot 2019-01-14 at 5 32 05 pm" src="https://user-images.githubusercontent.com/16882830/51145660-8f154000-1822-11e9-9b0c-1f97b504338d.png">
