### PR TITLE
fix: open pdf's externally

### DIFF
--- a/src/ui/component/fileRender/view.jsx
+++ b/src/ui/component/fileRender/view.jsx
@@ -107,14 +107,14 @@ class FileRender extends React.PureComponent<Props> {
       application: !source.url ? null : (
         <webview
           ref={element => this.processSandboxRef(element)}
-          title=''
-          sandbox='allow-scripts allow-forms allow-pointer-lock'
+          title=""
+          sandbox="allow-scripts allow-forms allow-pointer-lock"
           src={source.url}
-          autosize='on'
+          autosize="on"
           style={{ border: 0, width: '100%', height: '100%' }}
-          useragent='Mozilla/5.0 AppleWebKit/537 Chrome/60 Safari/537'
-          enableremotemodule='false'
-          webpreferences='sandbox=true,contextIsolation=true,webviewTag=false,enableRemoteModule=false,devTools=false'
+          useragent="Mozilla/5.0 AppleWebKit/537 Chrome/60 Safari/537"
+          enableremotemodule="false"
+          webpreferences="sandbox=true,contextIsolation=true,webviewTag=false,enableRemoteModule=false,devTools=false"
         />
       ),
       video: (
@@ -150,7 +150,14 @@ class FileRender extends React.PureComponent<Props> {
     if (!viewer && readableFiles.includes(mediaType)) {
       viewer = <DocumentViewer source={{ stream, fileType, contentType }} theme={currentTheme} />;
     }
-
+    // temp workaround
+    if (claim && claim.value.stream.metadata.fee && claim.value.stream.metadata.fee.amount > 0) {
+      const paidMessage = __(
+        'Currently, only free content is available on lbry.tv. Try viewing it in the desktop app.'
+      );
+      const paid = <LoadingScreen status={paidMessage} spinner={false} />;
+      return paid;
+    }
     // Message Error
     const unsupportedMessage = __("Sorry, looks like we can't preview this file.");
     const unsupported = <LoadingScreen status={unsupportedMessage} spinner={false} />;
@@ -160,7 +167,7 @@ class FileRender extends React.PureComponent<Props> {
   }
 
   render() {
-    return <div className='file-render'>{this.renderViewer()}</div>;
+    return <div className="file-render">{this.renderViewer()}</div>;
   }
 }
 

--- a/src/ui/component/fileViewer/internal/player.jsx
+++ b/src/ui/component/fileViewer/internal/player.jsx
@@ -287,19 +287,10 @@ class MediaPlayer extends React.PureComponent<Props, State> {
   }
 
   showLoadingScreen(isFileType: boolean, isPlayableType: boolean) {
-    const { claim, mediaType, contentType } = this.props;
+    const { mediaType, contentType } = this.props;
     const { unplayable, fileSource, hasMetadata } = this.state;
-    
-    if (claim && claim.value.stream.metadata.fee && claim.value.stream.metadata.fee.amount > 0) {
-      return {
-        isLoading: false,
-        loadingStatus: __(
-          'Currently, only free content is available on lbry.tv. Try viewing it in the desktop app.'
-        ),
-      };
-    }
 
-    if (['audio', 'video'].indexOf(mediaType) === -1) {
+    if (IS_WEB && ['audio', 'video'].indexOf(mediaType) === -1) {
       return {
         isLoading: false,
         loadingStatus: __(
@@ -361,7 +352,7 @@ class MediaPlayer extends React.PureComponent<Props, State> {
         {loadingStatus && <LoadingScreen status={loadingStatus} spinner={isLoading} />}
         {isFileReady && <FileRender claim={claim} source={fileSource} mediaType={mediaType} />}
         <div
-          className="content__view--container"
+          className='content__view--container'
           style={{ opacity: isLoading ? 0 : 1 }}
           ref={this.mediaContainer}
         />

--- a/src/ui/component/viewers/pdfViewer.jsx
+++ b/src/ui/component/viewers/pdfViewer.jsx
@@ -1,17 +1,41 @@
 // @flow
 import * as React from 'react';
 import { stopContextMenu } from 'util/context-menu';
+import Button from 'component/button';
+import { shell } from 'electron';
 
 type Props = {
   source: string,
 };
 
 class PdfViewer extends React.PureComponent<Props> {
-  render() {
+  constructor() {
+    super();
+
+    (this: any).openFile = this.openFile.bind(this);
+  }
+
+  componentDidMount() {
+    this.openFile();
+  }
+
+  openFile() {
     const { source } = this.props;
+    const path = `file://${source}`;
+    shell.openExternal(path);
+  }
+
+  render() {
+    // We used to be able to just render a webview and display the pdf inside the app
+    // This was disabled on electron@3
+    // https://github.com/electron/electron/issues/12337
     return (
-      <div className="file-render__viewer" onContextMenu={stopContextMenu}>
-        <webview src={`chrome://pdf-viewer/index.html?src=file://${source}`} />
+      <div className="file-render__viewer file-render--pdf" onContextMenu={stopContextMenu}>
+        <p>
+          {__('PDF opened externally.')}{' '}
+          <Button button="link" label={__('Click here')} onClick={this.openFile} />{' '}
+          {__('to open it again.')}
+        </p>
       </div>
     );
   }

--- a/src/ui/scss/component/_file-render.scss
+++ b/src/ui/scss/component/_file-render.scss
@@ -40,6 +40,13 @@
   }
 }
 
+.file-render--pdf {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5em;
+}
+
 .document-viewer {
   overflow: auto;
 


### PR DESCRIPTION
There isn't a good way to open pdf's in the app currently. I've added some new styles and js to open these with the OSes default viewer. I think this is something we should do for other file types (probably docx too).

We could have a list of file types that you can open in other programs, most likely limited to files that are usually opened in a standard application.

PDF's are probably one of the files that we _should_ be able to to view in the app, because it's so simple in the desktop, but a pain due to https://github.com/electron/electron/issues/12337

Will definitely break on web. I might move other files to this new viewer when I fix it there, but just getting this in for the app release.