### PR TITLE
fixes flow issue in sidebar by dynamically building link key

### DIFF
--- a/src/ui/component/sideBar/view.jsx
+++ b/src/ui/component/sideBar/view.jsx
@@ -68,7 +68,7 @@ function SideBar(props: Props) {
               ),
             },
           ].map(linkProps => (
-            <li key={linkProps.label}>
+            <li key={linkProps.navigate}>
               <Button {...linkProps} className="navigation-link" activeClass="navigation-link--active" />
             </li>
           ))}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Flow type correction 

## Fixes

Issue Number: #2024

## What is the current behavior?

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/ui/component/sideBar/view.jsx:71:22

Cannot create li element because in property key:
 • Either React.Element [1] is incompatible with string [2].
 • Or React.Element [1] is incompatible with number [3].

        src/ui/component/sideBar/view.jsx
    [1]  60│                   <>
         61│                     {__('Publishes')}
         62│                     <Spinner type="small" />
         63│                   </>
           :
         68│               ),
         69│             },
         70│           ].map(linkProps => (
         71│             <li key={linkProps.label}>
         72│               <Button {...linkProps} className="navigation-link" activeClass="navigation-link--active" />
         73│             </li>
         74│           ))}
         75│         </ul>
         76│

        /private/tmp/flow/flowlib_1ec7e4cc/react.js
 [2][3] 188│ declare type React$Key = string | number;
```

## What is the new behavior?

Does not pass a span as `li` key, which is the correct behavior for a react element

