### PR TITLE
Edit title to 'Latest Transactions' from 'Recent Transactions'

### DIFF
--- a/src/ui/component/transactionListRecent/view.jsx
+++ b/src/ui/component/transactionListRecent/view.jsx
@@ -24,7 +24,7 @@ class TransactionListRecent extends React.PureComponent<Props> {
       <section className="card">
         <TransactionList
           slim
-          title={__('Recent Transactions')}
+          title={__('Latest Transactions')}
           transactions={transactions}
           emptyMessage={__("Looks like you don't have any recent transactions.")}
         />


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/3045

## What is the current behavior?
- Currently the application displays "Recent Transactions" in the title prop of the TransactionList as passed down from TransactionListRecent, and the page size for the pagination is divided by TX_LIST.PAGE_SIZE which is currently set to 50, so we have 50 items per page.

## What is the new behavior?
- The application will now display "Recent Transactions" at the top of the Transaction List.

## Other information
- I'll be submitting a PR to the lbry-redux repo as well to modify the constant for page size so that pages now hold 10 items instead of 50

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
