### PR TITLE
Add Cancel and Close Button on Wallet Send and Receive Pages

### DIFF
--- a/src/ui/component/walletAddress/view.jsx
+++ b/src/ui/component/walletAddress/view.jsx
@@ -4,6 +4,7 @@ import Button from 'component/button';
 import CopyableText from 'component/copyableText';
 import QRCode from 'component/common/qr-code';
 import Card from 'component/common/card';
+import * as PAGES from 'constants/pages';
 
 type Props = {
   checkAddressIsMine: string => void,
@@ -64,6 +65,7 @@ class WalletAddress extends React.PureComponent<Props, State> {
                 />
               )}
               <Button button="link" label={showQR ? __('Hide QR code') : __('Show QR code')} onClick={this.toggleQR} />
+              <Button button="link" label={__('Close')} navigate={`$/${PAGES.WALLET}`}  />
             </div>
             <p className="help">
               {__('You can generate a new address at any time, and any previous addresses will continue to work.')}

--- a/src/ui/component/walletSend/view.jsx
+++ b/src/ui/component/walletSend/view.jsx
@@ -6,6 +6,7 @@ import { Form, FormField } from 'component/common/form';
 import { Formik } from 'formik';
 import { validateSendTx } from 'util/form-validation';
 import Card from 'component/common/card';
+import * as PAGES from 'constants/pages';
 
 type DraftTransaction = {
   address: string,
@@ -88,7 +89,12 @@ class WalletSend extends React.PureComponent<Props> {
                       !(parseFloat(values.amount) > 0.0) ||
                       parseFloat(values.amount) === balance
                     }
-                  />
+                    />
+                  <Button 
+                      button="link" 
+                      label={__('Cancel')} 
+                      navigate={`$/${PAGES.WALLET}`} 
+                    />
                   {!!Object.keys(errors).length || (
                     <span className="error-text">
                       {(!!values.address && touched.address && errors.address) ||


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ x] Bugfix
- [ x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## What is the current behavior?
Currently Wallet Receive and Wallet Send pages does not have Close and Cancel button it will make user confused with it

## What is the new behavior?
I Added Cancel button on Wallet send pages, this is alternative method
![image](https://user-images.githubusercontent.com/26609573/66185397-81059900-e6a9-11e9-8021-af52998a8a6f.png)
I Added Close button on Wallet Receive Pages, this is alternative method
![image](https://user-images.githubusercontent.com/26609573/66185463-b7431880-e6a9-11e9-87bc-b6529e264806.png)

TESTED LOCALLY ON MY MACHINE.. 

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
