### PR TITLE
Fix automatic dark mode.

### DIFF
--- a/src/ui/page/settings/view.jsx
+++ b/src/ui/page/settings/view.jsx
@@ -153,7 +153,6 @@ class SettingsPage extends React.PureComponent<Props, State> {
     } = this.props;
 
     const noDaemonSettings = !daemonSettings || Object.keys(daemonSettings).length === 0;
-    const isDarkModeEnabled = currentTheme === 'dark';
 
     const defaultMaxKeyFee = { currency: 'USD', amount: 50 };
     const disableMaxKeyFee = !(daemonSettings && daemonSettings.max_key_fee);
@@ -350,7 +349,6 @@ class SettingsPage extends React.PureComponent<Props, State> {
                     name="automatic_dark_mode"
                     onChange={() => this.onAutomaticDarkModeChange(!automaticDarkModeEnabled)}
                     checked={automaticDarkModeEnabled}
-                    disabled={isDarkModeEnabled}
                     label={__('Automatic dark mode (9pm to 8am)')}
                   />
                 </fieldset-section>


### PR DESCRIPTION
Fixes issue #2334 

## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2334 

## What is the current behavior?
Automatic dark mode can't turn on unless light mode is chosen first. 
## What is the new behavior?
be able to set that option regardless of the selected theme. If it is selected, it should not allow the theme to be changed.

