### PR TITLE
fix video length and tag cut off 

### DIFF
--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -133,6 +133,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  width: calc(100% - 12rem);
 }
 
 .claim-preview-info {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [x] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:  #3374

## What is the current behavior?

When the screen is reduced, the playing time is gone.
Containers with playing time have a width without considering the image next to it.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/38170596/70858991-7a1fc000-1f4f-11ea-923b-acc891ae0fc5.gif)




## What is the new behavior?

Container considered the image width for the maximum width.

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/38170596/70859017-0500ba80-1f50-11ea-8c48-0291449b15ff.gif)




## Other information

The issue of tags has not yet been resolved. I'll try to solve it.


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
