### PR TITLE
Makes channel thumbnails clickable on file page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.39.0] - [2019-3-19]
+
+### Added
+- Allows channel thumbnails to be clickable on file pages ([#3304](https://github.com/lbryio/lbry-desktop/pull/3304))
+
+
+
 ## [0.37.2] - [2019-11-21]
 
 ### Fixed
@@ -13,7 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Undefined tags prevents homepage from loading ([#3146](https://github.com/lbryio/lbry-desktop/pull/3146))
 
 ### Added
-- Allows channel thumbnails to be clickable on file pages ([#3304](https://github.com/lbryio/lbry-desktop/pull/3304))
 - Setting to start the app minimized when you login (Linux/Windows only) ([#3236](https://github.com/lbryio/lbry-desktop/pull/3236))
 - Search on downloads page ([#2969](https://github.com/lbryio/lbry-desktop/pull/2969))
 - Clear support state when clearing cache in settings([#3149](https://github.com/lbryio/lbry-desktop/pull/3149))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Undefined tags prevents homepage from loading ([#3146](https://github.com/lbryio/lbry-desktop/pull/3146))
 
 ### Added
-
+- Allows channel thumbnails to be clickable on file pages ([#3303](https://github.com/lbryio/lbry-desktop/pull/3303))
 - Setting to start the app minimized when you login (Linux/Windows only) ([#3236](https://github.com/lbryio/lbry-desktop/pull/3236))
 - Search on downloads page ([#2969](https://github.com/lbryio/lbry-desktop/pull/2969))
 - Clear support state when clearing cache in settings([#3149](https://github.com/lbryio/lbry-desktop/pull/3149))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Undefined tags prevents homepage from loading ([#3146](https://github.com/lbryio/lbry-desktop/pull/3146))
 
 ### Added
-- Allows channel thumbnails to be clickable on file pages ([#3303](https://github.com/lbryio/lbry-desktop/pull/3303))
+- Allows channel thumbnails to be clickable on file pages ([#3304](https://github.com/lbryio/lbry-desktop/pull/3304))
 - Setting to start the app minimized when you login (Linux/Windows only) ([#3236](https://github.com/lbryio/lbry-desktop/pull/3236))
 - Search on downloads page ([#2969](https://github.com/lbryio/lbry-desktop/pull/2969))
 - Clear support state when clearing cache in settings([#3149](https://github.com/lbryio/lbry-desktop/pull/3149))

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -191,7 +191,12 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
         'claim-preview--pending': pending,
       })}
     >
-      {isChannel ? <ChannelThumbnail uri={uri} obscure={channelIsBlocked} /> : <CardMedia thumbnail={thumbnail} />}
+      {isChannel ? (
+          <UriIndicator uri={uri} link>
+            <ChannelThumbnail uri={uri} obscure={channelIsBlocked} />
+          </UriIndicator>
+      ) : (<CardMedia thumbnail={thumbnail} />)
+      }
       <div className="claim-preview-metadata">
         <div className="claim-preview-info">
           <div className="claim-preview-title">

--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -1,4 +1,5 @@
 // @flow
+import type { Node } from 'react';
 import React from 'react';
 import Button from 'component/button';
 import Tooltip from 'component/common/tooltip';
@@ -14,6 +15,8 @@ type Props = {
   // Possibly because the resolve function is an arrow function that is passed in props?
   resolveUri: string => void,
   uri: string,
+  // to allow for other elements to be nested within the UriIndicator
+  children: ?Node,
 };
 
 class UriIndicator extends React.PureComponent<Props> {
@@ -38,7 +41,7 @@ class UriIndicator extends React.PureComponent<Props> {
   };
 
   render() {
-    const { link, isResolvingUri, claim, addTooltip } = this.props;
+    const { link, isResolvingUri, claim, addTooltip, children } = this.props;
 
     if (!claim) {
       return <span className="empty">{isResolvingUri ? 'Validating...' : 'Unused'}</span>;
@@ -67,10 +70,11 @@ class UriIndicator extends React.PureComponent<Props> {
             <Tooltip label={<ClaimPreview uri={channelLink} type="tooltip" placeholder={false} />}>{children}</Tooltip>
           )
         : 'span';
-
+      /* to wrap the UriIndicator element around other DOM nodes as a button */
+      const content = children ? children : (<Wrapper>{inner}</Wrapper>);
       return (
         <Button className="button--uri-indicator" navigate={channelLink}>
-          <Wrapper>{inner}</Wrapper>
+          {content}
         </Button>
       );
     } else {

--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -65,18 +65,22 @@ class UriIndicator extends React.PureComponent<Props> {
         return inner;
       }
 
-      const Wrapper = addTooltip
-        ? ({ children }) => (
-            <Tooltip label={<ClaimPreview uri={channelLink} type="tooltip" placeholder={false} />}>{children}</Tooltip>
-          )
-        : 'span';
-      /* to wrap the UriIndicator element around other DOM nodes as a button */
-      const content = children ? children : (<Wrapper>{inner}</Wrapper>);
-      return (
-        <Button className="button--uri-indicator" navigate={channelLink}>
-          {content}
-        </Button>
-      );
+      if (children) {
+        return <Button navigate={channelLink}>{children}</Button>;
+      } else {
+        const Wrapper = addTooltip
+          ? ({ children }) => (
+              <Tooltip label={<ClaimPreview uri={channelLink} type="tooltip" placeholder={false} />}>
+                {children}
+              </Tooltip>
+            )
+          : 'span';
+        return (
+          <Button className="button--uri-indicator" navigate={channelLink}>
+            <Wrapper>{inner}</Wrapper>
+          </Button>
+        );
+      }
     } else {
       return null;
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe:

##  Fixes  #3119  

## What is the current behavior?
Only the `@channelName` url can be clicked in the file page.

## What is the new behavior?
The channel thumbnail on the file page is clickable and directs you to the user's channel, if any.

## Other information
- Turning the channel title into a clickable link made the rest of the UI appear inconsistent and errant, and is thus left as before.
 
- `UriIndicator` accepts any arbitrary Node and wraps a button around it.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
