### PR TITLE
fixes several issues with lbry.tv metadata

### DIFF
--- a/src/platforms/web/server.js
+++ b/src/platforms/web/server.js
@@ -1,10 +1,10 @@
 const { parseURI } = require('lbry-redux');
+const { generateStreamUrl } = require('../../src/ui/util/lbrytv');
 const { WEB_SERVER_PORT } = require('../../config');
 const { readFileSync } = require('fs');
 const express = require('express');
 const path = require('path');
 const app = express();
-
 const mysql = require('mysql');
 
 const pool = mysql.createPool({
@@ -15,11 +15,11 @@ const pool = mysql.createPool({
   database: 'chainquery',
 });
 
-const getClaim = (claimName, claimId, callback) => {
+const getClaim = (claimName, claimId, channelName, channelClaimId, callback) => {
   let params = [claimName];
 
   let sql =
-    'SELECT channel_claim.name as channel, claim.claim_id, claim.name, claim.description, claim.language, claim.thumbnail_url, claim.title ' +
+    'SELECT channel_claim.name as channel, claim.claim_id, claim.name, claim.description, claim.language, claim.thumbnail_url, claim.title, claim.source_media_type, claim.frame_width, claim.frame_height ' +
     'FROM claim ' +
     'LEFT JOIN claim channel_claim on claim.publisher_id = channel_claim.claim_id ' +
     'WHERE claim.name = ?';
@@ -29,6 +29,17 @@ const getClaim = (claimName, claimId, callback) => {
     params.push(claimId + '%');
   } else {
     sql += ' AND claim.bid_state = "controlling"';
+  }
+
+  if (claimName[0] !== '@' && channelName) {
+    sql += ' AND channel_claim.name = ?';
+    params.push('@' + channelName);
+    if (channelClaimId) {
+      sql += ' AND channel_claim.claim_id LIKE ?';
+      params.push(channelClaimId + '%');
+    } else {
+      sql += ' AND channel_claim.bid_state = "controlling"';
+    }
   }
 
   sql += ' LIMIT 1';
@@ -43,7 +54,7 @@ function truncateDescription(description) {
 }
 
 function insertToHead(fullHtml, htmlToInsert) {
-  return fullHtml.replace('%%HEAD_TOKEN%%', htmlToInsert);
+  return fullHtml.replace('<!-- HEAD_REPLACEMENT_TOKEN -->', htmlToInsert);
 }
 
 const defaultHead =
@@ -67,7 +78,7 @@ app.get('*', async (req, res) => {
     const claimName = isChannel ? '@' + channelName : streamName;
     const claimId = isChannel ? channelClaimId : streamClaimId;
 
-    getClaim(claimName, claimId, (err, rows) => {
+    getClaim(claimName, claimId, channelName, channelClaimId, (err, rows) => {
       if (!err && rows && rows.length > 0) {
         const claim = rows[0];
         const title = claim.title ? claim.title : claimName;
@@ -83,6 +94,7 @@ app.get('*', async (req, res) => {
         let head = '';
 
         head += '<meta charset="utf8"/>';
+        head += `<title>${claimTitle}</title>`;
         head += `<meta name="description" content="${claimDescription}"/>`;
         if (claim.tags) {
           head += `<meta name="keywords" content="${claim.tags.toString()}"/>`;
@@ -95,7 +107,17 @@ app.get('*', async (req, res) => {
         head += `<meta property="og:type" content="website"/>`;
         // below should be canonical_url, but not provided by chainquery yet
         head += `<meta property="og:url" content="https://beta.lbry.tv/${claim.name}:${claim.claim_id}"/>`;
-        head += `<title>${claimTitle}</title>`;
+
+        if (claim.source_media_type && claim.source_media_type.startsWith('video/')) {
+          const videoUrl = generateStreamUrl(claim.name, claim.claim_id);
+          head += `<meta property="og:video" content="${videoUrl}" />`;
+          head += `<meta property="og:video:secure_url" content="${videoUrl}" />`;
+          head += `<meta property="og:video:type" content="${claim.source_media_type}" />`;
+          if (claim.frame_width && claim.frame_height) {
+            head += `<meta property="og:video:width" content="${claim.frame_width}/>`;
+            head += `<meta property="og:video:height" content="${claim.frame_height}/>`;
+          }
+        }
 
         html = insertToHead(html, head);
       } else {

--- a/src/ui/component/fileRender/view.jsx
+++ b/src/ui/component/fileRender/view.jsx
@@ -6,6 +6,9 @@ import VideoViewer from 'component/viewers/videoViewer';
 import ImageViewer from 'component/viewers/imageViewer';
 import AppViewer from 'component/viewers/appViewer';
 import Button from 'component/button';
+// @if TARGET='web'
+import { generateStreamUrl } from 'util/lbrytv';
+// @endif
 
 import path from 'path';
 import fs from 'fs';
@@ -101,7 +104,7 @@ class FileRender extends React.PureComponent<Props> {
 
     // Ideally the lbrytv api server would just replace the streaming_url returned by the sdk so we don't need this check
     // https://github.com/lbryio/lbrytv/issues/51
-    const source = IS_WEB ? `https://api.lbry.tv/content/claims/${claim.name}/${claim.claim_id}/stream` : streamingUrl;
+    const source = IS_WEB ? generateStreamUrl(claim.name, claim.claim_id) : streamingUrl;
 
     // Human-readable files (scripts and plain-text files)
     const readableFiles = ['text', 'document', 'script'];

--- a/src/ui/util/lbrytv.js
+++ b/src/ui/util/lbrytv.js
@@ -1,0 +1,5 @@
+function generateStreamUrl(claimName, claimId) {
+  return `https://api.lbry.tv/content/claims/${claimName}/${claimId}/stream`;
+}
+
+module.exports.generateStreamUrl = generateStreamUrl;

--- a/static/index-web.html
+++ b/static/index-web.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    %%HEAD_TOKEN%%
+    <!-- HEAD_REPLACEMENT_TOKEN -->
   </head>
 
   <body>

--- a/static/locales/pl.json
+++ b/static/locales/pl.json
@@ -608,5 +608,20 @@
   "Unlock": "Odblokuj",
   "Exit": "Wyjście",
   "Wallet Password": "Hasło portfela",
-  "Unlock Wallet": "Odblokuj portfel"
+  "Unlock Wallet": "Odblokuj portfel",
+  "URI does not include name.": "URI does not include name.",
+  "You're not following any channels.": "You're not following any channels.",
+  "Look what's trending for everyone": "Look what's trending for everyone",
+  "or": "or",
+  "Discover some channels!": "Discover some channels!",
+  "Block": "Block",
+  "This file is in your library.": "This file is in your library.",
+  "Send a tip to this creator": "Send a tip to this creator",
+  "File Size": "File Size",
+  "Loading": "Loading",
+  "LBRY Download Complete": "LBRY Download Complete",
+  "Find New Tags": "Find New Tags",
+  "View File": "View File",
+  "Close": "Close",
+  "% downloaded": "% downloaded"
 }


### PR DESCRIPTION
- fixes flash of `%%HEAD_TOKEN%%` on page load
- fixes incorrect serving of metadata for legacy URLs and potentially other cases (check out beta.lbry.tv/@brendonbrewer/3 prior to merge :man_facepalming:)
- adds video specific open graph metadata (#2806)