### PR TITLE
Fixes "Video player out of whack after resize of window #3423"

### DIFF
--- a/ui/component/fileViewer/view.jsx
+++ b/ui/component/fileViewer/view.jsx
@@ -105,10 +105,10 @@ export default function FileViewer(props: Props) {
       setFileViewerRect(rect);
     }
 
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    onFullscreenChange(window, 'add', handleResize);
     return () => {
-      handleResize();
-      window.addEventListener('resize', handleResize);
-      onFullscreenChange(window, 'add', handleResize);
       window.removeEventListener('resize', handleResize);
       onFullscreenChange(window, 'remove', handleResize);
     };


### PR DESCRIPTION
Fixes "Video player out of whack after resize of window #3423" by adding event listeners prior to cleanup.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix

## Fixes

Issue Number: #3423

## What is the current behavior?
Does not properly resize video in response to window resizing.

## What is the new behavior?
Properly resizes video in response to window resizing.

## Other information
I've tested the fix on Ubuntu desktop. This is my first time contributing to this project, please let me know if I should test elsewhere.

Feedback welcome.

(Broken)
![image](https://user-images.githubusercontent.com/15717854/71609101-75f8c280-2b4b-11ea-9c32-972efbc0f952.png)

(Broken)
![image](https://user-images.githubusercontent.com/15717854/71609124-9f195300-2b4b-11ea-8a3e-15a41ffac9fd.png)

(Fixed)
![image](https://user-images.githubusercontent.com/15717854/71609147-cd972e00-2b4b-11ea-9c7c-818bf34f3f80.png)

