### PR TITLE
Fix/web context menu

### DIFF
--- a/src/platforms/web/stubs.js
+++ b/src/platforms/web/stubs.js
@@ -16,11 +16,18 @@ export const remote = {
   },
   Menu: {
     getApplicationMenu: callable,
+    buildFromTemplate: () => {
+      return {
+        popup: () => {},
+      };
+    },
   },
   require: callable,
 };
 
-export const clipboard = {};
+export const clipboard = {
+  readText: () => '',
+};
 export const ipcRenderer = {};
 
 export const isDev = false;

--- a/src/ui/component/claimPreview/view.jsx
+++ b/src/ui/component/claimPreview/view.jsx
@@ -134,11 +134,13 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
   }
 
   function handleContextMenu(e) {
+    // @if TARGET='app'
     e.preventDefault();
     e.stopPropagation();
     if (claim) {
       openCopyLinkMenu(convertToShareLink(claim.permanent_url), e);
     }
+    // @endif
   }
 
   function handleOnClick(e) {


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

If the context is outside of the electron app, the context menu will not be handled.

Issue Number: #3065

## What is the current behavior?
Right clicking will bring up a context menu in the elctron app within lbry.tv
Right clicking in a browser on content will not bring up the context menu, and will print errors in the console.

## What is the new behavior?
Electron app continues to behave as normal.
Native context menu now appears in browsers.

## Other information

```
import { clipboard, remote, isDev } from 'web/stubs'; // eslint-disable-line
```
Would have loved to be able to include the `import clipboard` on line 6 in /ui/util/context-menu.js, but it seems that despite attempting to add an eslint-disable-line comment, eslint will return this anyways:

```
4 | // @endif
5 | // @if TARGET='web'
> 6 | import { clipboard, remote, isDev } from 'web/stubs'; // eslint-disable-line
  |          ^
7 | // @endif
8 |
9 | function injectDevelopmentTemplate(event, templates) {   

✖ 1 problem (1 error, 0 warnings)
```