### PR TITLE
welcome tags only shows on 0 tags

### DIFF
--- a/src/ui/component/tagsSelect/view.jsx
+++ b/src/ui/component/tagsSelect/view.jsx
@@ -58,10 +58,10 @@ export default function TagsSelect(props: Props) {
   }
 
   React.useEffect(() => {
-    if (tagCount === 0) {
+    if (tagCount === 0 && showClose) {
       setHasClosed(false);
     }
-  }, [tagCount, setHasClosed]);
+  }, [tagCount, setHasClosed, showClose]);
 
   return (
     ((showClose && !hasClosed) || !showClose) && (


### PR DESCRIPTION
useEffect was there to reenable customize screen if tags ever became 0 length, and was firing on the publish page. Chose to only trigger that on the dismissable version.