### PR TITLE
use contentFilter on web

### DIFF
--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -66,13 +66,13 @@ const whiteListedReducers = [
 const transforms = [
   // @if TARGET='app'
   walletFilter,
-  contentFilter,
   fileInfoFilter,
   blockedFilter,
   // @endif
   appFilter,
   searchFilter,
   tagsFilter,
+  contentFilter,
   createCompressor(),
 ];
 


### PR DESCRIPTION
So the `playingUri` isn't persisted, which causes the pop-out player to play on refresh.