### PR TITLE
fix title on small screen

### DIFF
--- a/src/ui/scss/component/_channel.scss
+++ b/src/ui/scss/component/_channel.scss
@@ -89,7 +89,7 @@ $metadata-z-index: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   // line-height: var(--font-heading);
-  font-size: var(--font-heading);
+  font-size: xx-large;
   font-weight: 800;
 
   // Quick hack to get this to work


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2948 

## What is the current behavior?
The Current behavior is on css use var(--font-heading), 
see this screenshot : 
![image](https://user-images.githubusercontent.com/26609573/66182850-c8d3f280-e6a0-11e9-867d-ffbdd344728a.png)

## What is the new behavior?
So. For Alternative method i use xx-large css style to make this better than before i think.
like this screenshot below. my screen resulution is 1280 x 768 
![image](https://user-images.githubusercontent.com/26609573/66182963-2ff1a700-e6a1-11e9-9323-292c300e8c77.png)


