### PR TITLE
feat(wallet): Added close buttons on send/address pages

### DIFF
--- a/src/ui/component/walletAddress/index.js
+++ b/src/ui/component/walletAddress/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { doCheckAddressIsMine, doGetNewAddress, selectReceiveAddress, selectGettingNewAddress } from 'lbry-redux';
 import WalletAddress from './view';
+import { withRouter } from 'react-router';
 
 const select = state => ({
   receiveAddress: selectReceiveAddress(state),
@@ -12,7 +13,9 @@ const perform = dispatch => ({
   getNewAddress: () => dispatch(doGetNewAddress()),
 });
 
-export default connect(
-  select,
-  perform
-)(WalletAddress);
+export default withRouter(
+  connect(
+    select,
+    perform
+  )(WalletAddress)
+);

--- a/src/ui/component/walletAddress/view.jsx
+++ b/src/ui/component/walletAddress/view.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { REMOVE } from 'constants/icons';
+import * as ICONS from 'constants/icons';
 import Button from 'component/button';
 import CopyableText from 'component/copyableText';
 import QRCode from 'component/common/qr-code';
@@ -53,7 +53,7 @@ class WalletAddress extends React.PureComponent<Props, State> {
         title={
           <React.Fragment>
             {__('Receive Credits')}
-            <Button button="close" icon={REMOVE} onClick={() => history.goBack()} />
+            <Button button="close" icon={ICONS.REMOVE} onClick={() => history.goBack()} />
           </React.Fragment>
         }
         subtitle={__('Use this address to receive LBC.')}

--- a/src/ui/component/walletAddress/view.jsx
+++ b/src/ui/component/walletAddress/view.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import { REMOVE } from 'constants/icons';
 import Button from 'component/button';
 import CopyableText from 'component/copyableText';
 import QRCode from 'component/common/qr-code';
@@ -10,6 +11,7 @@ type Props = {
   receiveAddress: string,
   getNewAddress: () => void,
   gettingNewAddress: boolean,
+  history: { goBack: () => void },
 };
 
 type State = {
@@ -43,12 +45,17 @@ class WalletAddress extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { receiveAddress, getNewAddress, gettingNewAddress } = this.props;
+    const { receiveAddress, getNewAddress, gettingNewAddress, history } = this.props;
     const { showQR } = this.state;
 
     return (
       <Card
-        title={__('Receive Credits')}
+        title={
+          <React.Fragment>
+            {__('Receive Credits')}
+            <Button button="close" icon={REMOVE} onClick={() => history.goBack()} />
+          </React.Fragment>
+        }
         subtitle={__('Use this address to receive LBC.')}
         actions={
           <React.Fragment>

--- a/src/ui/component/walletSend/index.js
+++ b/src/ui/component/walletSend/index.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { selectBalance } from 'lbry-redux';
 import { doOpenModal } from 'redux/actions/app';
 import WalletSend from './view';
+import { withRouter } from 'react-router';
 
 const perform = dispatch => ({
   openModal: (modal, props) => dispatch(doOpenModal(modal, props)),
@@ -11,7 +12,9 @@ const select = state => ({
   balance: selectBalance(state),
 });
 
-export default connect(
-  select,
-  perform
-)(WalletSend);
+export default withRouter(
+  connect(
+    select,
+    perform
+  )(WalletSend)
+);

--- a/src/ui/component/walletSend/view.jsx
+++ b/src/ui/component/walletSend/view.jsx
@@ -1,6 +1,6 @@
 // @flow
 import * as MODALS from 'constants/modal_types';
-import { REMOVE } from 'constants/icons';
+import * as ICONS from 'constants/icons';
 import React from 'react';
 import Button from 'component/button';
 import { Form, FormField } from 'component/common/form';
@@ -43,7 +43,7 @@ class WalletSend extends React.PureComponent<Props> {
         title={
           <React.Fragment>
             {__('Send Credits')}
-            <Button button="close" icon={REMOVE} onClick={() => history.goBack()} />
+            <Button button="close" icon={ICONS.REMOVE} onClick={() => history.goBack()} />
           </React.Fragment>
         }
         subtitle={__('Send LBC to your friends or favorite creators.')}

--- a/src/ui/component/walletSend/view.jsx
+++ b/src/ui/component/walletSend/view.jsx
@@ -1,5 +1,6 @@
 // @flow
 import * as MODALS from 'constants/modal_types';
+import { REMOVE } from 'constants/icons';
 import React from 'react';
 import Button from 'component/button';
 import { Form, FormField } from 'component/common/form';
@@ -15,6 +16,7 @@ type DraftTransaction = {
 type Props = {
   openModal: (id: string, { address: string, amount: number }) => void,
   balance: number,
+  history: { goBack: () => void },
 };
 
 class WalletSend extends React.PureComponent<Props> {
@@ -34,11 +36,16 @@ class WalletSend extends React.PureComponent<Props> {
   }
 
   render() {
-    const { balance } = this.props;
+    const { balance, history } = this.props;
 
     return (
       <Card
-        title={__('Send Credits')}
+        title={
+          <React.Fragment>
+            {__('Send Credits')}
+            <Button button="close" icon={REMOVE} onClick={() => history.goBack()} />
+          </React.Fragment>
+        }
         subtitle={__('Send LBC to your friends or favorite creators.')}
         actions={
           <Formik


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3143

## What is the current behavior?
You have to use the back button or one of the navigation steps to home/other pages to leave the send/receive pages.

## What is the new behavior?
New X button on the cards on the pages will send you back to where you came from.
This works on both the electron and web apps.

## Other information
![image](https://user-images.githubusercontent.com/8202335/67833364-abc4f080-faa1-11e9-85ff-a16982e788d4.png)
![image](https://user-images.githubusercontent.com/8202335/67833383-b2536800-faa1-11e9-8658-8cf73b225038.png)


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
