### PR TITLE
Use OS language to default localization

### DIFF
--- a/src/platforms/electron/createWindow.js
+++ b/src/platforms/electron/createWindow.js
@@ -5,6 +5,7 @@ import windowStateKeeper from 'electron-window-state';
 
 import setupBarMenu from './menu/setupBarMenu';
 import * as PAGES from '../../ui/constants/pages';
+import SUPPORTED_LANGUAGES from '../../ui/constants/supported_languages';
 
 export default appState => {
   // Get primary display dimensions from Electron.
@@ -149,7 +150,9 @@ export default appState => {
 async function setLanguage(window) {
   const storedLanguage = await window.webContents.executeJavaScript("localStorage.getItem('language')");
   const lang = storedLanguage || app.getLocale().slice(0, 2) || 'en';
-  if (['pl', 'id', 'de'].includes(lang)) {
+
+  const supportedNonEnglish = Object.keys(SUPPORTED_LANGUAGES).filter(language => language !== 'en');
+  if (supportedNonEnglish.includes(lang)) {
     const response = await fetch('https://lbry.com/i18n/get/lbry-desktop/app-strings/' + lang + '.json');
     const json = await response.json();
     const messages = {};

--- a/src/platforms/electron/createWindow.js
+++ b/src/platforms/electron/createWindow.js
@@ -87,6 +87,8 @@ export default appState => {
   window.loadURL(rendererURL + deepLinkingURI);
   setupBarMenu();
 
+  setLanguage(window);
+
   window.on('close', event => {
     if (!appState.isQuitting && !appState.autoUpdateAccepted) {
       event.preventDefault();
@@ -143,3 +145,16 @@ export default appState => {
 
   return window;
 };
+
+async function setLanguage(window) {
+  const storedLanguage = await window.webContents.executeJavaScript("localStorage.getItem('language')");
+  const lang = storedLanguage || app.getLocale().slice(0, 2) || 'en';
+  if (['pl', 'id', 'de'].includes(lang)) {
+    const response = await fetch('https://lbry.com/i18n/get/lbry-desktop/app-strings/' + lang + '.json');
+    const json = await response.json();
+    const messages = {};
+    messages[lang] = json;
+    // Send message to render layer to update language.
+    window.webContents.send('language-update', messages, lang);
+  }
+}

--- a/src/platforms/electron/createWindow.js
+++ b/src/platforms/electron/createWindow.js
@@ -5,7 +5,7 @@ import windowStateKeeper from 'electron-window-state';
 
 import setupBarMenu from './menu/setupBarMenu';
 import * as PAGES from '../../ui/constants/pages';
-import SUPPORTED_LANGUAGES from '../../ui/constants/supported_languages';
+import setLanguage from './setLanguage';
 
 export default appState => {
   // Get primary display dimensions from Electron.
@@ -146,18 +146,3 @@ export default appState => {
 
   return window;
 };
-
-async function setLanguage(window) {
-  const storedLanguage = await window.webContents.executeJavaScript("localStorage.getItem('language')");
-  const lang = storedLanguage || app.getLocale().slice(0, 2) || 'en';
-
-  const supportedNonEnglish = Object.keys(SUPPORTED_LANGUAGES).filter(language => language !== 'en');
-  if (supportedNonEnglish.includes(lang)) {
-    const response = await fetch('https://lbry.com/i18n/get/lbry-desktop/app-strings/' + lang + '.json');
-    const json = await response.json();
-    const messages = {};
-    messages[lang] = json;
-    // Send message to render layer to update language.
-    window.webContents.send('language-update', messages, lang);
-  }
-}

--- a/src/platforms/electron/setLanguage.js
+++ b/src/platforms/electron/setLanguage.js
@@ -1,0 +1,22 @@
+import SUPPORTED_LANGUAGES from '../../ui/constants/supported_languages';
+
+export default async function setLanguage(window) {
+  const storedLanguage = await window.webContents.executeJavaScript("localStorage.getItem('language')");
+  const lang = storedLanguage || app.getLocale().slice(0, 2) || 'en';
+  const supportedNonEnglish = Object.keys(SUPPORTED_LANGUAGES).filter(language => language !== 'en');
+
+  if (supportedNonEnglish.includes(lang)) {
+    fetch('https://lbry.com/i18n/get/lbry-desktop/app-strings/' + lang + '.json')
+      .then(response => response.json())
+      .then(json => {
+        const messages = {};
+        messages[lang] = json;
+        window.webContents.send('language-set', messages, lang);
+      })
+      .catch(error => {
+        window.webContents.send('language-set', {}, lang, error);
+      });
+  } else {
+    window.webContents.send('language-set', {}, lang);
+  }
+}

--- a/src/ui/component/settingLanguage/view.jsx
+++ b/src/ui/component/settingLanguage/view.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { FormField } from 'component/common/form';
 import Spinner from 'component/spinner';
 import { SETTINGS } from 'lbry-redux';
+import SUPPORTED_LANGUAGES from '../../constants/supported_languages';
 
 type Props = {
   language: string,
@@ -15,7 +16,7 @@ function SettingLanguage(props: Props) {
   const [isFetching, setIsFetching] = useState(false);
 
   // this should be fetched from lbry.com/transifex
-  const languages = { en: 'English', pl: 'Polski', id: 'Bahasa Indonesia', de: 'Deutsche' };
+  const languages = SUPPORTED_LANGUAGES;
 
   const { language, showToast, setClientSetting } = props;
 

--- a/src/ui/constants/supported_languages.js
+++ b/src/ui/constants/supported_languages.js
@@ -1,0 +1,10 @@
+import LANGUAGES from './languages';
+
+const SUPPORTED_LANGUAGES = {
+  en: LANGUAGES.en[1],
+  pl: LANGUAGES.pl[1],
+  id: LANGUAGES.id[1],
+  de: LANGUAGES.de[1],
+};
+
+export default SUPPORTED_LANGUAGES;

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -13,7 +13,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { doConditionalAuthNavigate, doDaemonReady, doAutoUpdate, doOpenModal, doHideModal } from 'redux/actions/app';
 import { Lbry, doToast, isURIValid, setSearchApi } from 'lbry-redux';
-import { doUpdateIsNightAsync, doSetClientSetting } from 'redux/actions/settings';
+import { doUpdateIsNightAsync } from 'redux/actions/settings';
 import {
   doAuthenticate,
   Lbryio,
@@ -176,7 +176,6 @@ ipcRenderer.on('devtools-is-opened', () => {
 ipcRenderer.on('language-update', (event, messages, language) => {
   window.i18n_messages = messages;
   window.localStorage.setItem(SETTINGS.LANGUAGE, language);
-  doSetClientSetting(SETTINGS.LANGUAGE, language);
 });
 
 // Force exit mode for html5 fullscreen api

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -30,7 +30,6 @@ import cookie from 'cookie';
 import { formatLbryUriForWeb } from 'util/uri';
 import { PersistGate } from 'redux-persist/integration/react';
 import analytics from 'analytics';
-import * as SETTINGS from 'constants/settings';
 
 // Import our app styles
 // If a style is not necessary for the initial page load, it should be removed from `all.scss`
@@ -171,11 +170,6 @@ ipcRenderer.on('window-is-focused', () => {
 
 ipcRenderer.on('devtools-is-opened', () => {
   doLogWarningConsoleMessage();
-});
-
-ipcRenderer.on('language-update', (event, messages, language) => {
-  window.i18n_messages = messages;
-  window.localStorage.setItem(SETTINGS.LANGUAGE, language);
 });
 
 // Force exit mode for html5 fullscreen api

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -13,7 +13,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { doConditionalAuthNavigate, doDaemonReady, doAutoUpdate, doOpenModal, doHideModal } from 'redux/actions/app';
 import { Lbry, doToast, isURIValid, setSearchApi } from 'lbry-redux';
-import { doUpdateIsNightAsync } from 'redux/actions/settings';
+import { doUpdateIsNightAsync, doSetClientSetting } from 'redux/actions/settings';
 import {
   doAuthenticate,
   Lbryio,
@@ -30,6 +30,7 @@ import cookie from 'cookie';
 import { formatLbryUriForWeb } from 'util/uri';
 import { PersistGate } from 'redux-persist/integration/react';
 import analytics from 'analytics';
+import * as SETTINGS from 'constants/settings';
 
 // Import our app styles
 // If a style is not necessary for the initial page load, it should be removed from `all.scss`
@@ -170,6 +171,12 @@ ipcRenderer.on('window-is-focused', () => {
 
 ipcRenderer.on('devtools-is-opened', () => {
   doLogWarningConsoleMessage();
+});
+
+ipcRenderer.on('language-update', (event, messages, language) => {
+  window.i18n_messages = messages;
+  window.localStorage.setItem(SETTINGS.LANGUAGE, language);
+  doSetClientSetting(SETTINGS.LANGUAGE, language);
 });
 
 // Force exit mode for html5 fullscreen api

--- a/static/index-electron.html
+++ b/static/index-electron.html
@@ -8,9 +8,21 @@
   <body>
     <div id="app"></div>
     <script>
-      const script = document.createElement('script');
-      script.setAttribute('src', 'ui.js');
-      document.body.appendChild(script);
+      function loadUi() {
+        const script = document.createElement('script');
+        script.setAttribute('src', 'ui.js');
+        document.body.appendChild(script);
+      }
+      
+      require('electron').ipcRenderer.on('language-set', (event, messages, language, error) => {
+        window.i18n_messages = messages;   
+        window.localStorage.setItem('language', language);
+        if(error) {
+          console.error('Can\'t set language to ' + language);
+          console.error(error);
+        }
+        loadUi();
+      });
     </script>
   </body>
 </html>

--- a/static/index-electron.html
+++ b/static/index-electron.html
@@ -8,28 +8,9 @@
   <body>
     <div id="app"></div>
     <script>
-      window.i18n_messages = {};
-
-      function loadUi () {
-        const script = document.createElement('script');
-        script.setAttribute('src', 'ui.js');
-        document.body.appendChild(script);
-      }
-
-      let lang;
-      try {
-        lang = window.localStorage.getItem('language') || 'en';
-      } catch {
-        lang = 'en';
-      }
-      if (lang && lang != 'en') {
-        fetch('https://lbry.com/i18n/get/lbry-desktop/app-strings/' + lang + '.json')
-                .then(r => r.json())
-                .then(j => { window.i18n_messages[lang] = j; loadUi(); })
-                .catch(loadUi);
-      } else {
-        loadUi();
-      }
+      const script = document.createElement('script');
+      script.setAttribute('src', 'ui.js');
+      document.body.appendChild(script);
     </script>
   </body>
 </html>

--- a/static/index-web.html
+++ b/static/index-web.html
@@ -24,13 +24,20 @@
         document.body.appendChild(script);
       }
 
+      function supportedNonEnglish(language) {
+        return language === 'pl' ||
+          language === 'id' ||
+          language === 'de'
+      }
+
       let lang;
       try {
-        lang = window.localStorage.getItem('language') || 'en';
+        browserLocale = window.navigator.language.slice(0,2);
+        lang = window.localStorage.getItem('language') || browserLocale || 'en';
       } catch {
         lang = 'en';
       }
-      if (lang && lang != 'en') {
+      if (lang && supportedNonEnglish(lang)) {
         fetch('https://lbry.com/i18n/get/lbry-desktop/app-strings/' + lang + '.json')
                 .then(r => r.json())
                 .then(j => { window.i18n_messages[lang] = j; loadUi(); })


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2955

## What is the current behavior?

When opening the app for the first time. The language is always English

## What is the new behavior?

The language is set to the primary OS language on first use.

After that, the logic stays the same. Use the stored language in the `window.localStorage` 

