### PR TITLE
Improve fullscreen mode of the viewer

### DIFF
--- a/src/ui/component/fileActions/view.jsx
+++ b/src/ui/component/fileActions/view.jsx
@@ -4,7 +4,7 @@ import * as ICONS from 'constants/icons';
 import * as React from 'react';
 import Button from 'component/button';
 import Tooltip from 'component/common/tooltip';
-import { requestFullscreen } from 'util/full-screen';
+import { requestFullscreen, fullscreenElement } from 'util/full-screen';
 
 type FileInfo = {
   claim_id: string,
@@ -16,14 +16,19 @@ type Props = {
   openModal: (id: string, { uri: string }) => void,
   claimIsMine: boolean,
   fileInfo: FileInfo,
+  viewerContainer: React.Ref,
   showFullscreen: boolean,
 };
 
 class FileActions extends React.PureComponent<Props> {
   maximizeViewer = () => {
-    // Get viewer container
-    const viewer = document.getElementsByClassName('content__embedded')[0];
-    requestFullscreen(viewer);
+    const { viewerContainer } = this.props;
+    const isFullscreen = fullscreenElement();
+    // Request fullscreen if viewer is ready
+    // And if there is no fullscreen element active
+    if (!isFullscreen && viewerContainer && viewerContainer.current !== null) {
+      requestFullscreen(viewerContainer.current);
+    }
   };
 
   render() {

--- a/src/ui/component/fileActions/view.jsx
+++ b/src/ui/component/fileActions/view.jsx
@@ -15,15 +15,34 @@ type Props = {
   openModal: (id: string, { uri: string }) => void,
   claimIsMine: boolean,
   fileInfo: FileInfo,
+  showFullscreen: boolean,
 };
 
 class FileActions extends React.PureComponent<Props> {
+  MaximizeViewer() {
+    // Get viewer container
+    const viewer = document.getElementsByClassName('content__embedded')[0];
+    viewer.webkitRequestFullscreen();
+  }
+
   render() {
-    const { fileInfo, uri, openModal, claimIsMine, claimId } = this.props;
+    const { fileInfo, uri, openModal, claimIsMine, claimId, showFullscreen } = this.props;
     const showDelete = claimIsMine || (fileInfo && Object.keys(fileInfo).length > 0);
 
     return (
       <React.Fragment>
+        {showFullscreen && (
+          <Tooltip onComponent body={__('Full screen (f)')}>
+            <Button
+              button="alt"
+              description={__('Fullscreen')}
+              icon={ICONS.FULLSCREEN}
+              onClick={() => {
+                this.MaximizeViewer();
+              }}
+            />
+          </Tooltip>
+        )}
         {showDelete && (
           <Tooltip onComponent body={__('Delete this file')}>
             <Button

--- a/src/ui/component/fileActions/view.jsx
+++ b/src/ui/component/fileActions/view.jsx
@@ -19,11 +19,11 @@ type Props = {
 };
 
 class FileActions extends React.PureComponent<Props> {
-  MaximizeViewer() {
+  maximizeViewer = () => {
     // Get viewer container
     const viewer = document.getElementsByClassName('content__embedded')[0];
     viewer.webkitRequestFullscreen();
-  }
+  };
 
   render() {
     const { fileInfo, uri, openModal, claimIsMine, claimId, showFullscreen } = this.props;
@@ -33,14 +33,7 @@ class FileActions extends React.PureComponent<Props> {
       <React.Fragment>
         {showFullscreen && (
           <Tooltip onComponent body={__('Full screen (f)')}>
-            <Button
-              button="alt"
-              description={__('Fullscreen')}
-              icon={ICONS.FULLSCREEN}
-              onClick={() => {
-                this.MaximizeViewer();
-              }}
-            />
+            <Button button="alt" description={__('Fullscreen')} icon={ICONS.FULLSCREEN} onClick={this.maximizeViewer} />
           </Tooltip>
         )}
         {showDelete && (

--- a/src/ui/component/fileActions/view.jsx
+++ b/src/ui/component/fileActions/view.jsx
@@ -4,6 +4,7 @@ import * as ICONS from 'constants/icons';
 import * as React from 'react';
 import Button from 'component/button';
 import Tooltip from 'component/common/tooltip';
+import { requestFullscreen } from 'util/full-screen';
 
 type FileInfo = {
   claim_id: string,
@@ -22,7 +23,7 @@ class FileActions extends React.PureComponent<Props> {
   maximizeViewer = () => {
     // Get viewer container
     const viewer = document.getElementsByClassName('content__embedded')[0];
-    viewer.webkitRequestFullscreen();
+    requestFullscreen(viewer);
   };
 
   render() {

--- a/src/ui/component/fileViewer/internal/player.jsx
+++ b/src/ui/component/fileViewer/internal/player.jsx
@@ -115,7 +115,9 @@ class MediaPlayer extends React.PureComponent<Props, State> {
         this.toggleFullscreen();
       }
       // Handle toggle play
+      // @if TARGET='app'
       this.togglePlay(event);
+      // @endif
     }
   };
 
@@ -130,19 +132,20 @@ class MediaPlayer extends React.PureComponent<Props, State> {
   toggleFullscreen = () => {
     const { viewerContainer } = this.props;
     const isFullscreen = fullscreenElement();
+    const isSupportedFile = this.isSupportedFile();
     const isPlayableType = this.playableType();
 
     if (!isFullscreen) {
       // Enter fullscreen mode if content is not playable
       // Otherwise it should be handle internally on the video player
       // or it will break the toggle fullscreen button
-      if (!isPlayableType && viewerContainer && viewerContainer.current !== null) {
+      if (!isPlayableType && isSupportedFile && viewerContainer && viewerContainer.current !== null) {
         requestFullscreen(viewerContainer.current);
       }
       // Request fullscreen mode for the media player (renderMedia)
       // Don't use this with the new player
       // @if TARGET='app'
-      else {
+      else if (isPlayableType) {
         const mediaContainer = this.mediaContainer.current;
         const mediaElement = mediaContainer && mediaContainer.children[0];
         if (mediaElement) {
@@ -209,8 +212,6 @@ class MediaPlayer extends React.PureComponent<Props, State> {
       );
     }
 
-    document.addEventListener('keydown', this.handleKeyDown);
-
     const mediaElement = container.children[0];
     if (mediaElement) {
       if (position) {
@@ -244,6 +245,9 @@ class MediaPlayer extends React.PureComponent<Props, State> {
       this.renderFile();
     }
     // @endif
+
+    // Fullscreen event for web and app
+    document.addEventListener('keydown', this.handleKeyDown);
   }
 
   // @if TARGET='app'

--- a/src/ui/component/fileViewer/internal/player.jsx
+++ b/src/ui/component/fileViewer/internal/player.jsx
@@ -1,14 +1,20 @@
 // @flow
 import '@babel/polyfill';
 import * as React from 'react';
+
 // @if TARGET='app'
-import { remote } from 'electron';
 import fs from 'fs';
+import { remote } from 'electron';
 // @endif
+
 import path from 'path';
 import player from 'render-media';
 import FileRender from 'component/fileRender';
 import LoadingScreen from 'component/common/loading-screen';
+import { fullscreenElement, requestFullscreen, exitFullscreen } from 'util/full-screen';
+
+// Shorcut key code for fullscreen (f)
+const F_KEYCODE = 70;
 
 type Props = {
   contentType: string,
@@ -23,6 +29,8 @@ type Props = {
   onFinishCb: ?() => void,
   savePosition: number => void,
   changeVolume: number => void,
+  viewerContainer: React.Ref,
+  searchBarFocused: boolean,
 };
 
 type State = {
@@ -69,7 +77,6 @@ class MediaPlayer extends React.PureComponent<Props, State> {
 
     this.mediaContainer = React.createRef();
     (this: any).togglePlay = this.togglePlay.bind(this);
-    (this: any).toggleFullScreen = this.toggleFullScreen.bind(this);
   }
 
   componentDidMount() {
@@ -91,25 +98,62 @@ class MediaPlayer extends React.PureComponent<Props, State> {
   componentWillUnmount() {
     const mediaElement = this.mediaContainer.current.children[0];
 
-    document.removeEventListener('keydown', this.togglePlay);
+    document.removeEventListener('keydown', this.handleKeyDown);
 
     if (mediaElement) {
       mediaElement.removeEventListener('click', this.togglePlay);
+      mediaElement.removeEventListener('dbclick', this.handleDoubleClick);
     }
   }
 
-  toggleFullScreen() {
-    const mediaElement = this.mediaContainer.current;
-    if (mediaElement) {
-      // $FlowFixMe
-      if (document.webkitIsFullScreen) {
-        // $FlowFixMe
-        document.webkitExitFullscreen();
-      } else {
-        mediaElement.webkitRequestFullScreen();
+  handleKeyDown = (event: SyntheticKeyboardEvent<*>) => {
+    const { searchBarFocused } = this.props;
+
+    if (!searchBarFocused) {
+      // Handle fullscreen shortcut key (f)
+      if (event.keyCode === F_KEYCODE) {
+        this.toggleFullscreen();
       }
+      // Handle toggle play
+      this.togglePlay(event);
     }
-  }
+  };
+
+  handleDoubleClick = (event: SyntheticInputEvent<*>) => {
+    // Prevent pause / play
+    event.preventDefault();
+    event.stopPropagation();
+    // Trigger fullscreen mode
+    this.toggleFullscreen();
+  };
+
+  toggleFullscreen = () => {
+    const { viewerContainer } = this.props;
+    const isFullscreen = fullscreenElement();
+    const isPlayableType = this.playableType();
+
+    if (!isFullscreen) {
+      // Enter fullscreen mode if content is not playable
+      // Otherwise it should be handle internally on the video player
+      // or it will break the toggle fullscreen button
+      if (!isPlayableType && viewerContainer && viewerContainer.current !== null) {
+        requestFullscreen(viewerContainer.current);
+      }
+      // Request fullscreen mode for the media player (renderMedia)
+      // Don't use this with the new player
+      // @if TARGET='app'
+      else {
+        const mediaContainer = this.mediaContainer.current;
+        const mediaElement = mediaContainer && mediaContainer.children[0];
+        if (mediaElement) {
+          requestFullscreen(mediaElement);
+        }
+      }
+      // @endif
+    } else {
+      exitFullscreen();
+    }
+  };
 
   async playMedia() {
     const container = this.mediaContainer.current;
@@ -165,7 +209,8 @@ class MediaPlayer extends React.PureComponent<Props, State> {
       );
     }
 
-    document.addEventListener('keydown', this.togglePlay);
+    document.addEventListener('keydown', this.handleKeyDown);
+
     const mediaElement = container.children[0];
     if (mediaElement) {
       if (position) {
@@ -188,7 +233,7 @@ class MediaPlayer extends React.PureComponent<Props, State> {
         changeVolume(mediaElement.volume);
       });
       mediaElement.volume = volume;
-      mediaElement.addEventListener('dblclick', this.toggleFullScreen);
+      mediaElement.addEventListener('dblclick', this.handleDoubleClick);
     }
     // @endif
 

--- a/src/ui/component/fileViewer/view.jsx
+++ b/src/ui/component/fileViewer/view.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import analytics from 'analytics';
 import LoadingScreen from 'component/common/loading-screen';
 import PlayButton from './internal/play-button';
+import { requestFullscreen, exitFullscreen } from 'util/full-screen';
 
 const Player = React.lazy(() =>
   import(
@@ -153,18 +154,18 @@ class FileViewer extends React.PureComponent<Props> {
       // Otherwise it should be handle internally on the video player
       // or it will break the toggle fullscreen button
       if (!isPlayableType) {
-        this.container.current.webkitRequestFullScreen();
+        requestFullscreen(this.container.current);
       }
       // Request fullscreen mode for the video player
       // Don't use this with the new player
       // @if TARGET='app'
       else {
         const video = document.getElementsByTagName('video')[0];
-        video && video.webkitRequestFullscreen();
+        video && requestFullscreen(video);
       }
       // @endif
     } else {
-      document.webkitExitFullscreen();
+      exitFullscreen();
     }
   }
 

--- a/src/ui/component/fileViewer/view.jsx
+++ b/src/ui/component/fileViewer/view.jsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import analytics from 'analytics';
 import LoadingScreen from 'component/common/loading-screen';
 import PlayButton from './internal/play-button';
-import { requestFullscreen, exitFullscreen } from 'util/full-screen';
 
 const Player = React.lazy(() =>
   import(
@@ -14,7 +13,6 @@ const Player = React.lazy(() =>
   )
 );
 
-const F_KEYCODE = 70;
 const SPACE_BAR_KEYCODE = 32;
 
 type Props = {
@@ -54,6 +52,7 @@ type Props = {
   nsfw: boolean,
   thumbnail: ?string,
   isPlayableType: boolean,
+  viewerContainer: React.Ref,
 };
 
 class FileViewer extends React.PureComponent<Props> {
@@ -68,8 +67,6 @@ class FileViewer extends React.PureComponent<Props> {
     // Don't add these variables to state because we don't need to re-render when their values change
     (this: any).startTime = undefined;
     (this: any).playTime = undefined;
-
-    (this: any).container = React.createRef();
   }
 
   componentDidMount() {
@@ -138,34 +135,6 @@ class FileViewer extends React.PureComponent<Props> {
         event.preventDefault(); // prevent page scroll
         this.playContent();
       }
-
-      // Handle fullscreen shortcut key (f)
-      if (event.keyCode === F_KEYCODE) {
-        this.toggleFullscreen();
-      }
-    }
-  }
-
-  toggleFullscreen() {
-    const { isPlayableType } = this.props;
-
-    if (!document.webkitFullscreenElement) {
-      // Enter fullscreen mode if content is not playable
-      // Otherwise it should be handle internally on the video player
-      // or it will break the toggle fullscreen button
-      if (!isPlayableType) {
-        requestFullscreen(this.container.current);
-      }
-      // Request fullscreen mode for the video player
-      // Don't use this with the new player
-      // @if TARGET='app'
-      else {
-        const video = document.getElementsByTagName('video')[0];
-        video && requestFullscreen(video);
-      }
-      // @endif
-    } else {
-      exitFullscreen();
     }
   }
 
@@ -260,6 +229,8 @@ class FileViewer extends React.PureComponent<Props> {
       obscureNsfw,
       mediaType,
       insufficientCredits,
+      viewerContainer,
+      searchBarFocused,
       thumbnail,
       nsfw,
     } = this.props;
@@ -295,7 +266,7 @@ class FileViewer extends React.PureComponent<Props> {
     const layoverStyle = !shouldObscureNsfw && thumbnail ? { backgroundImage: `url("${thumbnail}")` } : {};
 
     return (
-      <div className={classnames('video', {}, className)} ref={this.container}>
+      <div className={classnames('video', {}, className)} ref={viewerContainer}>
         {isPlaying && (
           <div className="content__view">
             {!isReadyToPlay ? (
@@ -320,6 +291,8 @@ class FileViewer extends React.PureComponent<Props> {
                   onStartCb={this.onFileStartCb}
                   onFinishCb={this.onFileFinishCb}
                   playingUri={playingUri}
+                  searchBarFocused={searchBarFocused}
+                  viewerContainer={viewerContainer}
                 />
               </Suspense>
             )}

--- a/src/ui/constants/icons.js
+++ b/src/ui/constants/icons.js
@@ -41,6 +41,7 @@ export const ACCOUNT = 'User';
 export const SETTINGS = 'Settings';
 export const INVITE = 'Users';
 export const FILE = 'File';
+export const FULLSCREEN = 'Maximize';
 export const OPTIONS = 'Sliders';
 export const YES = 'ThumbsUp';
 export const NO = 'ThumbsDown';

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -157,6 +157,13 @@ ipcRenderer.on('window-is-focused', () => {
 ipcRenderer.on('devtools-is-opened', () => {
   doLogWarningConsoleMessage();
 });
+
+// Force exit mode for html5 fullscreen api
+// See: https://github.com/electron/electron/issues/18188
+remote.getCurrentWindow().on('leave-full-screen', event => {
+  document.webkitExitFullscreen();
+});
+
 // @endif
 
 document.addEventListener('dragover', event => {

--- a/src/ui/page/file/view.jsx
+++ b/src/ui/page/file/view.jsx
@@ -62,16 +62,21 @@ class FilePage extends React.Component<Props> {
     'application',
   ];
 
+  constructor(props: Props) {
+    super(props);
+    (this: any).viewerContainer = React.createRef();
+  }
+
   componentDidMount() {
     const {
       uri,
+      claim,
       fetchFileInfo,
       fetchCostInfo,
       setViewed,
       isSubscribed,
       claimIsMine,
       fetchViewCount,
-      claim,
     } = this.props;
 
     if (isSubscribed) {
@@ -198,11 +203,12 @@ class FilePage extends React.Component<Props> {
           )}
           {showFile && (
             <FileViewer
-              insufficientCredits={insufficientCredits}
-              className="content__embedded"
               uri={uri}
+              className="content__embedded"
               mediaType={mediaType}
               isPlayableType={isPlayableType}
+              viewerContainer={this.viewerContainer}
+              insufficientCredits={insufficientCredits}
             />
           )}
           {!showFile &&
@@ -288,7 +294,12 @@ class FilePage extends React.Component<Props> {
 
             <div className="media__action-group--large">
               <FileDownloadLink uri={uri} />
-              <FileActions uri={uri} claimId={claim.claim_id} showFullscreen={isPreviewType} />
+              <FileActions
+                uri={uri}
+                claimId={claim.claim_id}
+                showFullscreen={isPreviewType}
+                viewerContainer={this.viewerContainer}
+              />
             </div>
           </div>
 

--- a/src/ui/page/file/view.jsx
+++ b/src/ui/page/file/view.jsx
@@ -92,7 +92,9 @@ class FilePage extends React.Component<Props> {
     setViewed(uri);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  // This is now marked as a react lecacy method:
+  // https://reactjs.org/docs/react-component.html#unsafe_componentwillmount
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { fetchFileInfo, uri, setViewed } = this.props;
     // @if TARGET='app'
     if (nextProps.fileInfo === undefined) {
@@ -152,7 +154,9 @@ class FilePage extends React.Component<Props> {
     const shouldObscureThumbnail = obscureNsfw && nsfw;
     const fileName = fileInfo ? fileInfo.file_name : null;
     const mediaType = getMediaType(contentType, fileName);
-    const showFile = PLAYABLE_MEDIA_TYPES.includes(mediaType) || PREVIEW_MEDIA_TYPES.includes(mediaType);
+    const isPreviewType = PREVIEW_MEDIA_TYPES.includes(mediaType);
+    const isPlayableType = PLAYABLE_MEDIA_TYPES.includes(mediaType);
+    const showFile = isPlayableType || isPreviewType;
 
     const speechShareable =
       costInfo && costInfo.cost === 0 && contentType && ['video', 'image'].includes(contentType.split('/')[0]);
@@ -203,6 +207,7 @@ class FilePage extends React.Component<Props> {
               className="content__embedded"
               uri={uri}
               mediaType={mediaType}
+              isPlayableType={isPlayableType}
             />
           )}
           {!showFile &&
@@ -288,7 +293,7 @@ class FilePage extends React.Component<Props> {
 
             <div className="media__action-group--large">
               <FileDownloadLink uri={uri} />
-              <FileActions uri={uri} claimId={claim.claim_id} />
+              <FileActions uri={uri} claimId={claim.claim_id} showFullscreen={isPreviewType} />
             </div>
           </div>
 

--- a/src/ui/page/file/view.jsx
+++ b/src/ui/page/file/view.jsx
@@ -92,23 +92,8 @@ class FilePage extends React.Component<Props> {
     setViewed(uri);
   }
 
-  // This is now marked as a react lecacy method:
-  // https://reactjs.org/docs/react-component.html#unsafe_componentwillmount
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    const { fetchFileInfo, uri, setViewed } = this.props;
-    // @if TARGET='app'
-    if (nextProps.fileInfo === undefined) {
-      fetchFileInfo(uri);
-    }
-    // @endif
-
-    if (uri !== nextProps.uri) {
-      setViewed(nextProps.uri);
-    }
-  }
-
   componentDidUpdate(prevProps: Props) {
-    const { isSubscribed, claim, uri, fetchViewCount, claimIsMine } = this.props;
+    const { isSubscribed, claim, uri, fileInfo, setViewed, fetchViewCount, claimIsMine, fetchFileInfo } = this.props;
 
     if (!prevProps.isSubscribed && isSubscribed) {
       this.removeFromSubscriptionNotifications();
@@ -116,6 +101,16 @@ class FilePage extends React.Component<Props> {
 
     if (prevProps.uri !== uri && claimIsMine) {
       fetchViewCount(claim.claim_id);
+    }
+
+    // @if TARGET='app'
+    if (fileInfo === undefined) {
+      fetchFileInfo(uri);
+    }
+    // @endif
+
+    if (prevProps.uri !== uri) {
+      setViewed(uri);
     }
   }
 

--- a/src/ui/scss/component/_content.scss
+++ b/src/ui/scss/component/_content.scss
@@ -43,6 +43,11 @@
       cursor: pointer;
     }
   }
+
+  &:-webkit-full-screen {
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .content__empty {

--- a/src/ui/util/full-screen.js
+++ b/src/ui/util/full-screen.js
@@ -26,7 +26,8 @@ const getPrefix = () => {
 
 export const fullscreenElement = () => {
   const index = getPrefix();
-  return prefixes.fullscreenElement[index];
+  const prefix = prefixes.fullscreenElement[index];
+  return document[prefix];
 };
 
 export const requestFullscreen = elem => {

--- a/src/ui/util/full-screen.js
+++ b/src/ui/util/full-screen.js
@@ -1,9 +1,14 @@
+/*
+  Polyfill functions for the HTML5 fullscreen api:
+  https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API
+*/
+
 const prefixes = {
-  fullscreenElement: ['fullscreenElement', 'msFullscreenElement', 'mozFullScreenElement', 'webkitFullscreenElement'],
-  fullscreenEnabled: ['fullscreenEnabled', 'msFullscreenEnabled', 'mozFullScreenEnabled', 'webkitFullscreenEnabled'],
-  requestFullscreen: ['requestFullscreen', 'msRequestFullscreen', 'mozRequestFullScreen', 'webkitRequestFullscreen'],
   exitFullscreen: ['exitFullscreen', 'msExitFullscreen', 'mozCancelFullScreen', 'webkitExitFullscreen'],
   fullscreenChange: ['fullscreenChange', 'MSFullscreenChange', 'mozfullscreenchange', 'webkitfullscreenchange'],
+  fullscreenEnabled: ['fullscreenEnabled', 'msFullscreenEnabled', 'mozFullScreenEnabled', 'webkitFullscreenEnabled'],
+  fullscreenElement: ['fullscreenElement', 'msFullscreenElement', 'mozFullScreenElement', 'webkitFullscreenElement'],
+  requestFullscreen: ['requestFullscreen', 'msRequestFullscreen', 'mozRequestFullScreen', 'webkitRequestFullscreen'],
 };
 
 const getPrefix = () => {

--- a/src/ui/util/full-screen.js
+++ b/src/ui/util/full-screen.js
@@ -1,0 +1,43 @@
+const prefixes = {
+  fullscreenElement: ['fullscreenElement', 'msFullscreenElement', 'mozFullScreenElement', 'webkitFullscreenElement'],
+  fullscreenEnabled: ['fullscreenEnabled', 'msFullscreenEnabled', 'mozFullScreenEnabled', 'webkitFullscreenEnabled'],
+  requestFullscreen: ['requestFullscreen', 'msRequestFullscreen', 'mozRequestFullScreen', 'webkitRequestFullscreen'],
+  exitFullscreen: ['exitFullscreen', 'msExitFullscreen', 'mozCancelFullScreen', 'webkitExitFullscreen'],
+  fullscreenChange: ['fullscreenChange', 'MSFullscreenChange', 'mozfullscreenchange', 'webkitfullscreenchange'],
+};
+
+const getPrefix = () => {
+  let prefixIndex = 0;
+  // validate prefix
+  prefixes.fullscreenEnabled.some((prefix, index) => {
+    if (document[prefix] || document[prefix] === false) {
+      prefixIndex = index;
+      return true;
+    }
+  });
+  // prefix vendor index
+  return prefixIndex;
+};
+
+export const fullscreenElement = () => {
+  const index = getPrefix();
+  return prefixes.fullscreenElement[index];
+};
+
+export const requestFullscreen = elem => {
+  const index = getPrefix();
+  const prefix = prefixes.requestFullscreen[index];
+  elem[prefix] && elem[prefix]();
+};
+
+export const exitFullscreen = () => {
+  const index = getPrefix();
+  const prefix = prefixes.exitFullscreen[index];
+  document[prefix] && document[prefix]();
+};
+
+export const onFullscreenChange = (event, callback) => {
+  const index = getPrefix();
+  const prefix = prefixes.fullscreenChange[index];
+  document[`${event}EventListener`](prefix, callback, false);
+};


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
- Toggle video player on DoubleClick.
- Toggle fullscreen when pressing `f` #2159
- Can't exit full-screen from embedded content with key F11 #2514
- Full screen (f11) does not work for games (PDFs and images also) #2267
- Full screen Button Stops Working After Double Click #2392


## Changes
- New button to toggle full screen mode of viewer.
- New shorcut to toggle fullscreen mode of viewer ( key:` f ` ).
- Fullscreen mode for all type of files.

## Todo
- [x] Polyfill fullscreen api (only works in chrome ).

![fullscreen](https://user-images.githubusercontent.com/14793624/58378434-02595c00-7f51-11e9-9669-40bd179e6730.gif)
