### PR TITLE
fix: load correct video player on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "reselect": "^3.0.0",
     "semver": "^5.3.0",
     "source-map-support": "^0.5.4",
-    "stream-to-blob-url": "^2.1.1",
     "three": "^0.93.0",
     "tree-kill": "^1.1.0",
     "video.js": "^7.2.2",

--- a/src/renderer/component/fileViewer/internal/player.jsx
+++ b/src/renderer/component/fileViewer/internal/player.jsx
@@ -7,8 +7,6 @@ import path from 'path';
 import player from 'render-media';
 import FileRender from 'component/fileRender';
 import LoadingScreen from 'component/common/loading-screen';
-// Loading this here so we have uniform video style even if we use two different players
-import 'video.js/dist/video-js.css';
 
 type Props = {
   contentType: string,

--- a/src/renderer/component/viewers/audioVideoViewer.jsx
+++ b/src/renderer/component/viewers/audioVideoViewer.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import { stopContextMenu } from 'util/context-menu';
 import videojs from 'video.js';
-import 'video.js/dist/video-js.css';
 
 type Props = {
   source: {

--- a/src/renderer/component/viewers/audioVideoViewer.jsx
+++ b/src/renderer/component/viewers/audioVideoViewer.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { stopContextMenu } from 'util/context-menu';
 import videojs from 'video.js';
+import 'video.js/dist/video-js.css';
 
 type Props = {
   source: {

--- a/src/renderer/scss/component/_button.scss
+++ b/src/renderer/scss/component/_button.scss
@@ -92,14 +92,17 @@
   }
 }
 
-.button--link:not(:disabled) {
-  html[data-mode='dark'] & {
-    &:not(:hover) {
-      color: $lbry-teal-4;
-    }
+.button--link {
+  word-break: break-all;
+  &:not(:disabled) {
+    html[data-mode='dark'] & {
+      &:not(:hover) {
+        color: $lbry-teal-4;
+      }
 
-    &:hover {
-      color: $lbry-teal-3;
+      &:hover {
+        color: $lbry-teal-3;
+      }
     }
   }
 }

--- a/src/renderer/scss/component/_file-render.scss
+++ b/src/renderer/scss/component/_file-render.scss
@@ -35,9 +35,9 @@
 
   // Removing the play button because we have autoplay turned on
   // These are classes added by video.js
-  // .video-js .vjs-big-play-button {
-  //   display: none;
-  // }
+  .video-js .vjs-big-play-button {
+    display: none;
+  }
 }
 
 .document-viewer {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9340,7 +9340,7 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
-stream-to-blob-url@^2.0.0, stream-to-blob-url@^2.1.1:
+stream-to-blob-url@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/stream-to-blob-url/-/stream-to-blob-url-2.1.1.tgz#e1ac97f86ca8e9f512329a48e7830ce9a50beef2"
   dependencies:


### PR DESCRIPTION
### Changes
- Web app doesn't break when you try to watch a video (still doesn't play though)
- Flow coverage on `src/renderer/fileViewer/internal/player.jsx`
- Don't explicitly render audio different from video if they use the same player