### PR TITLE
Escape link for tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Escape the generated link for tags ([#2984](https://github.com/lbryio/lbry-desktop/pull/2984))
+
 ### Added
 
 ### Changed

--- a/src/ui/component/tag/view.jsx
+++ b/src/ui/component/tag/view.jsx
@@ -15,7 +15,7 @@ type Props = {
 export default function Tag(props: Props) {
   const { name, onClick, type = 'link', disabled = false } = props;
   const isMature = MATURE_TAGS.includes(name);
-  const clickProps = onClick ? { onClick } : { navigate: `/$/tags?t=${name}` };
+  const clickProps = onClick ? { onClick } : { navigate: encodeURIComponent(`/$/tags?t=${name}`) };
 
   let title;
   if (!onClick) {

--- a/src/ui/component/tag/view.jsx
+++ b/src/ui/component/tag/view.jsx
@@ -15,7 +15,7 @@ type Props = {
 export default function Tag(props: Props) {
   const { name, onClick, type = 'link', disabled = false } = props;
   const isMature = MATURE_TAGS.includes(name);
-  const clickProps = onClick ? { onClick } : { navigate: encodeURIComponent(`/$/tags?t=${name}`) };
+  const clickProps = onClick ? { onClick } : { navigate: `/$/tags?t=${encodeURIComponent(name)}` };
 
   let title;
   if (!onClick) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2678

Escapes the generated link for tags by using `encodeURIComponent`
