### PR TITLE
maint: electron builder update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - os: osx
       env: TARGET=mac
-      osx_image: xcode9.2
+      osx_image: xcode10
       language: node_js
       node_js: '10'
     - os: linux

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@reach/tooltip": "^0.2.1",
     "electron-dl": "^1.11.0",
     "electron-log": "^2.2.12",
-    "electron-updater": "^4.0.6",
+    "electron-updater": "^4.1.2",
     "express": "^4.16.4",
     "keytar": "^4.4.1",
     "tiny-relative-date": "^1.3.0"
@@ -95,7 +95,7 @@
     "devtron": "^1.4.0",
     "dom-scroll-into-view": "^1.2.1",
     "electron": "4.1.0",
-    "electron-builder": "^20.41.0",
+    "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-is-dev": "^0.3.0",
     "electron-publisher-s3": "^20.8.1",


### PR DESCRIPTION
This fixes https://github.com/lbryio/lbry-desktop/issues/1192, the bug where the SDK would not get terminated if the installer was run while the app was running. Also tested app build on Mac 10.13.6 (xcode 10) which is required now for code signing (https://github.com/electron-userland/electron-builder/releases/tag/v21.0.10). Per Julie, works fine with 10.12.5 OSX, which is good. Will confirm signing is working correctly. 
