### PR TITLE
Fix a typo s/accross/across/

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -821,7 +821,6 @@
   "By continuing, I agree to the %terms% and confirm I am over the age of 13.": "By continuing, I agree to the %terms% and confirm I am over the age of 13.",
   "Advanced Editor": "Advanced Editor",
   "If you bid more than %amount% LBC, when someone navigates to %uri%, it will load your published content. However, you can get a longer version of this URL for any bid.": "If you bid more than %amount% LBC, when someone navigates to %uri%, it will load your published content. However, you can get a longer version of this URL for any bid.",
-  "Sync your balance and preferences across devices.": "Sync your balance and preferences across devices.",
   "%nameOrTitle% has been published to lbry://%name%. Click here to view it.": "%nameOrTitle% has been published to lbry://%name%. Click here to view it.",
   "Discussion": "Discussion",
   "If you don't choose a file, the file from your existing claim %name% will be used": "If you don't choose a file, the file from your existing claim %name% will be used",

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -821,7 +821,7 @@
   "By continuing, I agree to the %terms% and confirm I am over the age of 13.": "By continuing, I agree to the %terms% and confirm I am over the age of 13.",
   "Advanced Editor": "Advanced Editor",
   "If you bid more than %amount% LBC, when someone navigates to %uri%, it will load your published content. However, you can get a longer version of this URL for any bid.": "If you bid more than %amount% LBC, when someone navigates to %uri%, it will load your published content. However, you can get a longer version of this URL for any bid.",
-  "Sync your balance and preferences accross devices.": "Sync your balance and preferences accross devices.",
+  "Sync your balance and preferences across devices.": "Sync your balance and preferences across devices.",
   "%nameOrTitle% has been published to lbry://%name%. Click here to view it.": "%nameOrTitle% has been published to lbry://%name%. Click here to view it.",
   "Discussion": "Discussion",
   "If you don't choose a file, the file from your existing claim %name% will be used": "If you don't choose a file, the file from your existing claim %name% will be used",


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue not documented separately.

## What is the current behavior?

The word "across" is misspelled as "accross"

## What is the new behavior?

Proper spelling of "across"

## Other information

I'm not sure if changing the JSON key is going to cause breakage... this is my 1st attempt at patching LBRY. I'd welcome some feedback or additional information on how to validate the change!
