### PR TITLE
Add keyboard shortcuts to toggle player fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Escape the generated link for tags ([#2984](https://github.com/lbryio/lbry-desktop/pull/2984))
+- Toggle fullscreen when pressing `f` ([#2159](https://github.com/lbryio/lbry-desktop/issues/2159))
+- Can't exit full-screen from embedded content with key `F11` ([#2514](https://github.com/lbryio/lbry-desktop/issues/2514))
 
 ### Added
+
 - Keyboard shortcuts for the following actions: ([#2999](https://github.com/lbryio/lbry-desktop/pull/2999))
+
   - `→` to Seek Forward
   - `←` to Seek Backward
   - `f` to Going Fullscreen
@@ -19,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Ability to add multiple tags at once with commas ([#2833](https://github.com/lbryio/lbry-desktop/pull/2833))
 - Disable GIF animation unless user hovers ([#2986](https://github.com/lbryio/lbry-desktop/pull/2986))
+- Add keyboard shortcuts to toggle player fullscreen: ([#3015](https://github.com/lbryio/lbry-desktop/pull/3015))
+
+  - `f` or `f11` to toggle player fullscreen mode
 
 ### Changed
 

--- a/src/ui/component/viewers/videoViewer/view.jsx
+++ b/src/ui/component/viewers/videoViewer/view.jsx
@@ -5,6 +5,7 @@ import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
 import isUserTyping from 'util/detect-typing';
 
+const F11_KEYCODE = 122;
 const SPACE_BAR_KEYCODE = 32;
 const SMALL_F_KEYCODE = 70;
 const SMALL_M_KEYCODE = 77;
@@ -45,6 +46,7 @@ function VideoViewer(props: Props) {
   const { contentType, source, setPlayingUri, onEndedCB, changeVolume, changeMute, volume, muted } = props;
   const videoRef = useRef();
   const [requireRedraw, setRequireRedraw] = useState(false);
+  let player = null;
 
   useEffect(() => {
     const currentVideo: HTMLVideoElement | null = document.querySelector('video');
@@ -91,12 +93,11 @@ function VideoViewer(props: Props) {
       ],
     };
 
-    let player;
     if (!requireRedraw) {
       player = videojs(videoNode, videoJsOptions, function() {
-        const player = this;
-        player.volume(volume);
-        player.muted(muted);
+        const self = this;
+        self.volume(volume);
+        self.muted(muted);
       });
     }
 
@@ -136,9 +137,13 @@ function VideoViewer(props: Props) {
         videoNode.paused ? videoNode.play() : videoNode.pause();
       }
 
-      // Fullscreen Shortcut
-      if (e.keyCode === FULLSCREEN_KEYCODE) {
-        videoNode.webkitEnterFullscreen && videoNode.webkitEnterFullscreen();
+      // Fullscreen toggle shotcuts
+      if (e.keyCode === FULLSCREEN_KEYCODE || e.keyCode === F11_KEYCODE) {
+        if(!player.isFullscreen()) {
+          player.requestFullscreen();
+        } else {
+          player.exitFullscreen();
+        }
       }
 
       // Mute/Unmute Shortcuts

--- a/src/ui/component/viewers/videoViewer/view.jsx
+++ b/src/ui/component/viewers/videoViewer/view.jsx
@@ -137,7 +137,7 @@ function VideoViewer(props: Props) {
         videoNode.paused ? videoNode.play() : videoNode.pause();
       }
 
-      // Fullscreen toggle shotcuts
+      // Fullscreen toggle shortcuts
       if (e.keyCode === FULLSCREEN_KEYCODE || e.keyCode === F11_KEYCODE) {
         if(!player.isFullscreen()) {
           player.requestFullscreen();


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
- Can't exit full-screen from embedded content with key F11 #2514
- Toggle fullscreen when pressing `f` #2159
-  ~Gap between video player and background #3025~ ( unrelated ) 