### PR TITLE
Fix channel title and url overlay

### DIFF
--- a/src/ui/scss/component/_channel.scss
+++ b/src/ui/scss/component/_channel.scss
@@ -80,12 +80,15 @@ $metadata-z-index: 1;
   padding-left: calc(var(--channel-thumbnail-width) + var(--spacing-large));
   // padding-left: var(--spacing-large);
   padding-bottom: var(--spacing-medium);
+  min-width: 0;
 }
 
 .channel__title {
   font-size: 3rem;
   font-weight: 800;
-  margin-right: var(--spacing-large);
+  margin-right: var(--spacing-small);
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   // Quick hack to get this to work
   // We should have a generic style for "header with button next to it"
@@ -98,4 +101,5 @@ $metadata-z-index: 1;
   font-size: 1.2rem;
   margin-top: -0.25rem;
   color: rgba($lbry-white, 0.75);
+  margin-right: var(--spacing-large);
 }

--- a/src/ui/scss/component/_media.scss
+++ b/src/ui/scss/component/_media.scss
@@ -68,6 +68,7 @@
   font-size: 1.1rem;
   min-width: 0;
   margin-right: var(--spacing-small);
+  max-width: 100%;
 }
 
 .media__insufficient-credits {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2317

## What is the current behavior?

The channel Title and Url text was overlaying the card.

## What is the new behavior?

Add `...` to the end of long titles.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
I made a change as i've discussed on the dev-ux Discord channel.
