### PR TITLE
improves wallet server ux and resilience

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#bd9f1b1b0d2a16eaa9c08483400c9c3085301962",
+    "lbry-redux": "lbryio/lbry-redux#74eba1f297cd1fe458033323776a9c8d891a4fa1",
     "lbryinc": "lbryio/lbryinc#1e897d2c9108848637e1915700d3ae8ce176f9f8",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#74eba1f297cd1fe458033323776a9c8d891a4fa1",
+    "lbry-redux": "lbryio/lbry-redux#8086ccdc01f31a88a36e5d9e3404b308b2a70ee2",
     "lbryinc": "lbryio/lbryinc#1e897d2c9108848637e1915700d3ae8ce176f9f8",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -931,5 +931,7 @@
   "In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this content from our applications.": "In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this content from our applications.",
   "lbry.tv": "lbry.tv",
   "Your Blocked Channels": "Your Blocked Channels",
-  "Bid position must be a number.": "Bid position must be a number."
+  "Bid position must be a number.": "Bid position must be a number.",
+  "Copy": "Copy",
+  "Text copied": "Text copied"
 }

--- a/ui/component/settingWalletServer/index.js
+++ b/ui/component/settingWalletServer/index.js
@@ -1,22 +1,26 @@
 import { connect } from 'react-redux';
-import { DAEMON_SETTINGS } from 'lbry-redux';
-import { doSetDaemonSetting, doClearDaemonSetting, doGetDaemonStatus, doSaveCustomWalletServers, doFetchDaemonSettings } from 'redux/actions/settings';
-import { selectDaemonSettings, selectSavedWalletServers, selectDaemonStatus, selectHasWalletServerPrefs } from 'redux/selectors/settings';
+import { DAEMON_SETTINGS, selectIsWalletReconnecting } from 'lbry-redux';
+import {
+  doSetDaemonSetting,
+  doClearDaemonSetting,
+  doGetDaemonStatus,
+  doSaveCustomWalletServers,
+} from 'redux/actions/settings';
+import { selectSavedWalletServers, selectDaemonStatus, selectHasWalletServerPrefs } from 'redux/selectors/settings';
 import SettingWalletServer from './view';
 
 const select = state => ({
-  daemonSettings: selectDaemonSettings(state),
   daemonStatus: selectDaemonStatus(state),
   customWalletServers: selectSavedWalletServers(state),
   hasWalletServerPrefs: selectHasWalletServerPrefs(state),
+  walletReconnecting: selectIsWalletReconnecting(state),
 });
 
 const perform = dispatch => ({
-  setCustomWalletServers: (value) => dispatch(doSetDaemonSetting(DAEMON_SETTINGS.LBRYUM_SERVERS, value)),
+  setCustomWalletServers: value => dispatch(doSetDaemonSetting(DAEMON_SETTINGS.LBRYUM_SERVERS, value)),
   clearWalletServers: () => dispatch(doClearDaemonSetting(DAEMON_SETTINGS.LBRYUM_SERVERS)),
   getDaemonStatus: () => dispatch(doGetDaemonStatus()),
-  saveServerConfig: (servers) => dispatch(doSaveCustomWalletServers(servers)),
-  fetchDaemonSettings: () => dispatch(doFetchDaemonSettings()),
+  saveServerConfig: servers => dispatch(doSaveCustomWalletServers(servers)),
 });
 
 export default connect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7092,9 +7092,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#bd9f1b1b0d2a16eaa9c08483400c9c3085301962:
+lbry-redux@lbryio/lbry-redux#8086ccdc01f31a88a36e5d9e3404b308b2a70ee2:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/bd9f1b1b0d2a16eaa9c08483400c9c3085301962"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/8086ccdc01f31a88a36e5d9e3404b308b2a70ee2"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
 - removes daemonSettings, fetchDaemonSettings as unnecessary
 - on unmount, if available_servers is 0, clear to defaults
 - modify splash behavior to reset even when wallet is_running 
    - (control R after clearing servers could have been bad)
 - add connecting... state
 - no longer show or expect user to delete every default wallet server on switching to custom

Requires https://github.com/lbryio/lbry-redux/pull/255