### PR TITLE
feat: add mouse back/forward navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Support for sandbox applications ([#2178](https://github.com/lbryio/lbry-desktop/pull/2178))
+- Support for sandbox games and applications ([#2178](https://github.com/lbryio/lbry-desktop/pull/2178))
 - CTA to invite page on first run ([#2221](https://github.com/lbryio/lbry-desktop/pull/2221))
 - Responsive related content list ([#2226](https://github.com/lbryio/lbry-desktop/pull/2226))
 - Autoplay content in list of related files ([#2235](https://github.com/lbryio/lbry-desktop/pull/2235))
+- Support for back/forward mouse navigation on Windows/OSX ([#855](https://github.com/lbryio/lbry-desktop/issues/885))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CTA to invite page on first run ([#2221](https://github.com/lbryio/lbry-desktop/pull/2221))
 - Responsive related content list ([#2226](https://github.com/lbryio/lbry-desktop/pull/2226))
 - Autoplay content in list of related files ([#2235](https://github.com/lbryio/lbry-desktop/pull/2235))
-- Support for back/forward mouse navigation on Windows/OSX ([#855](https://github.com/lbryio/lbry-desktop/issues/885))
+- Support for back/forward mouse navigation on Windows ([#2250](https://github.com/lbryio/lbry-desktop/pull/2250))
 
 ### Changed
 

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -72,15 +72,28 @@ export default appState => {
   }
 
   setupBarMenu();
-
-  window.on('app-command', function(e, cmd) {
+  // Windows back/forward mouse navigation
+  window.on('app-command', (e, cmd) => {
     switch (cmd) {
       case 'browser-backward':
         window.webContents.send('navigate-backward', null);
-        return;
+        break;
       case 'browser-forward':
         window.webContents.send('navigate-forward', null);
-        return;
+        break;
+      default: // Do nothing
+    }
+  });
+  // Mac back/forward swipe navigation
+  window.on('swipe', (e, dir) => {
+    switch (dir) {
+      case 'left':
+        window.webContents.send('navigate-backward', null);
+        break;
+      case 'right':
+        window.webContents.send('navigate-forward', null);
+        break;
+      default: // Do nothing
     }
   });
 

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -73,6 +73,17 @@ export default appState => {
 
   setupBarMenu();
 
+  window.on('app-command', function(e, cmd) {
+    switch (cmd) {
+      case 'browser-backward':
+        window.webContents.send('navigate-backward', null);
+        return;
+      case 'browser-forward':
+        window.webContents.send('navigate-forward', null);
+        return;
+    }
+  });
+
   window.on('close', event => {
     if (!appState.isQuitting && !appState.autoUpdateAccepted) {
       event.preventDefault();

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -72,6 +72,7 @@ export default appState => {
   }
 
   setupBarMenu();
+
   // Windows back/forward mouse navigation
   window.on('app-command', (e, cmd) => {
     switch (cmd) {
@@ -79,18 +80,6 @@ export default appState => {
         window.webContents.send('navigate-backward', null);
         break;
       case 'browser-forward':
-        window.webContents.send('navigate-forward', null);
-        break;
-      default: // Do nothing
-    }
-  });
-  // Mac back/forward swipe navigation
-  window.on('swipe', (e, dir) => {
-    switch (dir) {
-      case 'left':
-        window.webContents.send('navigate-backward', null);
-        break;
-      case 'right':
         window.webContents.send('navigate-forward', null);
         break;
       default: // Do nothing

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -18,7 +18,7 @@ import {
   doHideModal,
 } from 'redux/actions/app';
 import { doToast, doBlackListedOutpointsSubscribe, isURIValid, setSearchApi } from 'lbry-redux';
-import { doNavigate } from 'redux/actions/navigation';
+import { doNavigate, doHistoryBack, doHistoryForward } from 'redux/actions/navigation';
 import { doDownloadLanguages, doUpdateIsNightAsync } from 'redux/actions/settings';
 import { doAuthenticate, Lbryio, rewards } from 'lbryinc';
 import 'scss/all.scss';
@@ -40,6 +40,14 @@ if (process.env.LBRY_API_URL) {
 if (process.env.SEARCH_API_URL) {
   setSearchApi(process.env.SEARCH_API_URL);
 }
+
+ipcRenderer.on('navigate-backward', () => {
+  app.store.dispatch(doHistoryBack());
+});
+
+ipcRenderer.on('navigate-forward', () => {
+  app.store.dispatch(doHistoryForward());
+});
 
 // We need to override Lbryio for getting/setting the authToken
 // We interect with ipcRenderer to get the auth key from a users keyring


### PR DESCRIPTION
Tested on Windows, but it should work on Mac too (Sean to verify). For Linux, we'd need Electron 3+ (https://github.com/electron/electron/pull/15441)  or https://github.com/jostrander/mouse-forward-back