### PR TITLE
preview styling fix yolo'd from github UI

### DIFF
--- a/ui/modal/modalPublish/view.jsx
+++ b/ui/modal/modalPublish/view.jsx
@@ -36,7 +36,7 @@ class ModalPublishSuccess extends React.PureComponent<Props> {
           closeModal();
         }}
       >
-        <p className="card__subtitle">
+        <p className="section__subtitle">
           {__(`Your %publishMessage% pending on LBRY. It will take a few minutes to appear for other users.`, {
             publishMessage,
           })}

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -27,13 +27,13 @@
 .card--reward-total {
   background-repeat: no-repeat;
   background-size: cover;
-  color: var(--color-white); //white;
+  color: var(--color-white);
   font-size: var(--font-large);
   font-weight: var(--font-weight-bold);
 }
 
 .card--inline {
-  border: 1px solid black; //gray-1;
+  border: 1px solid var(--color-border);
   border-radius: var(--card-radius);
   margin-bottom: var(--spacing-medium);
 

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -58,7 +58,7 @@
   overflow: visible;
   padding: var(--spacing-medium);
 
-  &:not(.claim-preview--inline) {
+  &:not(.claim-preview--inline):not(.claim-preview--pending) {
     cursor: pointer;
   }
 
@@ -113,12 +113,7 @@
 }
 
 .claim-preview--pending {
-  cursor: pointer;
   opacity: 0.6;
-
-  &:hover {
-    background-color: black; //white;
-  }
 }
 
 .claim-preview--inline {

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -186,6 +186,6 @@
 }
 
 .claim-upload__progress--inner {
-  background: black; //teal-1;
+  background: var(--color-primary-alt);
   padding: var(--spacing-miniscule);
 }


### PR DESCRIPTION
I'm not sure what this styling was supposed to be doing previously, but faded plus no-click-indicator seems to make the most sense for pending content.