### PR TITLE
Enable modal enter

### DIFF
--- a/src/ui/component/walletSendTip/view.jsx
+++ b/src/ui/component/walletSendTip/view.jsx
@@ -95,6 +95,7 @@ class WalletSendTip extends React.PureComponent<Props, State> {
                 label={__('Send')}
                 disabled={isPending || tipError || !tipAmount}
                 onClick={this.handleSendButtonClicked}
+                type="submit"
               />
             }
             helper={

--- a/src/ui/modal/modalConfirmTransaction/view.jsx
+++ b/src/ui/modal/modalConfirmTransaction/view.jsx
@@ -26,8 +26,6 @@ class ModalConfirmTransaction extends React.PureComponent<Props> {
         title={__('Send LBC')}
         contentLabel={__('Confirm Transaction')}
         type="custom"
-        // confirmButtonLabel={__('Send')}
-        // onConfirmed={() => this.onConfirmed()}
         onAborted={closeModal}
       >
         <Form className="card__content" onSubmit={() => this.onConfirmed()}>
@@ -37,7 +35,7 @@ class ModalConfirmTransaction extends React.PureComponent<Props> {
           <blockquote>{address}</blockquote>
           <p>{__('Once the transaction is sent, it cannot be reversed.')}</p>
           <div className="card__actions">
-            <Button autoFocus button="primary" label={__('Send')} onClick={() => this.onConfirmed()} />
+            <Button type="submit" button="primary" label={__('Send')} onClick={() => this.onConfirmed()} />
             <Button button="link" label={__('Cancel')} onClick={closeModal} />
           </div>
         </Form>

--- a/src/ui/modal/modalConfirmTransaction/view.jsx
+++ b/src/ui/modal/modalConfirmTransaction/view.jsx
@@ -35,7 +35,7 @@ class ModalConfirmTransaction extends React.PureComponent<Props> {
           <blockquote>{address}</blockquote>
           <p>{__('Once the transaction is sent, it cannot be reversed.')}</p>
           <div className="card__actions">
-            <Button type="submit" button="primary" label={__('Send')} onClick={() => this.onConfirmed()} />
+            <Button autoFocus button="primary" label={__('Send')} onClick={() => this.onConfirmed()} />
             <Button button="link" label={__('Cancel')} onClick={closeModal} />
           </div>
         </Form>

--- a/src/ui/modal/modalConfirmTransaction/view.jsx
+++ b/src/ui/modal/modalConfirmTransaction/view.jsx
@@ -1,5 +1,7 @@
 // @flow
 import React from 'react';
+import Button from 'component/button';
+import { Form } from 'component/common/form';
 import { Modal } from 'modal/modal';
 
 type Props = {
@@ -23,18 +25,22 @@ class ModalConfirmTransaction extends React.PureComponent<Props> {
         isOpen
         title={__('Send LBC')}
         contentLabel={__('Confirm Transaction')}
-        type="confirm"
-        confirmButtonLabel={__('Send')}
-        onConfirmed={() => this.onConfirmed()}
+        type="custom"
+        // confirmButtonLabel={__('Send')}
+        // onConfirmed={() => this.onConfirmed()}
         onAborted={closeModal}
       >
-        <section className="card__content">
+        <Form className="card__content" onSubmit={() => this.onConfirmed()}>
           <p>{__('Sending: ')}</p>
           <blockquote>{amount} LBC</blockquote>
           <p>{__('To address: ')}</p>
           <blockquote>{address}</blockquote>
           <p>{__('Once the transaction is sent, it cannot be reversed.')}</p>
-        </section>
+          <div className="card__actions">
+            <Button autoFocus button="primary" label={__('Send')} onClick={() => this.onConfirmed()} />
+            <Button button="link" label={__('Cancel')} onClick={closeModal} />
+          </div>
+        </Form>
       </Modal>
     );
   }

--- a/src/ui/modal/modalRemoveFile/view.jsx
+++ b/src/ui/modal/modalRemoveFile/view.jsx
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
 import { Modal } from 'modal/modal';
-import { FormField } from 'component/common/form';
+import { Form, FormField } from 'component/common/form';
+import Button from 'component/button';
 import usePersistedState from 'util/use-persisted-state';
 
 type Props = {
@@ -23,22 +24,13 @@ function ModalRemoveFile(props: Props) {
   const outpoint = fileInfo ? fileInfo.outpoint : `${txid}:${nout}`;
 
   return (
-    <Modal
-      isOpen
-      title="Remove File"
-      contentLabel={__('Confirm File Remove')}
-      type="confirm"
-      confirmButtonLabel={__('Remove')}
-      confirmButtonDisabled={!deleteChecked && !abandonChecked}
-      onConfirmed={() => deleteFile(outpoint || '', deleteChecked, abandonChecked)}
-      onAborted={closeModal}
-    >
+    <Modal isOpen title="Remove File" contentLabel={__('Confirm File Remove')} type="custom" onAborted={closeModal}>
       <section className="card__content">
         <p>
           {__("Are you sure you'd like to remove")} <cite>{`"${title}"`}</cite> {__('from the LBRY app?')}
         </p>
       </section>
-      <section className="card__content">
+      <Form className="card__content" onSubmit={() => deleteFile(outpoint || '', deleteChecked, abandonChecked)}>
         <FormField
           name="file_delete"
           label={__('Also delete this file from my computer')}
@@ -56,7 +48,17 @@ function ModalRemoveFile(props: Props) {
             onChange={() => setAbandonChecked(!abandonChecked)}
           />
         )}
-      </section>
+        <div className="card__actions">
+          <Button
+            autoFocus
+            button="primary"
+            label={__('OK')}
+            disabled={!deleteChecked && !abandonChecked}
+            onClick={() => deleteFile(outpoint || '', deleteChecked, abandonChecked)}
+          />
+          <Button button="link" label={__('Cancel')} onClick={closeModal} />
+        </div>
+      </Form>
     </Modal>
   );
 }

--- a/src/ui/modal/modalWalletEncrypt/view.jsx
+++ b/src/ui/modal/modalWalletEncrypt/view.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { Form, FormField } from 'component/common/form';
+import { Form, FormField, Submit } from 'component/common/form';
 import { Modal } from 'modal/modal';
 import Button from 'component/button';
 
@@ -94,9 +94,7 @@ class ModalWalletEncrypt extends React.PureComponent<Props, State> {
         isOpen
         title={__('Encrypt Wallet')}
         contentLabel={__('Encrypt Wallet')}
-        type="confirm"
-        confirmButtonLabel={__('Encrypt Wallet')}
-        abortButtonLabel={__('Cancel')}
+        type="custom"
         onConfirmed={() => this.submitEncryptForm()}
         onAborted={closeModal}
       >
@@ -135,6 +133,7 @@ class ModalWalletEncrypt extends React.PureComponent<Props, State> {
             )}
           </div>
           <FormField
+            inputButton={<Submit label={failMessage ? __('Encrypting Wallet') : __('Encrypt Wallet')} />}
             error={understandError === true ? 'You must enter "I understand"' : false}
             label={__('Enter "I understand"')}
             placeholder={__('Dear computer, I understand')}
@@ -144,6 +143,9 @@ class ModalWalletEncrypt extends React.PureComponent<Props, State> {
           />
           {failMessage && <div className="error-text">{__(failMessage)}</div>}
         </Form>
+        <div className="card__actions">
+          <Button button="link" label={__('Cancel')} onClick={closeModal} />
+        </div>
       </Modal>
     );
   }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2312 

## What is the current behavior?
.

## What is the new behavior?
The modal of send tips, encrypt wallet, transaction confirmation, and remove/delete file are now enterable.
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
