### PR TITLE
fix(tagsSearch): Undefined tagsPassedIn prop prevents page from loading

### DIFF
--- a/src/ui/component/tagsSearch/view.jsx
+++ b/src/ui/component/tagsSearch/view.jsx
@@ -26,7 +26,7 @@ type Props = {
 
 export default function TagsSearch(props: Props) {
   const {
-    tagsPassedIn,
+    tagsPassedIn = [],
     unfollowedTags = [],
     followedTags = [],
     doToggleTagFollow,


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: N/A (Should I create an issue?)

## What is the current behavior?
If no tags are passed in, then the prop is undefined and an exception causes the entire page to error out, since a map operation cannot be done on an undefined variable.

## What is the new behavior?
Undefined prop defaults to empty array, and the page loads successfully.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
