### PR TITLE
Remove unused dependency jsmediatags

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "hast-util-sanitize": "^1.1.2",
     "history": "^4.9.0",
     "husky": "^0.14.3",
-    "jsmediatags": "^3.8.1",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
     "lbry-redux": "lbryio/lbry-redux#1af092ce2cb507d9a41711b864874c0bd76935ae",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6572,13 +6572,6 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-jsmediatags@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/jsmediatags/-/jsmediatags-3.8.1.tgz#e27d26e957b0b330c28f9762c82940c4dcc64720"
-  integrity sha512-ZI4P8J0gDiM9BgkTC0QbPARFkWaFscGAJKnpL/UK2Xeux026R5ytChvx4OJAn7kxoYFqpVUeSTEToBVe+K4yhQ==
-  dependencies:
-    xhr2 "^0.1.4"
-
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -12415,11 +12408,6 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
-
-xhr2@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.1.4.tgz#7f87658847716db5026323812f818cadab387a5f"
-  integrity sha1-f4dliEdxbbUCYyOBL4GMras4el8=
 
 xhr@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
I was checking if I could use [music-metadata-browser](https://github.com/Borewit/music-metadata-browser) with the audio-viewer, but I noticed it has been removed. 

Therefor this dependency is no longer required: jsmediatags

Related PR: #2447 