### PR TITLE
reselect file for publish edits

### DIFF
--- a/src/ui/component/publishForm/view.jsx
+++ b/src/ui/component/publishForm/view.jsx
@@ -394,15 +394,16 @@ class PublishForm extends React.PureComponent<Props> {
               <header className="card__header">
                 <h2 className="card__title">{__('Thumbnail')}</h2>
                 <p className="card__subtitle">
-                  {uploadThumbnailStatus === THUMBNAIL_STATUSES.API_DOWN ? (
-                    __('Enter a URL for your thumbnail.')
-                  ) : (
-                    <React.Fragment>
-                      {__('Upload your thumbnail (.png/.jpg/.jpeg/.gif) to')}{' '}
-                      <Button button="link" label={__('spee.ch')} href="https://spee.ch/about" />.{' '}
-                      {__('Recommended size: 800x450 (16:9)')}
-                    </React.Fragment>
-                  )}
+                  {(uploadThumbnailStatus === undefined && __('You should reselect your file to choose a thumbnail')) ||
+                    (uploadThumbnailStatus === THUMBNAIL_STATUSES.API_DOWN ? (
+                      __('Enter a URL for your thumbnail.')
+                    ) : (
+                      <React.Fragment>
+                        {__('Upload your thumbnail (.png/.jpg/.jpeg/.gif) to')}{' '}
+                        <Button button="link" label={__('spee.ch')} href="https://spee.ch/about" />.{' '}
+                        {__('Recommended size: 800x450 (16:9)')}
+                      </React.Fragment>
+                    ))}
                 </p>
               </header>
 

--- a/src/ui/page/file/index.js
+++ b/src/ui/page/file/index.js
@@ -49,7 +49,7 @@ const perform = dispatch => ({
   fetchFileInfo: uri => dispatch(doFetchFileInfo(uri)),
   fetchCostInfo: uri => dispatch(doFetchCostInfoForUri(uri)),
   openModal: (modal, props) => dispatch(doOpenModal(modal, props)),
-  prepareEdit: (publishData, uri) => dispatch(doPrepareEdit(publishData, uri)),
+  prepareEdit: (publishData, uri, fileInfo) => dispatch(doPrepareEdit(publishData, uri, fileInfo)),
   setClientSetting: (key, value) => dispatch(doSetClientSetting(key, value)),
   setViewed: uri => dispatch(doSetContentHistoryItem(uri)),
   markSubscriptionRead: (channel, uri) => dispatch(doRemoveUnreadSubscription(channel, uri)),

--- a/src/ui/page/file/view.jsx
+++ b/src/ui/page/file/view.jsx
@@ -36,7 +36,7 @@ type Props = {
   isSubscribed: boolean,
   channelUri: string,
   viewCount: number,
-  prepareEdit: ({}, string) => void,
+  prepareEdit: ({}, string, {}) => void,
   openModal: (id: string, { uri: string }) => void,
   markSubscriptionRead: (string, string) => void,
   fetchViewCount: string => void,
@@ -268,7 +268,7 @@ class FilePage extends React.Component<Props> {
                   label={__('Edit')}
                   navigate="/$/publish"
                   onClick={() => {
-                    prepareEdit(claim, editUri);
+                    prepareEdit(claim, editUri, fileInfo);
                   }}
                 />
               )}

--- a/src/ui/redux/actions/publish.js
+++ b/src/ui/redux/actions/publish.js
@@ -137,7 +137,7 @@ export const doUploadThumbnail = (filePath: string, thumbnailBuffer: Uint8Array)
     .catch(err => uploadError(err.message));
 };
 
-export const doPrepareEdit = (claim: StreamClaim, uri: string) => (dispatch: Dispatch) => {
+export const doPrepareEdit = (claim: StreamClaim, uri: string, fileInfo: FileListItem) => (dispatch: Dispatch) => {
   const { name, amount, channel_name: channelName, value } = claim;
 
   const {
@@ -187,6 +187,15 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string) => (dispatch: Dis
     publishData.otherLicenseDescription = license;
   } else {
     publishData.licenseType = license;
+  }
+
+  if (fileInfo && fileInfo.download_path) {
+    try {
+      fs.accessSync(fileInfo.download_path, fs.constants.R_OK);
+      publishData.filePath = fileInfo.download_path;
+    } catch (e) {
+      console.error(e.name, e.message);
+    }
   }
 
   dispatch({ type: ACTIONS.DO_PREPARE_EDIT, data: publishData });


### PR DESCRIPTION
## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)

## PR Type

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: #2531 

## What is the new behavior?
clicking edit on fileview page, loads publish page with file source selected (in case file is accessible)
for edits issued from publish page (i.e naming claim to an existing claim and editing it) thumbnail section notes user (if no thumbnail exists) to re-select their file again.
