### PR TITLE
fix: crash on share modal

### DIFF
--- a/src/ui/component/channelContent/view.jsx
+++ b/src/ui/component/channelContent/view.jsx
@@ -67,7 +67,7 @@ function ChannelContent(props: Props) {
       {!channelIsMine && <HiddenNsfwClaims className="card__subtitle" uri={uri} />}
 
       {hasContent && !channelIsBlocked && !channelIsBlackListed && (
-        <ClaimList header={false} uris={claimsInChannel.map(claim => claim.canonical_url)} />
+        <ClaimList header={false} uris={claimsInChannel.map(claim => claim && claim.canonical_url)} />
       )}
       {!channelIsBlocked && !channelIsBlackListed && (
         <Paginate

--- a/src/ui/component/errorBoundary/view.jsx
+++ b/src/ui/component/errorBoundary/view.jsx
@@ -83,7 +83,7 @@ class ErrorBoundary extends React.Component<Props, State> {
                     label={__('refreshing the app')}
                     onClick={this.refresh}
                   />{' '}
-                  {__('to fix it')}.
+                  {__("to fix it. If that doesn't work, press CMD/CTRL-R to reset to the homepage.")}.
                 </p>
               </Fragment>
             }

--- a/src/ui/component/socialShare/view.jsx
+++ b/src/ui/component/socialShare/view.jsx
@@ -26,11 +26,11 @@ class SocialShare extends React.PureComponent<Props> {
 
   render() {
     const { claim } = this.props;
-    const { canonical_url: canonicalUrl } = claim;
+    const { canonical_url: canonicalUrl, permanent_url: permanentUrl } = claim;
     const { speechShareable, onDone } = this.props;
     const lbryTvPrefix = 'https://beta.lbry.tv/';
     const lbryPrefix = 'https://open.lbry.com/';
-    const lbryUri = canonicalUrl.split('lbry://')[1];
+    const lbryUri = canonicalUrl ? canonicalUrl.split('lbry://')[1] : permanentUrl.split('lbry://')[1];
     const lbryWebUrl = lbryUri.replace(/#/g, ':');
     const encodedLbryURL: string = `${lbryPrefix}${encodeURIComponent(lbryWebUrl)}`;
     const lbryURL: string = `${lbryPrefix}${lbryWebUrl}`;

--- a/src/ui/redux/actions/app.js
+++ b/src/ui/redux/actions/app.js
@@ -427,7 +427,7 @@ export function doAnalyticsView(uri, timeToStart) {
     const outpoint = `${txid}:${nout}`;
 
     if (claimIsMine) {
-      return;
+      return Promise.resolve();
     }
 
     return analytics.apiLogView(uri, outpoint, claimId, timeToStart);


### PR DESCRIPTION
This happens randomly from file/channel pages or when the claim is not confirmed but accessed via wallet page.

+ Added note to use ctrl-R to refresh in cases the button doesn't work.