### PR TITLE
When this is merged, dates on claim previews will be the same as youtube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Always round down dates on claim previews for better yotube parity ([#3353](https://github.com/lbryio/lbry-desktop/pull/3353))
+
 ## [0.37.2] - [2019-11-21]
 
 ### Fixed

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -915,5 +915,14 @@
   "Any amount will give you the highest bid, but larger amounts help your content be trusted and discovered.": "Any amount will give you the highest bid, but larger amounts help your content be trusted and discovered.",
   "Loading 3D model.": "Loading 3D model.",
   "Click here": "Click here",
-  "PDF opened externally. %click_here% to open it again.": "PDF opened externally. %click_here% to open it again."
+  "PDF opened externally. %click_here% to open it again.": "PDF opened externally. %click_here% to open it again.",
+  "%numberOfMonthsSincePublish% years ago": "%numberOfMonthsSincePublish% years ago",
+  "%numberOfYearsSincePublish% years ago": "%numberOfYearsSincePublish% years ago",
+  "%numberOfYearsSincePublish% year ago": "%numberOfYearsSincePublish% year ago",
+  "%numberOfMonthsSincePublish% year ago": "%numberOfMonthsSincePublish% year ago",
+  "Followers": "Followers",
+  "%numberOfMonthsSincePublish% month ago": "%numberOfMonthsSincePublish% month ago",
+  "%numberOfMonthsSincePublish% months ago": "%numberOfMonthsSincePublish% months ago",
+  "%numberOfDaysSincePublish% months ago": "%numberOfDaysSincePublish% months ago",
+  "%numberOfDaysSincePublish% days ago": "%numberOfDaysSincePublish% days ago"
 }

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -25,7 +25,7 @@ class DateTime extends React.PureComponent<Props> {
 
       // Moment is very liberal with it's rounding
       // Wait to show "two years ago" until it's actually been two years (or higher)
-      const numberOfYearsSincePublish = moment().diff(date, 'years');
+      const numberOfYearsSincePublish = Math.floor(moment().diff(date, 'years'));
 
       if (numberOfYearsSincePublish === 1) {
         return <span>{__('%numberOfYearsSincePublish% year ago', { numberOfYearsSincePublish })}</span>;
@@ -33,6 +33,21 @@ class DateTime extends React.PureComponent<Props> {
         return <span>{__('%numberOfYearsSincePublish% years ago', { numberOfYearsSincePublish })}</span>;
       }
 
+      const numberOfMonthsSincePublish = Math.floor(moment().diff(date, 'months'));
+      if (numberOfMonthsSincePublish === 1) {
+        return <span>{__('%numberOfMonthsSincePublish% month ago', { numberOfMonthsSincePublish })}</span>;
+      } else if (numberOfMonthsSincePublish > 1) {
+        return <span>{__('%numberOfMonthsSincePublish% months ago', { numberOfMonthsSincePublish })}</span>;
+      }
+
+      const numberOfDaysSincePublish = Math.floor(moment().diff(date, 'days'));
+      if (numberOfDaysSincePublish === 1) {
+        return <span>{__('%numberOfDaysSincePublish% day ago', { numberOfDaysSincePublish })}</span>;
+      } else if (numberOfDaysSincePublish > 1) {
+        return <span>{__('%numberOfDaysSincePublish% days ago', { numberOfDaysSincePublish })}</span>;
+      }
+
+      // "just now", "a few minutes ago"
       return <span>{moment(date).from(moment())}</span>;
     }
 

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -19,7 +19,21 @@ class DateTime extends React.PureComponent<Props> {
     const show = this.props.show || DateTime.SHOW_BOTH;
 
     if (timeAgo) {
-      return date ? <span>{moment(date).from(moment())}</span> : <span />;
+      if (!date) {
+        return null;
+      }
+
+      // Moment is very liberal with it's rounding
+      // Wait to show "two years ago" until it's actually been two years (or higher)
+      const numberOfYearsSincePublish = moment().diff(date, 'years');
+
+      if (numberOfYearsSincePublish === 1) {
+        return <span>{__('%numberOfYearsSincePublish% year ago', { numberOfYearsSincePublish })}</span>;
+      } else if (numberOfYearsSincePublish > 1) {
+        return <span>{__('%numberOfYearsSincePublish% years ago', { numberOfYearsSincePublish })}</span>;
+      }
+
+      return <span>{moment(date).from(moment())}</span>;
     }
 
     return (


### PR DESCRIPTION
Tested a few channels and it seems like all the dates are the same as they are listed on youtube.