### PR TITLE
Release blockers (warning - it's ugly in here)

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "husky": "^0.14.3",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#9919a8150998822ca997cd23418f023d64d4a3da",
+    "lbry-redux": "lbryio/lbry-redux#18c5496d54aeecf7256388bd6655f9b04a4c769d",
     "lbryinc": "lbryio/lbryinc#fb2e73ab31c2b9f80a53f082843a01e3f213ca45",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "codemirror": "^5.39.2",
     "concurrently": "^4.1.2",
     "connected-react-router": "^6.4.0",
-    "cookie": "^0.3.1",
     "copy-webpack-plugin": "^4.6.0",
     "country-data": "^0.0.31",
     "cross-env": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lbry",
-  "version": "0.37.0-rc.4",
+  "version": "0.37.0-rc.5",
   "description": "A browser for the LBRY network, a digital marketplace controlled by its users.",
   "keywords": [
     "lbry"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lbry",
-  "version": "0.37.0-rc.5",
+  "version": "0.37.0-rc.6",
   "description": "A browser for the LBRY network, a digital marketplace controlled by its users.",
   "keywords": [
     "lbry"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "@reach/menu-button": "^0.1.18",
     "@reach/rect": "^0.2.1",
     "@reach/tabs": "^0.1.5",
-    "@reach/tooltip": "^0.2.1",
     "@types/three": "^0.93.1",
     "adm-zip": "^0.4.13",
     "async-exit-hook": "^2.0.1",

--- a/src/ui/component/app/index.js
+++ b/src/ui/component/app/index.js
@@ -1,7 +1,7 @@
 import * as SETTINGS from 'constants/settings';
 import { hot } from 'react-hot-loader/root';
 import { connect } from 'react-redux';
-import { selectUser, doRewardList, doFetchRewardedContent, doFetchAccessToken } from 'lbryinc';
+import { selectUser, doRewardList, doFetchRewardedContent, doFetchAccessToken, selectAccessToken } from 'lbryinc';
 import { doFetchTransactions, doFetchChannelListMine, selectBalance } from 'lbry-redux';
 import { makeSelectClientSetting, selectThemePath } from 'redux/selectors/settings';
 import { selectIsUpgradeAvailable, selectAutoUpdateDownloaded } from 'redux/selectors/app';
@@ -17,6 +17,7 @@ const select = state => ({
   isUpgradeAvailable: selectIsUpgradeAvailable(state),
   balance: selectBalance(state),
   syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
+  accessToken: selectAccessToken(state),
 });
 
 const perform = dispatch => ({

--- a/src/ui/component/claimPreview/index.js
+++ b/src/ui/component/claimPreview/index.js
@@ -15,7 +15,7 @@ import {
   doPrepareEdit,
 } from 'lbry-redux';
 import { selectBlackListedOutpoints, selectFilteredOutpoints } from 'lbryinc';
-import { selectShowMatureContent, selectShowAnonymousContent } from 'redux/selectors/settings';
+import { selectShowMatureContent } from 'redux/selectors/settings';
 import { makeSelectHasVisitedUri } from 'redux/selectors/content';
 import { makeSelectIsSubscribed } from 'redux/selectors/subscriptions';
 import { push } from 'connected-react-router';
@@ -26,7 +26,6 @@ const select = (state, props) => ({
   pending: props.uri && makeSelectClaimIsPending(props.uri)(state),
   claim: props.uri && makeSelectClaimForUri(props.uri)(state),
   obscureNsfw: !selectShowMatureContent(state),
-  hideAnonymous: !selectShowAnonymousContent(state),
   claimIsMine: props.uri && makeSelectClaimIsMine(props.uri)(state),
   isResolvingUri: props.uri && makeSelectIsUriResolving(props.uri)(state),
   thumbnail: props.uri && makeSelectThumbnailForUri(props.uri)(state),

--- a/src/ui/component/claimPreview/view.jsx
+++ b/src/ui/component/claimPreview/view.jsx
@@ -22,7 +22,6 @@ type Props = {
   uri: string,
   claim: ?Claim,
   obscureNsfw: boolean,
-  hideAnonymous: boolean,
   showUserBlocked: boolean,
   claimIsMine: boolean,
   pending?: boolean,
@@ -55,7 +54,6 @@ type Props = {
 const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
   const {
     obscureNsfw,
-    hideAnonymous,
     claimIsMine,
     pending,
     history,
@@ -101,9 +99,8 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
   const isChannel = isValid ? parseURI(uri).isChannel : false;
   const includeChannelTooltip = type !== 'inline' && type !== 'tooltip' && !isChannel;
   const signingChannel = claim && claim.signing_channel;
-  const isAnonymous = !isChannel && !signingChannel;
-  const blocked = !claimIsMine && ((obscureNsfw && nsfw) || (hideAnonymous && isAnonymous));
-  let shouldHide = placeholder !== 'loading' && ((abandoned && !showPublishLink) || (blocked && !showUserBlocked));
+  let shouldHide =
+    placeholder !== 'loading' && ((abandoned && !showPublishLink) || (!claimIsMine && obscureNsfw && nsfw));
 
   // This will be replaced once blocking is done at the wallet server level
   if (claim && !shouldHide && blackListedOutpoints) {

--- a/src/ui/component/common/tooltip.jsx
+++ b/src/ui/component/common/tooltip.jsx
@@ -1,18 +1,20 @@
 // @flow
 import type { Node } from 'react';
 import React from 'react';
-import ReachTooltip from '@reach/tooltip';
-import '@reach/tooltip/styles.css';
 
 type Props = {
   label: string | Node,
-  children?: Node,
+  children: Node,
 };
 
 function Tooltip(props: Props) {
   const { children, label } = props;
 
-  return <ReachTooltip label={label}>{children}</ReachTooltip>;
+  if (typeof label !== 'string') {
+    return children;
+  }
+
+  return <span title={label}>{children}</span>;
 }
 
 export default Tooltip;

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -26,10 +26,10 @@ import pjson from 'package.json';
 import app from './app';
 import doLogWarningConsoleMessage from './logWarningConsoleMessage';
 import { ConnectedRouter, push } from 'connected-react-router';
-import cookie from 'cookie';
 import { formatLbryUriForWeb } from 'util/uri';
 import { PersistGate } from 'redux-persist/integration/react';
 import analytics from 'analytics';
+import { getAuthToken, setAuthToken } from 'util/saved-passwords';
 
 // Import our app styles
 // If a style is not necessary for the initial page load, it should be removed from `all.scss`
@@ -82,12 +82,7 @@ Lbryio.setOverride(
         }
 
         authToken = response.auth_token;
-
-        let date = new Date();
-        date.setFullYear(date.getFullYear() + 1);
-        document.cookie = cookie.serialize('auth_token', authToken, {
-          expires: date,
-        });
+        setAuthToken(authToken);
 
         // @if TARGET='app'
         ipcRenderer.send('set-auth-token', authToken);
@@ -114,7 +109,7 @@ Lbryio.setOverride(
         ipcRenderer.send('get-auth-token');
         // @endif
         // @if TARGET='web'
-        const { auth_token: authToken } = cookie.parse(document.cookie);
+        const authToken = getAuthToken();
         resolve(authToken);
         // @endif
       }

--- a/src/ui/modal/modalWalletEncrypt/view.jsx
+++ b/src/ui/modal/modalWalletEncrypt/view.jsx
@@ -74,6 +74,10 @@ class ModalWalletEncrypt extends React.PureComponent<Props, State> {
   submitEncryptForm() {
     const { state } = this;
 
+    if (!state.newPassword) {
+      return;
+    }
+
     let invalidEntries = false;
 
     if (state.newPassword !== state.newPasswordConfirm) {
@@ -89,9 +93,8 @@ class ModalWalletEncrypt extends React.PureComponent<Props, State> {
     if (invalidEntries === true) {
       return;
     }
-    if (state.rememberPassword === true) {
-      setSavedPassword(state.newPassword);
-    }
+
+    setSavedPassword(state.newPassword, state.rememberPassword);
     this.setState({ submitted: true });
     this.props.encryptWallet(state.newPassword);
   }

--- a/src/ui/modal/modalWalletUnlock/view.jsx
+++ b/src/ui/modal/modalWalletUnlock/view.jsx
@@ -39,9 +39,7 @@ class ModalWalletUnlock extends React.PureComponent<Props, State> {
     const { props } = this;
 
     if (props.walletUnlockSucceded === true) {
-      if (this.state.rememberPassword) {
-        setSavedPassword(this.state.password);
-      }
+      setSavedPassword(this.state.password, this.state.rememberPassword);
       props.closeModal();
     }
   }

--- a/src/ui/page/settings/index.js
+++ b/src/ui/page/settings/index.js
@@ -10,7 +10,6 @@ import SettingsPage from './view';
 const select = state => ({
   daemonSettings: selectDaemonSettings(state),
   showNsfw: makeSelectClientSetting(SETTINGS.SHOW_MATURE)(state),
-  showAnonymous: makeSelectClientSetting(SETTINGS.SHOW_ANONYMOUS)(state),
   instantPurchaseEnabled: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_ENABLED)(state),
   instantPurchaseMax: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_MAX)(state),
   currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),

--- a/src/ui/page/settings/view.jsx
+++ b/src/ui/page/settings/view.jsx
@@ -47,7 +47,6 @@ type Props = {
   clearCache: () => Promise<any>,
   daemonSettings: DaemonSettings,
   showNsfw: boolean,
-  showAnonymous: boolean,
   instantPurchaseEnabled: boolean,
   instantPurchaseMax: Price,
   currentTheme: string,
@@ -178,7 +177,6 @@ class SettingsPage extends React.PureComponent<Props, State> {
     const {
       daemonSettings,
       showNsfw,
-      showAnonymous,
       instantPurchaseEnabled,
       instantPurchaseMax,
       currentTheme,
@@ -374,14 +372,14 @@ class SettingsPage extends React.PureComponent<Props, State> {
                     )}
                   />
 
-                  <FormField
+                  {/* <FormField
                     type="checkbox"
                     name="show_anonymous"
                     onChange={() => setClientSetting(SETTINGS.SHOW_ANONYMOUS, !showAnonymous)}
                     checked={showAnonymous}
                     label={__('Show anonymous content')}
                     helper={__('Anonymous content is published without a channel.')}
-                  />
+                  /> */}
 
                   <FormField
                     type="checkbox"

--- a/src/ui/redux/actions/app.js
+++ b/src/ui/redux/actions/app.js
@@ -37,8 +37,7 @@ import { doAuthenticate, doGetSync, doResetSync } from 'lbryinc';
 import { lbrySettings as config, version as appVersion } from 'package.json';
 import { push } from 'connected-react-router';
 import analytics from 'analytics';
-import { deleteAuthToken, getSavedPassword } from 'util/saved-passwords';
-import cookie from 'cookie';
+import { deleteAuthToken, getSavedPassword, getAuthToken } from 'util/saved-passwords';
 
 // @if TARGET='app'
 const { autoUpdater } = remote.require('electron-updater');
@@ -437,7 +436,7 @@ export function doAnalyticsView(uri, timeToStart) {
 export function doSignIn() {
   return (dispatch, getState) => {
     // @if TARGET='web'
-    const { auth_token: authToken } = cookie.parse(document.cookie);
+    const authToken = getAuthToken();
     Lbry.setApiHeader('X-Lbry-Auth-Token', authToken);
     dispatch(doBalanceSubscribe());
     dispatch(doFetchChannelListMine());
@@ -471,7 +470,9 @@ export function doSyncWithPreferences() {
       dispatch(doFetchChannelListMine());
 
       function successCb(savedPreferences) {
-        dispatch(doPopulateSharedUserState(savedPreferences));
+        if (savedPreferences !== null) {
+          dispatch(doPopulateSharedUserState(savedPreferences));
+        }
       }
 
       function failCb() {

--- a/src/ui/redux/reducers/settings.js
+++ b/src/ui/redux/reducers/settings.js
@@ -36,7 +36,6 @@ const defaultState = {
 
     // Content
     [SETTINGS.SHOW_MATURE]: false,
-    [SETTINGS.SHOW_ANONYMOUS]: true,
     [SETTINGS.AUTOPLAY]: true,
     [SETTINGS.FLOATING_PLAYER]: true,
     [SETTINGS.AUTO_DOWNLOAD]: true,

--- a/src/ui/redux/selectors/settings.js
+++ b/src/ui/redux/selectors/settings.js
@@ -26,7 +26,6 @@ export const makeSelectClientSetting = setting =>
 
 // refactor me
 export const selectShowMatureContent = makeSelectClientSetting(SETTINGS.SHOW_MATURE);
-export const selectShowAnonymousContent = makeSelectClientSetting(SETTINGS.SHOW_ANONYMOUS);
 
 export const selectTheme = makeSelectClientSetting(SETTINGS.THEME);
 export const selectAutomaticDarkModeEnabled = makeSelectClientSetting(SETTINGS.AUTOMATIC_DARK_MODE_ENABLED);

--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -68,7 +68,6 @@ const whiteListedReducers = [
   'search',
   'blocked',
   'settings',
-  'sync',
   'subscriptions',
 ];
 

--- a/src/ui/util/saved-passwords.js
+++ b/src/ui/util/saved-passwords.js
@@ -41,9 +41,15 @@ export const setSavedPassword = (value?: string, saveToDisk: boolean) => {
       resolve(success);
     });
 
-    sessionPassword = value;
-    if (saveToDisk && value !== undefined && value !== null && value !== '') {
-      ipcRenderer.send('set-password', value);
+    const password = value === undefined || value === null ? '' : value;
+    sessionPassword = password;
+
+    if (saveToDisk) {
+      if (password) {
+        ipcRenderer.send('set-password', password);
+      } else {
+        deleteSavedPassword();
+      }
     }
   });
 };

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -821,5 +821,13 @@
   "Sync": "Sync",
   "earned and bound in tips": "earned and bound in tips",
   "currently staked": "currently staked",
-  "%amountBehind% block behind": "%amountBehind% block behind"
+  "%amountBehind% block behind": "%amountBehind% block behind",
+  "Sync balance and preferences across devices.": "Sync balance and preferences across devices.",
+  "By continuing, I agree to the %terms% and confirm I am over the age of 13.": "By continuing, I agree to the %terms% and confirm I am over the age of 13.",
+  "Advanced Editor": "Advanced Editor",
+  "If you bid more than %amount% LBC, when someone navigates to %uri%, it will load your published content. However, you can get a longer version of this URL for any bid.": "If you bid more than %amount% LBC, when someone navigates to %uri%, it will load your published content. However, you can get a longer version of this URL for any bid.",
+  "Sync your balance and preferences accross devices.": "Sync your balance and preferences accross devices.",
+  "%nameOrTitle% has been published to lbry://%name%. Click here to view it.": "%nameOrTitle% has been published to lbry://%name%. Click here to view it.",
+  "Discussion": "Discussion",
+  "If you don't choose a file, the file from your existing claim %name% will be used": "If you don't choose a file, the file from your existing claim %name% will be used"
 }

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -820,5 +820,6 @@
   "Content may be hidden on this %type% because of your %settings%.": "Content may be hidden on this %type% because of your %settings%.",
   "Sync": "Sync",
   "earned and bound in tips": "earned and bound in tips",
-  "currently staked": "currently staked"
+  "currently staked": "currently staked",
+  "%amountBehind% block behind": "%amountBehind% block behind"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6865,9 +6865,9 @@ lazy-val@^1.0.3, lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#9919a8150998822ca997cd23418f023d64d4a3da:
+lbry-redux@lbryio/lbry-redux#18c5496d54aeecf7256388bd6655f9b04a4c769d:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/9919a8150998822ca997cd23418f023d64d4a3da"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/18c5496d54aeecf7256388bd6655f9b04a4c769d"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,7 +897,7 @@
   resolved "https://registry.yarnpkg.com/@posthtml/esm/-/esm-1.0.0.tgz#09bcb28a02438dcee22ad1970ca1d85a000ae0cf"
   integrity sha512-dEVG+ITnvqKGa4v040tP+n8LOKOqr94qjLva7bE5pnfm2KHJwsKz69J4KMxgWLznbpBJzy8vQfCayEk3vLZnZQ==
 
-"@reach/auto-id@0.2.0", "@reach/auto-id@^0.2.0":
+"@reach/auto-id@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.2.0.tgz#97f9e48fe736aa5c6f4f32cf73c1f19d005f8550"
   integrity sha512-lVK/svL2HuQdp7jgvlrLkFsUx50Az9chAhxpiPwBqcS83I2pVWvXp98FOcSCCJCV++l115QmzHhFd+ycw1zLBg==
@@ -948,18 +948,6 @@
     "@reach/utils" "^0.2.2"
     warning "^4.0.2"
 
-"@reach/tooltip@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@reach/tooltip/-/tooltip-0.2.1.tgz#70a80d6defedee53cedf5480cd3d37dfb20020d0"
-  integrity sha512-3O7oXoymNkEAolHN9WbuspY7mA3zIOrTaibmYkKFtGT6FgyBrAQyOQn1ZhBuSza6RjSIkEtFRpbDEKK1UJEI6A==
-  dependencies:
-    "@reach/auto-id" "0.2.0"
-    "@reach/portal" "^0.2.1"
-    "@reach/rect" "^0.2.1"
-    "@reach/utils" "^0.2.3"
-    "@reach/visually-hidden" "^0.1.4"
-    prop-types "^15.7.2"
-
 "@reach/utils@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.2.2.tgz#c3a05ae9fd1f921988ae8a89b5a0d28d1a2b92df"
@@ -969,11 +957,6 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.2.3.tgz#820f6a6af4301b4c5065cfc04bb89e6a3d1d723f"
   integrity sha512-zM9rA8jDchr05giMhL95dPeYkK67cBQnIhCVrOKKqgWGsv+2GE/HZqeptvU4zqs0BvIqsThwov+YxVNVh5csTQ==
-
-"@reach/visually-hidden@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.1.4.tgz#0dc4ecedf523004337214187db70a46183bd945b"
-  integrity sha512-QHbzXjflSlCvDd6vJwdwx16mSB+vUCCQMiU/wK/CgVNPibtpEiIbisyxkpZc55DyDFNUIqP91rSUsNae+ogGDQ==
 
 "@reach/window-size@^0.1.4":
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,11 +2941,6 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookie@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
-
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"


### PR DESCRIPTION
- manually reverts #3001
- removes @reach/tooltip and temporarily hides claim preview tooltips
  - They were causing the app to crash even more than normal and am unsure of the real fix for now
- Removes `cookie` npm module and add utils to write/delete cookies