### PR TITLE
fix: view htm files with HtmlViewer

### DIFF
--- a/src/ui/component/fileRender/view.jsx
+++ b/src/ui/component/fileRender/view.jsx
@@ -143,6 +143,7 @@ class FileRender extends React.PureComponent<Props> {
       pdf: <PdfViewer source={downloadPath} />,
       docx: <DocxViewer source={downloadPath} />,
       html: <HtmlViewer source={downloadPath} />,
+      htm: <HtmlViewer source={downloadPath} />,
       // @endif
       // Add routes to viewer...
     };


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3124 
## What is the current behavior?
htm files are not opened in-app, while html files are
## What is the new behavior?
htm files are also opened in-app
## Other information
resolves #3124 
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

