### PR TITLE
Fix illegal package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "LBRY",
+  "name": "lbry",
   "version": "0.35.2",
   "description": "A browser for the LBRY network, a digital marketplace controlled by its users.",
   "keywords": [


### PR DESCRIPTION
NPM package name must be lowercase: https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields