### PR TITLE
fix: missing spee.ch error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Error message when thumbupload failed([#2254](https://github.com/lbryio/lbry-desktop/pull/2254))
 - Flow errors ([#2213](https://github.com/lbryio/lbry-desktop/pull/2213))
 - Video position on previously viewed files ([#2240](https://github.com/lbryio/lbry-desktop/pull/2240))
 

--- a/src/renderer/redux/actions/publish.js
+++ b/src/renderer/redux/actions/publish.js
@@ -97,9 +97,13 @@ export const doUploadThumbnail = (filePath: string, nsfw: boolean) => (
       batchActions(
         {
           type: ACTIONS.UPDATE_PUBLISH_FORM,
-          data: { uploadThumbnailStatus: THUMBNAIL_STATUSES.API_DOWN },
+          data: {
+            uploadThumbnailStatus: THUMBNAIL_STATUSES.READY,
+            thumbnail: '',
+            nsfw: false,
+          },
         },
-        doError(MODALS.ERROR, { error })
+        doError(error)
       )
     );
 


### PR DESCRIPTION
Also, decided to reset the publish status. Unless we know for sure know it's a spee.ch issue, we should let them upload again (what If i selected an mp4 or another unsupported type?) They can still manually choose the manual URL method.