### PR TITLE
feat(settings): Clear support state when clearing cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Context menu does not open in the webapp when right clicking video tiles ([#3135](https://github.com/lbryio/lbry-desktop/pull/3135))
+- Undefined tags prevents homepage from loading ([#3146](https://github.com/lbryio/lbry-desktop/pull/3146))
+
 ### Added
 
 - Search on downloads page ([#2969](https://github.com/lbryio/lbry-sdk/pull/2969))
+- Clear support state when clearing cache in settings([#3149](https://github.com/lbryio/lbry-desktop/pull/3149))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "husky": "^0.14.3",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#e5440ba86078dcdfced490bc444810c8f57dc774",
+    "lbry-redux": "lbryio/lbry-redux#130edee41ca4a11fac1d57c25c854ef8aeb4e16e",
     "lbryinc": "lbryio/lbryinc#f962cdf31a4c36f7bdb8b71fc403a3377d58a460",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/src/ui/redux/actions/app.js
+++ b/src/ui/redux/actions/app.js
@@ -19,6 +19,7 @@ import {
   doClearPublish,
   doPreferenceGet,
   doToast,
+  doClearSupport,
 } from 'lbry-redux';
 import Native from 'native';
 import { doFetchDaemonSettings } from 'redux/actions/settings';
@@ -339,6 +340,7 @@ export function doClearCache() {
     // const reducersToClear = whiteListedReducers.filter(reducerKey => reducerKey !== 'tags');
     // window.cacheStore.purge(reducersToClear);
     window.localStorage.clear();
+    dispatch(doClearSupport());
     return dispatch(doClearPublish());
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6843,9 +6843,9 @@ lazy-val@^1.0.3, lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#e5440ba86078dcdfced490bc444810c8f57dc774:
+lbry-redux@lbryio/lbry-redux#130edee41ca4a11fac1d57c25c854ef8aeb4e16e:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/e5440ba86078dcdfced490bc444810c8f57dc774"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/130edee41ca4a11fac1d57c25c854ef8aeb4e16e"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3141

## What is the current behavior?
Sometimes a support can get locked up due to having a larger wallet / sdk connectivity issues, and when this happens, you can't send any other supports because the send button is greyed out.

## What is the new behavior?
Clearing the cache will dispatch an action, `CLEAR_SUPPORT_TRANSACTION`, which will set the sendingSupport state to false.

## Other information
🚨 This PR on lbry-redux will need to be merged first for this to work. 🚨 
https://github.com/lbryio/lbry-redux/pull/231

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
