### PR TITLE
Sanitize urls with single quotation marks

### DIFF
--- a/src/ui/component/cardMedia/view.jsx
+++ b/src/ui/component/cardMedia/view.jsx
@@ -18,7 +18,7 @@ class CardMedia extends React.PureComponent<Props> {
     }
 
     const url = thumbnail || Placeholder;
-    return <div style={{ backgroundImage: `url('${url}')` }} className={className} />;
+    return <div style={{ backgroundImage: `url('${url.replace(/'/g,"\\'")}')` }} className={className} />;
   }
 }
 


### PR DESCRIPTION

## PR Checklist


Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Does not fix anything already in an issue.
However, it does fix behavior for thumbnails whose `src` URLs contain single quotes.

## What is the current behavior?

Thumbnail images which have URLs containing `'` are broken and do not show up.
An example is as follows:
The behavior for a thumbnail URL like `https://sesamestrong.github.io/lbry-desktop/google's%20logo.png` is that **the thumbnail does not show up**; the CSS rule changes from `background-image: url('https://sesamestrong.github.io/lbry-desktop/google's%20logo.png')` to `background-image: url((unknown));` because there is an extra `'` in the URL, which breaks CSS parsing.

## What is the new behavior?

The new behavior is that the CSS rule for URLs with `'` has every `'` in the URL replaced with `\'`, resulting in that **the thumbnail shows up**.

## Other information

This PR does not contain any breaking changes; however, it is possible that problems similar to this one might show up in the future. In that case, it might be desirable to add a URL sanitization utility function somewhere in the project for reuse.
