### PR TITLE
Fix content aspect ratio breaking WebGL

### DIFF
--- a/src/renderer/scss/component/_content.scss
+++ b/src/renderer/scss/component/_content.scss
@@ -37,6 +37,14 @@
 
 .content__embedded {
   @include thumbnail;
+  <<<<<<<Updated upstream
+=======
+  align-items: center;
+  background-color: $lbry-black;
+  display: flex;
+  justify-content: center;
+  margin-bottom: var(--spacing-vertical-large);
+  >>>>>>>Stashed changes
   position: relative;
 
   video {


### PR DESCRIPTION
Removes forced aspect ratio from the top level, this is breaking the webview