### PR TITLE
Fix back/forward navigation using dedicated mouse/keyboard buttons.

### DIFF
--- a/src/platforms/electron/createWindow.js
+++ b/src/platforms/electron/createWindow.js
@@ -88,10 +88,10 @@ export default appState => {
   window.on('app-command', (e, cmd) => {
     switch (cmd) {
       case 'browser-backward':
-        window.webContents.send('navigate-backward', null);
+        window.webContents.goBack();
         break;
       case 'browser-forward':
-        window.webContents.send('navigate-forward', null);
+        window.webContents.goForward();
         break;
       default: // Do nothing
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: none

## What is the current behavior?

The LBRY app does not navigate backward or forward when using the dedicated back/forward keyboard or mouse buttons.

## What is the new behavior?

Back/forward keyboard and mouse buttons cause the LBRY app to navigate backward/forward.

## Other information

The handlers for the 'navigate-backward' and 'navigate-forward' events introduced in #2250 look like they were removed at one point. So instead of firing those events upon receiving the back/forward app-command, I've rewritten it to call the window's WebContents goBack and goForward methods.

Tested on Windows 10 x64.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
