### PR TITLE
copyableInput no longer uses electron clipboard

### DIFF
--- a/src/ui/component/copyableText/view.jsx
+++ b/src/ui/component/copyableText/view.jsx
@@ -1,7 +1,6 @@
 // @flow
 import * as ICONS from 'constants/icons';
 import * as React from 'react';
-import { clipboard } from 'electron';
 import { FormField } from 'component/common/form';
 import Button from 'component/button';
 
@@ -18,9 +17,18 @@ export default class CopyableText extends React.PureComponent<Props> {
 
     this.input = React.createRef();
     (this: any).onFocus = this.onFocus.bind(this);
+    (this: any).copyToClipboard = this.copyToClipboard.bind(this);
   }
 
   input: { current: React.ElementRef<any> };
+
+  copyToClipboard() {
+    const topRef = this.input.current;
+    if (topRef && topRef.input && topRef.input.current) {
+      topRef.input.current.select();
+    }
+    document.execCommand('copy');
+  }
 
   onFocus() {
     // We have to go a layer deep since the input is inside the form component
@@ -47,7 +55,7 @@ export default class CopyableText extends React.PureComponent<Props> {
             button="inverse"
             icon={ICONS.COPY}
             onClick={() => {
-              clipboard.writeText(copyable);
+              this.copyToClipboard();
               doToast({
                 message: snackMessage || __('Text copied'),
               });

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -638,5 +638,15 @@
   "For more details on backing up and best practices": "For more details on backing up and best practices",
   "File Size": "File Size",
   "You deposited 1 LBC as a support!": "You deposited 1 LBC as a support!",
-  "Refreshed!": "Refreshed!"
+  "Refreshed!": "Refreshed!",
+  "Starting...": "Starting...",
+  "Spin Spin Sugar": "Spin Spin Sugar",
+  "You're not following any channels.": "You're not following any channels.",
+  "Look what's trending for everyone": "Look what's trending for everyone",
+  "or": "or",
+  "Discover some channels!": "Discover some channels!",
+  "Trending": "Trending",
+  "Top": "Top",
+  "New": "New",
+  "Loading": "Loading"
 }


### PR DESCRIPTION
This works well enough for copyableInput since it's an input field.
The same strategy doesn't work for ClaimURI which is a button, so you apparently can't buttonRef.current.select() it.
So that component still uses electron clipboard.