### PR TITLE
adds selectAll to electron menu enabling CMD+A

### DIFF
--- a/src/platforms/electron/menu/setupBarMenu.js
+++ b/src/platforms/electron/menu/setupBarMenu.js
@@ -15,6 +15,7 @@ export default () => {
         { role: 'cut' },
         { role: 'copy' },
         { role: 'paste' },
+        { role: 'selectAll' },
       ],
     },
     {


### PR DESCRIPTION
Electron needs these menu items in order to bring shortcut keys into an app, at least on Mac.