### PR TITLE
fix: abandoning without file

### DIFF
--- a/src/ui/redux/actions/file.js
+++ b/src/ui/redux/actions/file.js
@@ -2,7 +2,14 @@ import * as ACTIONS from 'constants/action_types';
 // @if TARGET='app'
 import { shell } from 'electron';
 // @endif
-import { Lbry, batchActions, doAbandonClaim, selectMyClaimsOutpoints, makeSelectFileInfoForUri } from 'lbry-redux';
+import {
+  Lbry,
+  batchActions,
+  doAbandonClaim,
+  selectMyClaimsOutpoints,
+  makeSelectFileInfoForUri,
+  makeSelectClaimForUri,
+} from 'lbry-redux';
 import { doHideModal } from 'redux/actions/app';
 import { goBack } from 'connected-react-router';
 import { doSetPlayingUri } from 'redux/actions/content';
@@ -54,9 +61,12 @@ export function doDeleteFileAndMaybeGoBack(uri, deleteFromComputer, abandonClaim
     const state = getState();
     const playingUri = selectPlayingUri(state);
     const { outpoint } = makeSelectFileInfoForUri(uri)(state) || '';
+    const { nout, txid } = makeSelectClaimForUri(uri)(state);
+    const claimOutpoint = `${txid}:${nout}`;
+
     const actions = [];
     actions.push(doHideModal());
-    actions.push(doDeleteFile(outpoint, deleteFromComputer, abandonClaim));
+    actions.push(doDeleteFile(outpoint || claimOutpoint, deleteFromComputer, abandonClaim));
 
     if (playingUri === uri) {
       actions.push(doSetPlayingUri(null));


### PR DESCRIPTION
This fixes not being able to abandon without first downloading the file.
I noticed the "go back" part is broken here and in the prod app...Sean can you see what's up there?