### PR TITLE
[WIP] Revive old audio viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "if-env": "^1.0.4",
     "keytar": "^4.4.1",
     "mysql": "^2.17.1",
-    "nodemon": "^1.19.1"
+    "nodemon": "^1.19.1",
+    "music-metadata-browser": "^1.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/ui/component/fileRender/view.jsx
+++ b/src/ui/component/fileRender/view.jsx
@@ -8,6 +8,14 @@ import AppViewer from 'component/viewers/appViewer';
 import path from 'path';
 import fs from 'fs';
 
+// This is half complete, the video viewer works fine for audio, it just doesn't look pretty
+const AudioViewer = React.lazy<*>(() =>
+  import(
+    /* webpackChunkName: "audioViewer" */
+    'component/viewers/audioViewer'
+  )
+);
+
 const DocumentViewer = React.lazy<*>(() =>
   import(
     /* webpackChunkName: "documentViewer" */
@@ -112,7 +120,7 @@ class FileRender extends React.PureComponent<Props> {
       // @endif
 
       video: <VideoViewer uri={uri} source={source} contentType={contentType} />,
-      audio: <VideoViewer uri={uri} source={source} contentType={contentType} />,
+      audio: <AudioViewer uri={uri} source={source} contentType={contentType} />,
       image: <ImageViewer uri={uri} source={source} />,
       // Add routes to viewer...
     };

--- a/src/ui/component/viewers/audioViewer.jsx
+++ b/src/ui/component/viewers/audioViewer.jsx
@@ -13,21 +13,6 @@ import styles from './audioViewer.module.scss';
 
 const isButterchurnSupported = detectButterchurnSupport();
 
-const EQ_BANDS_SIMPLE = [55, 150, 250, 400, 500, 1000, 2000, 4000, 8000, 16000];
-/*
-const EQ_LOWSHELF = EQ_BANDS_SIMPLE.shift();
-const EQ_HIGHSHELF = EQ_BANDS_SIMPLE.pop();
-
-const eqFilters = EQ.map(function(band) {
-            var filter = wavesurfer.backend.ac.createBiquadFilter();
-            filter.type = 'peaking';
-            filter.gain.value = 0;
-            filter.Q.value = 1;
-            filter.frequency.value = band.f;
-            return filter;
-        });
-*/
-
 type Props = {
   source: {
     url: string,

--- a/src/ui/component/viewers/audioViewer.jsx
+++ b/src/ui/component/viewers/audioViewer.jsx
@@ -77,6 +77,8 @@ class AudioVideoViewer extends React.PureComponent {
 
     const audioNode = this.audioNode;
 
+    this.audioNode.src = source;
+
     audioNode.crossOrigin = 'anonymous';
     audioNode.autostart = true;
 
@@ -129,7 +131,7 @@ class AudioVideoViewer extends React.PureComponent {
 
     wavesurfer.load(audioNode);
 
-    console.log('parsing: "' + source + '"');
+    this.audioNode.play();
 
     musicMetadata
       .fetchFromUrl(source)
@@ -150,6 +152,7 @@ class AudioVideoViewer extends React.PureComponent {
           artist,
           title,
         });
+
       })
       .catch(error => {
         console.log(':(', error.type, error.info);
@@ -283,7 +286,6 @@ class AudioVideoViewer extends React.PureComponent {
         />
         <audio
           ref={node => (this.audioNode = node)}
-          src={source}
           style={{ position: 'absolute', top: '-100px' }}
           onPlay={() => this.setState({ playing: true })}
           onPause={() => this.setState({ playing: false })}

--- a/src/ui/component/viewers/audioViewer.jsx
+++ b/src/ui/component/viewers/audioViewer.jsx
@@ -72,8 +72,7 @@ class AudioVideoViewer extends React.PureComponent {
   }
 
   componentDidMount() {
-    const me = this;
-    const { source } = me.props;
+    const { source } = this.props;
 
     const audioNode = this.audioNode;
 
@@ -82,12 +81,12 @@ class AudioVideoViewer extends React.PureComponent {
     audioNode.crossOrigin = 'anonymous';
     audioNode.autostart = true;
 
-    const canvasHeight = me.canvasNode.offsetHeight;
-    const canvasWidth = me.canvasNode.offsetWidth;
+    const canvasHeight = this.canvasNode.offsetHeight;
+    const canvasWidth = this.canvasNode.offsetWidth;
 
     // Required for canvas, nuance of rendering
-    me.canvasNode.height = canvasHeight;
-    me.canvasNode.width = canvasWidth;
+    this.canvasNode.height = canvasHeight;
+    this.canvasNode.width = canvasWidth;
 
     const AudioContext = window.AudioContext || window.webkitAudioContext;
     const audioContext = new AudioContext();
@@ -96,7 +95,7 @@ class AudioVideoViewer extends React.PureComponent {
     audioSource.connect(audioContext.destination);
 
     if (isButterchurnSupported) {
-      const visualizer = (me.visualizer = butterchurn.createVisualizer(audioContext, me.canvasNode, {
+      const visualizer = (this.visualizer = butterchurn.createVisualizer(audioContext, this.canvasNode, {
         height: canvasHeight,
         width: canvasWidth,
         pixelRatio: window.devicePixelRatio || 1,
@@ -106,14 +105,14 @@ class AudioVideoViewer extends React.PureComponent {
       visualizer.connectAudio(audioSource);
       visualizer.loadPreset(presets[Math.floor(Math.random() * presets.length)], 2.0);
 
-      me._frameCycle = () => {
-        requestAnimationFrame(me._frameCycle);
+      this._frameCycle = () => {
+        requestAnimationFrame(this._frameCycle);
 
-        if (me.state.enableMilkdrop === true) {
+        if (this.state.enableMilkdrop === true) {
           visualizer.render();
         }
       };
-      me._frameCycle();
+      this._frameCycle();
     }
 
     const wavesurfer = WaveSurfer.create({
@@ -142,12 +141,12 @@ class AudioVideoViewer extends React.PureComponent {
           const cover = picture[0]; // ToDo: select cover smart
           const byteArray = new Uint8Array(cover.data);
           const blob = new Blob([byteArray], { type: cover.format });
-          me.artNode.src = URL.createObjectURL(blob);
+          this.artNode.src = URL.createObjectURL(blob);
 
-          me.setState({ artLoaded: true });
+          this.setState({ artLoaded: true });
         }
 
-        me.setState({
+        this.setState({
           album,
           artist,
           title,
@@ -177,8 +176,7 @@ class AudioVideoViewer extends React.PureComponent {
   };
 
   render() {
-    const me = this;
-    const { contentType, poster, claim, source } = me.props;
+    const { contentType, poster, claim, source } = this.props;
     const {
       album,
       artist,
@@ -204,8 +202,8 @@ class AudioVideoViewer extends React.PureComponent {
     return (
       <div
         className={userActive ? styles.userActive : styles.wrapper}
-        onMouseEnter={() => me.setState({ userActive: true })}
-        onMouseLeave={() => me.setState({ userActive: false })}
+        onMouseEnter={() => this.setState({ userActive: true })}
+        onMouseLeave={() => this.setState({ userActive: false })}
         onContextMenu={stopContextMenu}
       >
         <div className={enableMilkdrop ? styles.containerWithMilkdrop : styles.container}>

--- a/src/ui/component/viewers/audioViewer.jsx
+++ b/src/ui/component/viewers/audioViewer.jsx
@@ -1,0 +1,296 @@
+// @flow
+import React from 'react';
+import * as ICONS from 'constants/icons';
+import Button from 'component/button';
+import Tooltip from 'component/common/tooltip';
+import { stopContextMenu } from 'util/context-menu';
+import butterchurn from 'butterchurn';
+import detectButterchurnSupport from 'butterchurn/lib/isSupported.min';
+import * as musicMetadata from 'music-metadata-browser';
+import WaveSurfer from 'wavesurfer.js';
+
+import styles from './audioViewer.module.scss';
+
+const isButterchurnSupported = detectButterchurnSupport();
+
+const EQ_BANDS_SIMPLE = [55, 150, 250, 400, 500, 1000, 2000, 4000, 8000, 16000];
+/*
+const EQ_LOWSHELF = EQ_BANDS_SIMPLE.shift();
+const EQ_HIGHSHELF = EQ_BANDS_SIMPLE.pop();
+
+const eqFilters = EQ.map(function(band) {
+            var filter = wavesurfer.backend.ac.createBiquadFilter();
+            filter.type = 'peaking';
+            filter.gain.value = 0;
+            filter.Q.value = 1;
+            filter.frequency.value = band.f;
+            return filter;
+        });
+*/
+
+type Props = {
+  source: {
+    url: string,
+    stream: string => void,
+    downloadCompleted: string,
+    downloadPath: string,
+    status: string,
+  },
+  contentType: string,
+  poster?: string,
+  claim: StreamClaim,
+};
+
+const presets = [
+  require('butterchurn-presets/presets/converted/Flexi - when monopolies were the future [simple warp + non-reactive moebius].json'),
+  require('butterchurn-presets/presets/converted/Rovastar & Loadus - FractalDrop (Active Sparks Mix).json'),
+  require('butterchurn-presets/presets/converted/shifter - tumbling cubes (ripples).json'),
+  require('butterchurn-presets/presets/converted/ORB - Blue Emotion.json'),
+  require('butterchurn-presets/presets/converted/shifter - urchin mod.json'),
+  require('butterchurn-presets/presets/converted/Stahlregen & fishbrain + flexi + geiss - The Machine that conquered the Aether.json'),
+  require('butterchurn-presets/presets/converted/Zylot - Crosshair Dimension (Light of Ages).json'),
+];
+
+class AudioVideoViewer extends React.PureComponent {
+  // audioNode: ?HTMLAudioElement;
+  // player: ?{ dispose: () => void };
+
+  state = {
+    playing: false,
+    enableMilkdrop: isButterchurnSupported,
+    showEqualizer: false,
+    showSongDetails: true,
+    enableArt: true,
+    artLoaded: false,
+    artist: null,
+    title: null,
+    album: null,
+  };
+
+  constructor(props: Props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    const me = this;
+    const { source } = me.props;
+
+    const audioNode = this.audioNode;
+
+    audioNode.crossOrigin = 'anonymous';
+    audioNode.autostart = true;
+
+    const canvasHeight = me.canvasNode.offsetHeight;
+    const canvasWidth = me.canvasNode.offsetWidth;
+
+    // Required for canvas, nuance of rendering
+    me.canvasNode.height = canvasHeight;
+    me.canvasNode.width = canvasWidth;
+
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const audioContext = new AudioContext();
+
+    const audioSource = audioContext.createMediaElementSource(audioNode);
+    audioSource.connect(audioContext.destination);
+
+    if (isButterchurnSupported) {
+      const visualizer = (me.visualizer = butterchurn.createVisualizer(audioContext, me.canvasNode, {
+        height: canvasHeight,
+        width: canvasWidth,
+        pixelRatio: window.devicePixelRatio || 1,
+        textureRatio: 1,
+      }));
+
+      visualizer.connectAudio(audioSource);
+      visualizer.loadPreset(presets[Math.floor(Math.random() * presets.length)], 2.0);
+
+      me._frameCycle = () => {
+        requestAnimationFrame(me._frameCycle);
+
+        if (me.state.enableMilkdrop === true) {
+          visualizer.render();
+        }
+      };
+      me._frameCycle();
+    }
+
+    const wavesurfer = WaveSurfer.create({
+      barWidth: 3,
+      container: this.waveNode,
+      waveColor: '#000',
+      progressColor: '#fff',
+      mediaControls: true,
+      responsive: true,
+      normalize: true,
+      backend: 'MediaElement',
+      minPxPerSec: 100,
+      height: this.waveNode.offsetHeight,
+    });
+
+    wavesurfer.load(audioNode);
+
+    console.log('parsing: "' + source + '"');
+
+    musicMetadata
+      .fetchFromUrl(source)
+      .then(metadata => {
+        const { album, artist, title, picture } = metadata.common;
+
+        if (picture && picture.length >= 1) {
+          const cover = picture[0]; // ToDo: select cover smart
+          const byteArray = new Uint8Array(cover.data);
+          const blob = new Blob([byteArray], { type: cover.format });
+          me.artNode.src = URL.createObjectURL(blob);
+
+          me.setState({ artLoaded: true });
+        }
+
+        me.setState({
+          album,
+          artist,
+          title,
+        });
+      })
+      .catch(error => {
+        console.log(':(', error.type, error.info);
+      });
+  }
+
+  componentWillUnmount() {
+    if (this.player) {
+      this.player.dispose();
+    }
+
+    // Kill the render loop
+    this._frameCycle = () => {};
+  }
+
+  handleClickPlay = () =>  {
+    if (this.audioNode.paused) {
+      this.audioNode.play();
+    } else {
+      this.audioNode.pause();
+    }
+  };
+
+  render() {
+    const me = this;
+    const { contentType, poster, claim, source } = me.props;
+    const {
+      album,
+      artist,
+      title,
+      enableMilkdrop,
+      showEqualizer,
+      showSongDetails,
+      enableArt,
+      artLoaded,
+      playing,
+      userActive,
+    } = this.state;
+
+    const renderArt = enableArt && artLoaded;
+
+    const playButton = (
+      <div
+        onClick={this.handleClickPlay}
+        className={playing ? styles.playButtonPause : styles.playButtonPlay}
+      />
+    );
+
+    return (
+      <div
+        className={userActive ? styles.userActive : styles.wrapper}
+        onMouseEnter={() => me.setState({ userActive: true })}
+        onMouseLeave={() => me.setState({ userActive: false })}
+        onContextMenu={stopContextMenu}
+      >
+        <div className={enableMilkdrop ? styles.containerWithMilkdrop : styles.container}>
+          <div style={{ position: 'absolute', top: 0, right: 0 }}>
+            <Tooltip onComponent body={__('Toggle Visualizer')}>
+              <Button
+                icon={enableMilkdrop ? ICONS.VISUALIZER_ON : ICONS.VISUALIZER_OFF}
+                onClick={() => {
+                  if (!isButterchurnSupported) {
+                    return;
+                  }
+
+                  // Get new preset
+                  this.visualizer.loadPreset(presets[Math.floor(Math.random() * presets.length)], 2.0);
+
+                  this.setState({ enableMilkdrop: !enableMilkdrop });
+                }}
+              />
+            </Tooltip>
+            <Tooltip onComponent body={__('Toggle Album Art')}>
+              <Button
+                icon={enableArt ? ICONS.MUSIC_ART_ON : ICONS.MUSIC_ART_OFF}
+                onClick={() => this.setState({ enableArt: !enableArt })}
+              />
+            </Tooltip>
+            <Tooltip onComponent body={__('Toggle Details')}>
+              <Button
+                icon={showSongDetails ? ICONS.MUSIC_DETAILS_ON : ICONS.MUSIC_DETAILS_OFF}
+                onClick={() => this.setState({ showSongDetails: !showSongDetails })}
+              />
+            </Tooltip>
+            <Tooltip onComponent body={__('Equalizer')}>
+              <Button icon={ICONS.MUSIC_EQUALIZER} onClick={() => this.setState({ showEqualizer: !showEqualizer })} />
+            </Tooltip>
+          </div>
+          <div ref={node => (this.waveNode = node)} className={styles.wave} />
+          <div className={styles.infoContainer}>
+            <div className={renderArt ? styles.infoArtContainer : styles.infoArtContainerHidden}>
+              <img className={styles.infoArtImage} ref={node => (this.artNode = node)} />
+              {renderArt && playButton}
+            </div>
+            <div
+              className={
+                showSongDetails
+                  ? renderArt
+                    ? styles.songDetailsContainer
+                    : styles.songDetailsContainerNoArt
+                  : styles.songDetailsContainerHidden
+              }
+            >
+              <div className={renderArt ? styles.songDetails : styles.songDetailsNoArt}>
+                {artist && (
+                  <div className={styles.detailsLineArtist}>
+                    <Button icon={ICONS.MUSIC_ARTIST} className={styles.detailsIconArtist} />
+                    {artist}
+                  </div>
+                )}
+                {title && (
+                  <div className={styles.detailsLineSong}>
+                    <Button icon={ICONS.MUSIC_SONG} className={styles.detailsIconSong} />
+                    {title}
+                  </div>
+                )}
+                {album && (
+                  <div className={styles.detailsLineAlbum}>
+                    <Button icon={ICONS.MUSIC_ALBUM} className={styles.detailsIconAlbum} />
+                    {album}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+          {!renderArt && <div className={styles.playButtonDetachedContainer}>{playButton}</div>}
+        </div>
+        <canvas
+          ref={node => (this.canvasNode = node)}
+          className={enableMilkdrop ? styles.milkdrop : styles.milkdropDisabled}
+        />
+        <audio
+          ref={node => (this.audioNode = node)}
+          src={source}
+          style={{ position: 'absolute', top: '-100px' }}
+          onPlay={() => this.setState({ playing: true })}
+          onPause={() => this.setState({ playing: false })}
+        />
+      </div>
+    );
+  }
+}
+
+export default AudioVideoViewer;

--- a/src/ui/component/viewers/audioViewer.module.scss
+++ b/src/ui/component/viewers/audioViewer.module.scss
@@ -1,0 +1,193 @@
+.wrapper {
+  composes: 'file-render__viewer' from global;
+}
+
+.userActive {
+  composes: wrapper;
+}
+
+.container {
+  background: #212529;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  display: flex;
+}
+
+.containerWithMilkdrop {
+  composes: container;
+
+  background: rgba(50, 50, 55, 0.7);
+}
+
+.wave {
+  position: absolute;
+  bottom: -20%;
+  height: 40%;
+  opacity: 0.5;
+  overflow: hidden;
+  width: 100%;
+}
+
+.infoContainer {
+  padding: 0 20%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42%;
+  align-self: center;
+  width: 100%;
+  margin-top: -10%;
+}
+
+.infoArtContainer {
+  align-self: flex-start;
+  width: 40%;
+  float: left;
+  position: relative;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.infoArtContainerHidden {
+  display: none;
+}
+
+.infoArtImage {
+  display: block;
+  opacity: 1;
+  transition: opacity 0.7s;
+
+  .userActive & {
+    opacity: 0.2;
+  }
+}
+
+.songDetailsContainer {
+  text-align: left;
+  padding: 3%;
+  width: 50%;
+}
+
+.songDetailsContainerHidden {
+  display: none;
+}
+
+.songDetailsContainerNoArt {
+  composes: songDetailsContainer;
+
+  text-align: center;
+}
+
+.songDetails {
+  width: 150%;
+  text-shadow: 2px 2px 3px #000;
+}
+
+.songDetailsNoArt {
+  composes: songDetails;
+
+  width: 200%;
+  margin-left: -50%;
+}
+
+.detailsIcon {
+  color: rgba(255, 255, 255, 0.5);
+  top: -3px;
+  padding-right: 10px;
+  width: 30px;
+}
+
+.detailsIconArtist {
+  composes: detailsIcon;
+
+  top: -3px;
+}
+
+.detailsIconSong {
+  composes: detailsIcon;
+
+  top: -5px;
+}
+
+.detailsIconAlbum {
+  composes: detailsIcon;
+}
+
+.detailsLineArtist {
+  font-size: 26px;
+  padding-bottom: 5px;
+}
+
+.detailsLineSong {
+  font-size: 34px;
+  line-height: 36px;
+}
+
+.detailsLineAlbum {
+  font-size: 20px;
+  padding-top: 8px;
+}
+
+.playButton {
+  position: absolute;
+  border: 5px solid #fff;
+  border-radius: 45px;
+  color: #fff;
+  font-family: arial;
+  font-size: 60px;
+  left: 50%;
+  line-height: 80px;
+  margin-left: -45px;
+  padding-left: 20px;
+  bottom: 50%;
+  margin-bottom: -45px;
+  height: 90px;
+  width: 90px;
+  opacity: 0;
+  transition: opacity 0.7s;
+
+  .userActive & {
+    opacity: 0.6;
+  }
+}
+
+.playButtonPlay {
+  composes: playButton;
+
+  &::after {
+    display: block;
+    content: '▶';
+  }
+}
+
+.playButtonPause {
+  composes: playButton;
+
+  font-size: 50px;
+  line-height: 75px;
+  padding-left: 20px;
+  letter-spacing: -24px;
+
+  &::after {
+    display: block;
+    content: '▎▎';
+  }
+}
+
+.playButtonDetachedContainer {
+  bottom: 35%;
+  position: absolute;
+  left: 50%;
+}
+
+.milkdrop {
+  top: 0;
+  z-index: 100;
+  height: 100%;
+  width: 100%;
+  display: block;
+}
+
+.milkdropDisabled {
+  display: none;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,6 +1599,16 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
+  dependencies:
+    es6-object-assign "^1.1.0"
+    is-nan "^1.2.1"
+    object-is "^1.0.1"
+    util "^0.12.0"
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -2428,6 +2438,13 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
+"chainsaw@>=0.0.7 <0.1":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.0.9.tgz#11a05102d1c4c785b6d0415d336d5a3a1612913e"
+  integrity sha1-EaBRAtHEx4W20EFdM21aOhYSkT4=
+  dependencies:
+    traverse ">=0.3.0 <0.4"
+
 chainsaw@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
@@ -2951,7 +2968,7 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-content-type@~1.0.4:
+content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -4247,6 +4264,11 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-object-assign@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
+
 es6-promise@^4.0.3:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
@@ -4864,6 +4886,11 @@ file-loader@^3.0.1:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
+
+file-type@^12.1.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-12.2.0.tgz#bc4bce830e38a96a0ecfea0e2dfcee2855ed1380"
+  integrity sha512-bkDBeH5doAqP69axEO69OviLlWbrZ10Ne2OPHaxBgG+fyT0w/2zfMzJz21SPwq5Iq0aN70q7RN3KRcdUY427Mg==
 
 file-type@^3.8.0:
   version "3.9.0"
@@ -5607,6 +5634,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+"hashish@>=0.0.2 <0.1":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/hashish/-/hashish-0.0.4.tgz#6d60bc6ffaf711b6afd60e426d077988014e6554"
+  integrity sha1-bWC8b/r3Ebav1g5CbQd5iAFOZVQ=
+  dependencies:
+    traverse ">=0.2.4"
+
 hast-to-hyperscript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-4.0.0.tgz#3eb25483ec72a8e9a71e4b1ad7eb8f7c86f755db"
@@ -6197,6 +6231,11 @@ is-alphanumerical@^1.0.0:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
 
+is-arguments@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
+  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -6342,6 +6381,11 @@ is-function@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
   integrity sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=
+
+is-generator-function@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.7.tgz#d2132e529bb0000a7f80794d4bdf5cd5e5813522"
+  integrity sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==
 
 is-glob@^2.0.0:
   version "2.0.1"
@@ -6538,7 +6582,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -7463,6 +7507,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 mem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
@@ -7752,6 +7801,32 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+music-metadata-browser@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/music-metadata-browser/-/music-metadata-browser-1.2.3.tgz#23f03522aeff35910e23cae971c5e138b08f9990"
+  integrity sha512-f9E5Abi8YIPKuATm8zELrFg0K4xJCOcY/yhErX7q0hdlpzqvldzXt0ZpQCKupu2KkOPBd8iViRBoOMvcmYtXVw==
+  dependencies:
+    assert "^2.0.0"
+    buffer "^5.2.1"
+    debug "^4.0.1"
+    music-metadata "^4.3.0"
+    readable-stream "^3.3.0"
+    readable-web-to-node-stream "^1.1.4"
+    remove "^0.1.5"
+    typedarray-to-buffer "^3.1.5"
+
+music-metadata@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-4.3.0.tgz#00359a3e93a5be17c04790235d93a65c7221f265"
+  integrity sha512-3AkowwE+sdT/YqGOacbekPEQvMszzFHLJid1mVBAiOM9HPuPV7Wm+uej3SRYydhzaLJpZW+yPqGYpgz4BwrcuQ==
+  dependencies:
+    content-type "^1.0.4"
+    debug "^4.1.0"
+    file-type "^12.1.0"
+    media-typer "^1.1.0"
+    strtok3 "^3.0.0"
+    token-types "^1.0.1"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -8186,6 +8261,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+  integrity sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=
+
 object-keys@^1.0.12:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -8202,6 +8282,16 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.entries@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
+  integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 object.fromentries@^2.0.0:
   version "2.0.0"
@@ -9997,6 +10087,15 @@ readable-stream@^3.0.6, readable-stream@^3.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@^3.3.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -10006,6 +10105,11 @@ readable-stream@~1.1.9:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-web-to-node-stream@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-1.1.4.tgz#5857d32fb9f791d1c4ca3c297ff028acb41218c6"
+  integrity sha512-DfwzynATtPmyLSMETPMlgVAB4b/0NNPePAEFEjSzw8VkqUZfx75gjNkaSqa0fP6iul2TL+jheLn2np0SWtW4iw==
 
 readdirp@^2.2.1:
   version "2.2.1"
@@ -10271,6 +10375,13 @@ remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+remove@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/remove/-/remove-0.1.5.tgz#095ffd827d65c9f41ad97d33e416a75811079955"
+  integrity sha1-CV/9gn1lyfQa2X0z5BanWBEHmVU=
+  dependencies:
+    seq ">= 0.3.5"
 
 renderkid@^2.0.1:
   version "2.0.3"
@@ -10661,6 +10772,14 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
+
+"seq@>= 0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/seq/-/seq-0.3.5.tgz#ae02af3a424793d8ccbf212d69174e0c54dffe38"
+  integrity sha1-rgKvOkJHk9jMvyEtaRdODFTf/jg=
+  dependencies:
+    chainsaw ">=0.0.7 <0.1"
+    hashish ">=0.0.2 <0.1"
 
 serialize-javascript@^1.4.0, serialize-javascript@^1.7.0:
   version "1.7.0"
@@ -11321,6 +11440,15 @@ strip-markdown@^3.0.3:
   resolved "https://registry.yarnpkg.com/strip-markdown/-/strip-markdown-3.0.3.tgz#93b4526abe32a1d69e5ca943f4d9ba25c01a4d48"
   integrity sha512-G2DSM9wy3PWxY3miAibWpsTqZgXLXgRoq0yVyaVs9O7FDGEwPO6pmSE8CyzHhU88Z2w1dkFqFmWUklFNsQKwqg==
 
+strtok3@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-3.0.0.tgz#2fe07702c27787fd4766a22cafe4ac9a4d9e0706"
+  integrity sha512-Sm17gVuapi4jR5cE6UnYhstZ7jGeH9a/eM7Sbg5IDk6bw3Z7FF0UTA1tnZo2Gt7OmY+/O9kVAnAGJ9mglvf36w==
+  dependencies:
+    debug "^4.1.1"
+    then-read-stream "^2.0.0"
+    token-types "^1.0.1"
+
 style-loader@^0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
@@ -11551,6 +11679,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+then-read-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/then-read-stream/-/then-read-stream-2.0.0.tgz#94bb75f01cac12198ecfc277f914d3ce5a1eb787"
+  integrity sha512-mdQRdZ+71UVL9H6y2bRt/SlpIgzi223LEx8gxbRCfVURnXrokMYo1w+jNcATTZLR25kVUb+h8X6BlmoW4173fQ==
+
 three-full@^17.1.0:
   version "17.1.0"
   resolved "https://registry.yarnpkg.com/three-full/-/three-full-17.1.0.tgz#ecab0ff39c76c94530cda50d40fb9d66b2141701"
@@ -11686,6 +11819,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+token-types@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-1.0.1.tgz#c91671bd80f7e2ded10dee4b8ff17247c40378c7"
+  integrity sha512-Q2yPT4GA4gmIAgUrL9O9LRzKFKJ8FA1P5eiOfC2eH+IZMSJVQBCML1SOooeRicIIvTr/UZuTAX5PqMzgBXJOvg==
+
 toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
@@ -11720,6 +11858,11 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+traverse@>=0.2.4:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
@@ -11831,6 +11974,13 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -12229,6 +12379,17 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
+
+util@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.1.tgz#f908e7b633e7396c764e694dd14e716256ce8ade"
+  integrity sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    object.entries "^1.1.0"
+    safe-buffer "^5.1.2"
 
 utila@^0.4.0, utila@~0.4:
   version "0.4.0"


### PR DESCRIPTION
Related to issue number: #2757

Restores the "old" audio player.

Start playing audio automatically after the audio viewer is activated.

----

I think the visualization leaves room for improvement. I propose to:
- Keep displaying the main album cover
- Improve the visualization of the metadata:
   - artist
   - track title
   - track number, if applicable
   - maybe the album the track is part of  
- Display audio format: container, codec, bit-rate
- Cut out, the milk-drop visualization, maybe a small spectrum-analyzer instead

To attract artists releasing their music to LBRY, I think it would interesting to offer the possibility to release albums.