### PR TITLE
actually fix lbry.tv on edge

### DIFF
--- a/lbrytv/package.json
+++ b/lbrytv/package.json
@@ -38,6 +38,7 @@
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.3.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/plugin-transform-flow-strip-types": "^7.2.3",
     "@babel/plugin-transform-runtime": "^7.4.3",
     "@babel/polyfill": "^7.2.5",

--- a/lbrytv/webpack.config.js
+++ b/lbrytv/webpack.config.js
@@ -28,9 +28,9 @@ const webConfig = {
       {
         loader: 'babel-loader',
         test: /\.jsx?$/,
-        exclude: /node_modules/,
         options: {
-          rootMode: 'upward',
+          presets: ['@babel/env', '@babel/react', '@babel/flow'],
+          plugins: ['@babel/plugin-proposal-object-rest-spread', '@babel/plugin-proposal-class-properties'],
         },
       },
       {


### PR DESCRIPTION
The fix is running babel on node_modules with a new plugin to transpile `...` into `Object.assign()`. Also removing the `css-doodle` import on the sidebar. It isn't supported on edge but it wasn't being used anyway.