### PR TITLE
fix: pass error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Flow errors ([#2213](https://github.com/lbryio/lbry-desktop/pull/2213))
 - Video position on previously viewed files ([#2240](https://github.com/lbryio/lbry-desktop/pull/2240))
+- Pass download error details on modal ([#2255](https://github.com/lbryio/lbry-desktop/pull/2255))
 
 ## [0.27.1] - 2018-01-22
 

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -180,12 +180,13 @@ function handleLoadVideoError(uri, errorType = '') {
         data: { uri },
       });
       dispatch(doSetPlayingUri(null));
+      // this is not working, but should be it's own separate modal in the future (https://github.com/lbryio/lbry-desktop/issues/892)
       if (errorType === 'timeout') {
         doOpenModal(MODALS.FILE_TIMEOUT, { uri });
       } else {
         dispatch(
           doError(
-            `Failed to download ${uri}, please try again. If this problem persists, visit https://lbry.io/faq/support for support.`
+            `Failed to download ${uri}, please try again or see error details:\n${errorType}\n\nIf this problem persists, visit https://lbry.io/support for help. `
           )
         );
       }
@@ -204,6 +205,7 @@ export function doLoadVideo(uri, shouldRecordViewEvent) {
 
     Lbry.get({ uri })
       .then(streamInfo => {
+        // need error code from SDK to capture properly
         const timeout =
           streamInfo === null || typeof streamInfo !== 'object' || streamInfo.error === 'Timeout';
 
@@ -221,8 +223,8 @@ export function doLoadVideo(uri, shouldRecordViewEvent) {
           }
         }
       })
-      .catch(() => {
-        dispatch(handleLoadVideoError(uri));
+      .catch(error => {
+        dispatch(handleLoadVideoError(uri, error));
       });
   };
 }

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -186,7 +186,7 @@ function handleLoadVideoError(uri, errorType = '') {
       } else {
         dispatch(
           doError(
-            `Failed to download ${uri}, please try again or see error details:\n${errorType}\n\nIf this problem persists, visit https://lbry.io/support for help. `
+            `Failed to download ${uri}, please try again or see error details:\n\n${errorType}\n\nIf this problem persists, visit https://lbry.io/support for help. `
           )
         );
       }

--- a/src/renderer/scss/component/_modal.scss
+++ b/src/renderer/scss/component/_modal.scss
@@ -107,6 +107,7 @@
 .error-modal {
   max-width: none;
   width: var(--modal-width);
+  white-space: pre-wrap;
 }
 
 .error-modal__error-list {
@@ -120,4 +121,5 @@
   color: $lbry-red-5;
   list-style: none;
   overflow-y: scroll;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
Pass the download error message from SDK and fix up new line formatting on modals. We aren't using the timeout modal, but leaving in because we should use a special one for download failures in the future.
![image](https://user-images.githubusercontent.com/8120721/52128059-f2181c80-2601-11e9-9389-26737f23814a.png)
