### PR TITLE
fix: show 'no preview available' for files correctly

### DIFF
--- a/src/renderer/component/fileViewer/internal/player.jsx
+++ b/src/renderer/component/fileViewer/internal/player.jsx
@@ -283,8 +283,8 @@ class MediaPlayer extends React.PureComponent {
     const isLoadingFile = !fileSource && isFileType;
     const isLbryPackage = /application\/x(-ext)?-lbry$/.test(contentType);
     const isUnsupported =
-      !isLbryPackage && (!this.supportedType() && !isFileType && !isPlayableType);
-
+      (mediaType === 'application' && !isLbryPackage) ||
+      (!this.supportedType() && !isFileType && !isPlayableType);
     // Media (audio, video)
     const isUnplayable = isPlayableType && unplayable;
     const isLoadingMetadata = isPlayableType && (!hasMetadata && !unplayable);

--- a/src/renderer/redux/selectors/app.js
+++ b/src/renderer/redux/selectors/app.js
@@ -118,7 +118,6 @@ export const selectNavLinks = createSelector(
       page === PAGES.WALLET ||
       page === PAGES.SEND ||
       page === PAGES.GET_CREDITS ||
-      page === PAGES.REWARDS ||
       page === PAGES.HISTORY ||
       page === PAGES.BACKUP;
 
@@ -178,9 +177,6 @@ export const selectNavLinks = createSelector(
         ...buildLink('Get Credits', PAGES.GET_CREDITS),
       },
       {
-        ...buildLink('Rewards', PAGES.REWARDS),
-      },
-      {
         ...buildLink('Backup', PAGES.BACKUP),
       },
     ];
@@ -207,6 +203,11 @@ export const selectNavLinks = createSelector(
         {
           ...buildLink('Invite', PAGES.INVITE),
           icon: ICONS.INVITE,
+        },
+        {
+          ...buildLink('Rewards', PAGES.REWARDS),
+          // This probably shouldn't use the "FEATURED" icon, but not sure what else to use
+          icon: ICONS.FEATURED,
         },
         {
           ...buildLink('Downloads', PAGES.DOWNLOADED),


### PR DESCRIPTION
The games code removed a line that correctly showed a message saying "No preview available" for certain files.