### PR TITLE
fix #2240: reset time to zero on file end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Flow errors ([#2213](https://github.com/lbryio/lbry-desktop/pull/2213))
+- Video position on previously viewed files ([#2240](https://github.com/lbryio/lbry-desktop/pull/2240))
 
 ## [0.27.1] - 2018-01-22
 

--- a/src/renderer/component/fileViewer/internal/player.jsx
+++ b/src/renderer/component/fileViewer/internal/player.jsx
@@ -48,6 +48,7 @@ class MediaPlayer extends React.PureComponent {
       claim,
       onStartCb,
       onFinishCb,
+      savePosition,
     } = this.props;
 
     const loadedMetadata = () => {
@@ -95,13 +96,7 @@ class MediaPlayer extends React.PureComponent {
       if (position) {
         mediaElement.currentTime = position;
       }
-      mediaElement.addEventListener('timeupdate', () =>
-        this.props.savePosition(
-          claim.claim_id,
-          `${claim.txid}:${claim.nout}`,
-          mediaElement.currentTime
-        )
-      );
+      mediaElement.addEventListener('timeupdate', () => savePosition(mediaElement.currentTime));
       mediaElement.addEventListener('click', this.togglePlayListener);
       mediaElement.addEventListener('loadedmetadata', loadedMetadata.bind(this), {
         once: true,
@@ -110,6 +105,7 @@ class MediaPlayer extends React.PureComponent {
         if (onFinishCb) {
           onFinishCb();
         }
+        savePosition(0);
       });
       mediaElement.addEventListener('webkitfullscreenchange', win32FullScreenChange.bind(this));
       mediaElement.addEventListener('volumechange', () => {

--- a/src/renderer/component/fileViewer/view.jsx
+++ b/src/renderer/component/fileViewer/view.jsx
@@ -18,6 +18,7 @@ type Props = {
     written_bytes: number,
     download_path: string,
     completed: boolean,
+    blobs_completed: number,
   },
   fileInfoErrors: ?{
     [string]: boolean,
@@ -259,7 +260,9 @@ class FileViewer extends React.PureComponent<Props> {
                 downloadCompleted={fileInfo.completed}
                 changeVolume={changeVolume}
                 volume={volume}
-                savePosition={savePosition}
+                savePosition={newPosition =>
+                  savePosition(claim.claim_id, `${claim.txid}:${claim.nout}`, newPosition)
+                }
                 claim={claim}
                 uri={uri}
                 position={position}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2240

## What is the current behavior?
When you finish a video and navigate back to it, the video starts at the end. 

## What is the new behavior?
When you finish a video and navigate back to it, the video starts at the beginning.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
