### PR TITLE
Missing Class Made YRBL Too Big For His Boots

### DIFF
--- a/src/renderer/page/subscriptions/internal/first-run.jsx
+++ b/src/renderer/page/subscriptions/internal/first-run.jsx
@@ -26,7 +26,7 @@ export default (props: Props) => {
       <div className="yrbl-wrap">
         <img
           alt="Friendly gerbil"
-          className="subscriptions__gerbil"
+          className="subscriptions__gerbil yrbl--first-run"
           src={Native.imagePath('gerbil-happy.png')}
         />
         <div className="card__content">


### PR DESCRIPTION
Missing class `yrbl--first-run` made YRBLE 100% of the screen `height` and `width`, which also knocked everything out of view.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

Missing class `yrbl--first-run` made YRBLE 100% of the screen `height` and `width`, which also knocked everything out of view.

![image](https://user-images.githubusercontent.com/29914179/51963410-35ae4180-24af-11e9-95d3-855b4e8deb2e.png)


## What is the new behavior?

With the missing class added, Mr/Mrs/Miss/Ms YRBL is back to his/her normal self.

![image](https://user-images.githubusercontent.com/29914179/51963439-4d85c580-24af-11e9-93a4-c70335d86900.png)
 
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
