### PR TITLE
change file viewer background color

### DIFF
--- a/ui/scss/themes/dark.scss
+++ b/ui/scss/themes/dark.scss
@@ -31,7 +31,7 @@
   --color-card-background: #2c3237;
   --color-card-background-highlighted: #384046;
   --color-header-background: #434b53;
-  --color-file-viewer-background: #212529;
+  --color-file-viewer-background: var(--color-white);
   --color-tab-text: var(--color-white);
   --color-tabs-background: #434b53;
   --color-tab-divider: var(--color-white);

--- a/ui/scss/themes/dark.scss
+++ b/ui/scss/themes/dark.scss
@@ -31,7 +31,6 @@
   --color-card-background: #2c3237;
   --color-card-background-highlighted: #384046;
   --color-header-background: #434b53;
-  --color-file-viewer-background: var(--color-white);
   --color-tab-text: var(--color-white);
   --color-tabs-background: #434b53;
   --color-tab-divider: var(--color-white);

--- a/ui/scss/themes/light.scss
+++ b/ui/scss/themes/light.scss
@@ -29,7 +29,7 @@
   --color-card-background: #ffffff;
   --color-card-background-highlighted: #f6faff;
   --color-list-header: #fff;
-  --color-file-viewer-background: #212529;
+  --color-file-viewer-background: var(--color-white);
   --color-tabs-background: var(--color-secondary-alt);
   --color-tab-divider: var(--color-secondary);
 

--- a/ui/scss/themes/light.scss
+++ b/ui/scss/themes/light.scss
@@ -29,7 +29,7 @@
   --color-card-background: #ffffff;
   --color-card-background-highlighted: #f6faff;
   --color-list-header: #fff;
-  --color-file-viewer-background: var(--color-white);
+  --color-file-viewer-background: var(--color-card-background);
   --color-tabs-background: var(--color-secondary-alt);
   --color-tab-divider: var(--color-secondary);
 


### PR DESCRIPTION
This makes @eggplantbren's article https://lbry.tv/@BrendonBrewer:3/trending:a readable from lbry.tv

While this fixes that case, it also makes me wonder why this rule existed as it did. Are there cases that `<DocumentViewer>` should have a dark background?