### PR TITLE
Fix tooltip styles

### DIFF
--- a/src/ui/scss/all.scss
+++ b/src/ui/scss/all.scss
@@ -45,5 +45,6 @@
 @import 'component/tabs';
 @import 'component/tags';
 @import 'component/time';
+@import 'component/tooltip';
 @import 'component/wunderbar';
 @import 'component/yrbl';

--- a/src/ui/scss/component/_tooltip.scss
+++ b/src/ui/scss/component/_tooltip.scss
@@ -1,0 +1,7 @@
+[data-reach-tooltip] {
+  [data-mode='dark'] & {
+    color: var(--dm-color-01);
+    background-color: $lbry-black;
+    border-color: $border-color--dark;
+  }
+}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Incorrect styles of tooltip on dark theme #3031

## What is the current behavior?

There is a white border and spacing around the tooltip content visible when dark theme is active.

![tooltip-dark-bug](https://user-images.githubusercontent.com/14793624/66710457-f15d8b80-ed35-11e9-9acf-00a7887b196a.png)

## New behavior

![tooltip-dark-fix](https://user-images.githubusercontent.com/14793624/66710464-3da8cb80-ed36-11e9-964d-325dc4e16de8.png)

