### PR TITLE
Bundle headers with app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,14 @@ before_install:
     else
       sudo apt-get -qq update
       sudo apt-get install -y libsecret-1-dev
-      sudo apt-get install --no-install-recommends -y gcc-multilib g++-multilib
+      sudo apt-get install --no-install-recommends -y gcc-multilib g++-multilib wget
       curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
       export PATH="$HOME/.yarn/bin:$PATH"
     fi
 before_script:
   - git lfs pull
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then unset WIN_CSC_LINK; unset CSC_LINK; fi
+  - wget https://headers.lbry.io/blockchain_headers_latest -O $TRAVIS_BUILD_DIR/static/daemon/headers
 script:
   - |
     if [ "$TARGET" == "windows" ]; then

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -7,13 +7,18 @@
   "files": [
     {
       "from": "dist/electron/webpack",
-      "to": "./",
-      "filter": ["!dist/!electron/!webpack/*.js", "!dist/!electron/!webpack/!static/**/*"]
+      "to": "./"
     },
     {
       "from": "dist/electron/static",
-      "to": "./",
-      "filter": ["!dist/!electron/!static/index-electron.html"]
+      "to": "./"
+    }
+  ],
+  "extraResources": [
+    {
+      "from": "./static/daemon/",
+      "to": "static/daemon/",
+      "filter": ["**/*"]
     }
   ],
   "publish": [

--- a/webpack.electron.config.js
+++ b/webpack.electron.config.js
@@ -46,11 +46,15 @@ let mainConfig = {
       {
         from: `${STATIC_ROOT}/`,
         to: `${DIST_ROOT}/electron/static/`,
-        ignore: ['index-web.html', 'index-electron.html'],
+        ignore: ['index-web.html', 'index-electron.html', 'daemon/**/*'],
       },
       {
         from: `${STATIC_ROOT}/index-electron.html`,
         to: `${DIST_ROOT}/electron/static/index.html`,
+      },
+      {
+        from: `${STATIC_ROOT}/daemon`,
+        to: `${DIST_ROOT}/electron/daemon`,
       },
     ]),
   ],


### PR DESCRIPTION
I was having a ton of issues electron-builder not letting me ignore the daemon files when it started bundling. I changed the webpack build to output the daemon files to their own folder, so it was easier to copy in electron-builder