### PR TITLE
add message to say content is hidden according to settings (2703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Volume setting is now saved between videos ([#2934](https://github.com/lbryio/lbry-desktop/pull/2934))
 - Granular balance information on wallet page - includes LBC locked in tips/claims/supports ([#2916](https://github.com/lbryio/lbry-desktop/pull/2916))
 - Acknowledgement of [terms of service](https://lbry.com/termsofservice) and age verification on sign in ([#2925](https://github.com/lbryio/lbry-desktop/pull/2925))
+- Hidden NSFW content message on tag search results page ([#3038](https://github.com/lbryio/lbry-desktop/pull/3038))
 
 ### Changed
 

--- a/src/ui/component/claimListDiscover/view.jsx
+++ b/src/ui/component/claimListDiscover/view.jsx
@@ -45,6 +45,7 @@ type Props = {
     [string]: Array<string>,
   },
   hiddenUris: Array<string>,
+  hiddenNsfwMessage?: Node,
 };
 
 function ClaimListDiscover(props: Props) {
@@ -61,6 +62,7 @@ function ClaimListDiscover(props: Props) {
     location,
     hiddenUris,
     hideCustomization,
+    hiddenNsfwMessage,
   } = props;
   const didNavigateForward = history.action === 'PUSH';
   const [page, setPage] = useState(1);
@@ -109,6 +111,7 @@ function ClaimListDiscover(props: Props) {
     (personalSort === SEARCH_SORT_CHANNELS && subscribedChannels.length) ||
     (personalSort === SEARCH_SORT_YOU && !!tags.length) ||
     personalSort === SEARCH_SORT_ALL;
+  const hasMatureTags = tags.some(t => MATURE_TAGS.includes(t));
   const claimSearchCacheQuery = createNormalizedClaimSearchKey(options);
   const uris = (hasContent && claimSearchByQuery[claimSearchCacheQuery]) || [];
   const shouldPerformSearch =
@@ -237,6 +240,7 @@ function ClaimListDiscover(props: Props) {
           ))}
         </FormField>
       )}
+      {hasMatureTags && hiddenNsfwMessage}
     </Fragment>
   );
 

--- a/src/ui/component/common/hidden-nsfw.jsx
+++ b/src/ui/component/common/hidden-nsfw.jsx
@@ -1,0 +1,23 @@
+// @flow
+import React from 'react';
+import Button from 'component/button';
+import * as ICONS from 'constants/icons';
+import Icon from 'component/common/icon';
+import I18nMessage from 'component/i18nMessage';
+
+type Props = {
+  type?: string,
+};
+
+export default function HiddenNsfw(props: Props) {
+  const { type = 'page' } = props;
+
+  return (
+    <div className="section--padded section__subtitle">
+      <Icon className="icon--hidden" icon={ICONS.EYE_OFF} />
+      <I18nMessage tokens={{ type, settings: <Button button="link" label={__('settings')} href="/$/settings" /> }}>
+        Content may be hidden on this %type% because of your %settings%
+      </I18nMessage>
+    </div>
+  );
+}

--- a/src/ui/component/common/hidden-nsfw.jsx
+++ b/src/ui/component/common/hidden-nsfw.jsx
@@ -1,7 +1,8 @@
 // @flow
+import * as PAGES from 'constants/pages';
+import * as ICONS from 'constants/icons';
 import React from 'react';
 import Button from 'component/button';
-import * as ICONS from 'constants/icons';
 import Icon from 'component/common/icon';
 import I18nMessage from 'component/i18nMessage';
 
@@ -15,8 +16,15 @@ export default function HiddenNsfw(props: Props) {
   return (
     <div className="section--padded section__subtitle">
       <Icon className="icon--hidden" icon={ICONS.EYE_OFF} />
-      <I18nMessage tokens={{ type, settings: <Button button="link" label={__('settings')} href="/$/settings" /> }}>
-        Content may be hidden on this %type% because of your %settings%
+      <I18nMessage
+        tokens={{
+          type,
+          settings: (
+            <Button button="link" label={__('settings')} navigate={`/$/${PAGES.SETTINGS}`} requiresAuth={IS_WEB} />
+          ),
+        }}
+      >
+        Content may be hidden on this %type% because of your %settings%.
       </I18nMessage>
     </div>
   );

--- a/src/ui/page/tags/view.jsx
+++ b/src/ui/page/tags/view.jsx
@@ -5,6 +5,7 @@ import ClaimListDiscover from 'component/claimListDiscover';
 import Button from 'component/button';
 import useHover from 'effects/use-hover';
 import analytics from 'analytics';
+import HiddenNsfw from 'component/common/hidden-nsfw';
 
 type Props = {
   location: { search: string },
@@ -45,6 +46,7 @@ function TagsPage(props: Props) {
     <Page>
       <ClaimListDiscover
         tags={tags}
+        hiddenNsfwMessage={<HiddenNsfw type="page" />}
         meta={<Button ref={buttonRef} button="link" onClick={handleFollowClick} requiresAuth={IS_WEB} label={label} />}
       />
     </Page>

--- a/src/ui/scss/component/_icon.scss
+++ b/src/ui/scss/component/_icon.scss
@@ -28,3 +28,7 @@
   height: 1rem;
   width: 1rem;
 }
+
+.icon--hidden {
+  margin-right: var(--spacing-small);
+}

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -813,5 +813,10 @@
   "Claimed Rewards": "Claimed Rewards",
   "This feature is not yet available for wallets with balances, but the gerbils are working on it.": "This feature is not yet available for wallets with balances, but the gerbils are working on it.",
   "I Understand": "I Understand",
-  "No modifier provided after separator %modSeperator%.": "No modifier provided after separator %modSeperator%."
+  "No modifier provided after separator %modSeperator%.": "No modifier provided after separator %modSeperator%.",
+  "Show anonymous content": "Show anonymous content",
+  "Anonymous content is published without a channel.": "Anonymous content is published without a channel.",
+  "settings": "settings",
+  "Content may be hidden on this %type% because of your %settings%": "Content may be hidden on this %type% because of your %settings%",
+  "Content may be hidden on this %type% because of your %settings%.": "Content may be hidden on this %type% because of your %settings%."
 }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 2703 (https://github.com/lbryio/lbry-desktop/issues/2703)

## What is the current behavior?

- No warning message that content might be hidden

## What is the new behavior?
- A message shows up in the UI near the top notifying the user that there settings might hide some content, and there is a link to go to the settings page and modify them.

- Although the ticket only asked for mature tags, the message is not too much in the users face so I thought it would be good to have it in the landing discover page, during tag searches, and during regular text searches:

![image](https://user-images.githubusercontent.com/11186044/66725432-942a0e80-edf7-11e9-8fd9-e966f852c661.png)

![image](https://user-images.githubusercontent.com/11186044/66725437-a441ee00-edf7-11e9-8e2e-69afc9710d37.png)

![image](https://user-images.githubusercontent.com/11186044/66725442-ac9a2900-edf7-11e9-817e-2b9c3a632bf9.png)




## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
