### PR TITLE
Copy path, open, and backup buttons for wallet on Help page

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@reach/rect": "^0.2.1",
     "@reach/tabs": "^0.1.5",
     "@types/three": "^0.93.1",
+    "adm-zip": "^0.4.13",
     "async-exit-hook": "^2.0.1",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",

--- a/src/ui/component/walletBackup/view.jsx
+++ b/src/ui/component/walletBackup/view.jsx
@@ -1,6 +1,9 @@
 // @flow
 import * as React from 'react';
+import { shell, clipboard, remote } from 'electron';
 import Button from 'component/button';
+import AdmZip from 'adm-zip';
+import path from 'path';
 
 type Props = {
   daemonSettings: {
@@ -8,7 +11,95 @@ type Props = {
   },
 };
 
-class WalletBackup extends React.PureComponent<Props> {
+type State = {
+  errorMessage: ?string,
+  successMessage: ?string,
+};
+
+class WalletBackup extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      errorMessage: null,
+      successMessage: null,
+    };
+  }
+
+  showErrorMessage(message: string) {
+    this.setState({ errorMessage: message });
+  }
+
+  showSuccessMessage(message: string) {
+    this.setState({ successMessage: message });
+  }
+
+  flashSuccessMessage(message: string, delay: ?number) {
+    delay = delay || 2000;
+    this.showSuccessMessage(message);
+    setTimeout(() => this.setState({ successMessage: null }), delay, { once: true });
+  }
+
+  clearMessages() {
+    this.setState({ errorMessage: null, successMessage: null });
+  }
+
+  backupWalletDir(lbryumWalletDir: ?string) {
+    this.clearMessages();
+
+    if (!lbryumWalletDir) {
+      this.showErrorMessage(__('No wallet folder was found.'));
+      return;
+    }
+
+    // Colon fails on Windows. Backups should be portable, so replace it on other platforms, too.
+    const filenameTime = new Date().toISOString().replace(/:/g, '-');
+
+    const outputFilename = [path.basename(lbryumWalletDir), '-', filenameTime, '.zip'].join('');
+
+    // Prefer placing backup in user's Downloads folder, then their home folder, and finally
+    // right next to the lbryum folder itself.
+    let outputDir = path.dirname(lbryumWalletDir);
+    if (remote && remote.app) {
+      outputDir = remote.app.getPath('downloads') || remote.app.getPath('home') || outputDir;
+    }
+
+    const outputPath = path.join(outputDir, outputFilename);
+
+    const zip = new AdmZip();
+
+    try {
+      zip.addLocalFolder(lbryumWalletDir);
+    } catch (err) {
+      console.error(err);
+      this.showErrorMessage(__('The wallet folder could not be added to the zip archive.'));
+      return;
+    }
+
+    try {
+      zip.writeZip(outputPath);
+    } catch (err) {
+      console.error(err);
+      this.showErrorMessage(__('There was a problem writing the zip archive to disk.'));
+      return;
+    }
+
+    this.showSuccessMessage(__('Saved zip archive to ' + outputPath));
+
+    shell.showItemInFolder(outputPath);
+  }
+
+  copyWalletDirToClipboard(lbryumWalletDir: ?string) {
+    this.clearMessages();
+
+    if (lbryumWalletDir) {
+      clipboard.writeText(lbryumWalletDir);
+      this.flashSuccessMessage(__('Copied path to clipboard.'));
+    } else {
+      this.showErrorMessage(__('No wallet folder was found.'));
+    }
+  }
+
   render() {
     const { daemonSettings } = this.props;
     const { wallet_dir: lbryumWalletDir } = daemonSettings;
@@ -55,6 +146,25 @@ class WalletBackup extends React.PureComponent<Props> {
                 <Button button="link" href="https://lbry.com/faq/how-to-backup-wallet" label={__('see this article')} />
                 .
               </p>
+              <p className={'card__message card__message--error' + (this.state.errorMessage ? '' : ' hidden')}>
+                {this.state.errorMessage}
+              </p>
+              <p className={'card__message card__message--success' + (this.state.successMessage ? '' : ' hidden')}>
+                {this.state.successMessage}
+              </p>
+              <div className="card__actions">
+                <Button
+                  button="primary"
+                  label={__('Copy Folder Path')}
+                  onClick={() => this.copyWalletDirToClipboard(lbryumWalletDir)}
+                />
+                <Button button="primary" label={__('Open Folder')} onClick={() => shell.openItem(lbryumWalletDir)} />
+                <Button
+                  button="primary"
+                  label={__('Create Backup')}
+                  onClick={() => this.backupWalletDir(lbryumWalletDir)}
+                />
+              </div>
             </div>
           </React.Fragment>
         )}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #1601 #1635 

## What is the current behavior?

## What is the new behavior?
There are buttons to copy the path of the lbryum folder to the clipboard, open that folder in the system's file manager, and create a backup zip archive of the folder's contents. The backup zip's filename includes a timestamp, and it gets placed (in order of preference) in the user's Downloads folder, in their home folder, or right next to the lbryum folder itself. Afterwards, the backup zip is shown in the system file manager at which point the user can choose what to do with it.
## Other information
The zipping functionality is provided by the `adm-zip` package, and it is unfortunately synchronous, locking the UI for a second or so. I initially tested the asynchronous `archiver` package but was unable to get it to work in Electron.

Similar to #1628 and #1638 which were closed but not merged. If desired, I could attempt to make the "copy path" functionality more in line with what was discussed in those PRs with a new CopyableInput component.

I hesitate to submit features unsolicited, so no worries if this isn't quite what you're looking for. My main goal with this work has been to learn more about Electron and freshen up on React, but I hope you find it useful.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
