### PR TITLE
Renamed language names to their natives

### DIFF
--- a/src/ui/redux/reducers/settings.js
+++ b/src/ui/redux/reducers/settings.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 const reducers = {};
 const defaultState = {
   isNight: false,
-  languages: { en: 'English', pl: 'Polish', id: 'Bahasa Indonesia', de: 'German' }, // this could/should be loaded directly from Transifex and/or lbry.com
+  languages: { en: 'English', pl: 'Polski', id: 'Bahasa Indonesia', de: 'Deutsche' }, // this could/should be loaded directly from Transifex and/or lbry.com
   isFetchingLanguage: false,
   daemonSettings: {},
   clientSettings: {


### PR DESCRIPTION
This change will allow users to easly find their language even if they not know english very well.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

## What is the current behavior?
App displays language names in English.

## What is the new behavior?
Now App display languages in native languages (ex. Polish = Polski)
So users can easly find their own language.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
