### PR TITLE
Adds icon to unsubscribe from side bar

### DIFF
--- a/src/ui/component/sideBar/view.jsx
+++ b/src/ui/component/sideBar/view.jsx
@@ -1,4 +1,5 @@
 // @flow
+import SubscribeButton from 'component/subscribeButton';
 import * as PAGES from 'constants/pages';
 import * as ICONS from 'constants/icons';
 import React from 'react';
@@ -56,12 +57,15 @@ function SideBar(props: Props) {
         <ul className="navigation__links--small">
           {subscriptions.map(({ uri, channelName }, index) => (
             <li key={uri} className="">
-              <Button
-                navigate={uri}
-                label={channelName}
-                className="navigation__link"
-                activeClass="navigation__link--active"
-              />
+              <div className="card__actions">
+                <SubscribeButton uri={uri} mini />
+                <Button
+                  navigate={uri}
+                  label={channelName}
+                  className="navigation__link"
+                  activeClass="navigation__link--active"
+                />
+              </div>
             </li>
           ))}
         </ul>

--- a/src/ui/component/subscribeButton/view.jsx
+++ b/src/ui/component/subscribeButton/view.jsx
@@ -20,6 +20,7 @@ type Props = {
   doOpenModal: (id: string) => void,
   showSnackBarOnSubscribe: boolean,
   doToast: ({ message: string }) => void,
+  mini: Boolean,
 };
 
 export default function SubscribeButton(props: Props) {
@@ -32,6 +33,7 @@ export default function SubscribeButton(props: Props) {
     isSubscribed,
     showSnackBarOnSubscribe,
     doToast,
+    mini,
   } = props;
   const buttonRef = useRef();
   const isHovering = useHover(buttonRef);
@@ -46,7 +48,7 @@ export default function SubscribeButton(props: Props) {
       iconColor="red"
       icon={unfollowOverride ? ICONS.UNSUBSCRIBE : ICONS.SUBSCRIBE}
       button={'alt'}
-      label={unfollowOverride || subscriptionLabel}
+      label={mini ? null : unfollowOverride || subscriptionLabel}
       onClick={e => {
         e.stopPropagation();
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
#1396
I know this is closed, but I think its a great stop gap solution until #1394 is finished. It allows users to quickly prune their subscriptions. It should also allow you to unsubscribe from deleted channels (which I think @eggplantbren mentioned was an issue). It might even be better than #1394, because it keeps things simple for the end user, and I'm not sure how useful editing and tipping without entering the claim would be compared to the complexity cost to the user.

## What is the current behavior?
No unsubscribe button next to the list of subscribers.
## What is the new behavior?
Unsubscribe button next to the list of subscribers. It looks like this 
![image](https://user-images.githubusercontent.com/19354425/61936058-23d2c600-af49-11e9-9c95-482df5d5fab6.png)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
