### PR TITLE
Fix glitchy follow button behaviour

### DIFF
--- a/src/ui/component/subscribeButton/view.jsx
+++ b/src/ui/component/subscribeButton/view.jsx
@@ -40,6 +40,7 @@ export default function SubscribeButton(props: Props) {
   const subscriptionHandler = isSubscribed ? doChannelUnsubscribe : doChannelSubscribe;
   const subscriptionLabel = isSubscribed ? __('Following') : __('Follow');
   const unfollowOverride = isSubscribed && isHovering && __('Unfollow');
+  const unfollowStyling = isHovering ? { letterSpacing: '0.35px' } : { letterSpacing: '-0.3px' };
 
   return permanentUrl ? (
     <Button
@@ -48,6 +49,7 @@ export default function SubscribeButton(props: Props) {
       icon={unfollowOverride ? ICONS.UNSUBSCRIBE : ICONS.SUBSCRIBE}
       button={'alt'}
       label={unfollowOverride || subscriptionLabel}
+      style={unfollowStyling}
       onClick={e => {
         e.stopPropagation();
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2677 

## What is the current behavior?

Hovering over a very particular part of the button caused the text to change, which made the element smaller, which made it so you were no longer hovering over it, causing it to change to bigger text, which made it so you were hovering over it, causing a feedback loop and creating a glitchy visual bug.

## What is the new behavior?

Now, the smaller text has a tiny bit of barely noticeable letter spacing, and the larger bit has had a tiny bit of letter spacing removed, to make the two states the same width, meaning the label remains the same size.

## Other information

As far as I'm aware, there's no other information required.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
