### PR TITLE
Add Creative Commons Attribution 3.0 license

### DIFF
--- a/src/ui/constants/licenses.js
+++ b/src/ui/constants/licenses.js
@@ -1,5 +1,9 @@
 export const CC_LICENSES = [
   {
+    value: 'Creative Commons Attribution 3.0',
+    url: 'https://creativecommons.org/licenses/by/3.0/legalcode',
+  },
+  {
     value: 'Creative Commons Attribution 4.0 International',
     url: 'https://creativecommons.org/licenses/by/4.0/legalcode',
   },


### PR DESCRIPTION
This license is used for many presentation recordings. It would be great to have the license supported by the application directly and avoid constantly looking for the license link.

I know that adding licenses could be a controversial issue but this would be a small help for me to have smoother uploads of the videos to LBRY. If you don't agree that CC-BY 3 should be part of the common known licenses than feel free to close this. I won't be mad about that :).

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [x] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [X] Other - Please describe: Add license to the list of licenses.

## Fixes

Issue Number: N/A

## What is the current behavior?
Missing CC-BY v3 license in the list of licenses.

## What is the new behavior?
Add this license to the list.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
