### PR TITLE
Allow parentheses in certain links

### DIFF
--- a/ui/util/remark-lbry.js
+++ b/ui/util/remark-lbry.js
@@ -2,7 +2,7 @@ import { parseURI } from 'lbry-redux';
 import visit from 'unist-util-visit';
 
 const protocol = 'lbry://';
-const uriRegex = /(lbry:\/\/)[^\s"]*/g;
+const uriRegex = /(lbry:\/\/)[^\s"]*[^)]/g;
 
 const mentionToken = '@';
 const mentionTokenCode = 64; // @
@@ -78,32 +78,13 @@ function tokenizeMention(eat, value, silent) {
   return validateURI(match, eat, self);
 }
 
-function onlyMatchingParens(string) {
-  if (!string) return null;
-  let parens = 0;
-
-  let i;
-  for (i = 0; i < string.length; i++) {
-    switch (string[i]) {
-      case '(':
-        parens++;
-        break;
-      case ')':
-        parens--;
-        break;
-    }
-    if (parens < 0) break;
-  }
-  return string.slice(0, i);
-}
-
 // Generate a markdown link from lbry url
 function tokenizeURI(eat, value, silent) {
   if (silent) {
     return true;
   }
 
-  const match = onlyMatchingParens(value.match(uriRegex));
+  const match = value.match(uriRegex);
 
   return validateURI(match, eat);
 }

--- a/ui/util/remark-lbry.js
+++ b/ui/util/remark-lbry.js
@@ -2,7 +2,7 @@ import { parseURI } from 'lbry-redux';
 import visit from 'unist-util-visit';
 
 const protocol = 'lbry://';
-const uriRegex = /(lbry:\/\/)[^\s()"]*/g;
+const uriRegex = /(lbry:\/\/)[^\s"]*/g;
 
 const mentionToken = '@';
 const mentionTokenCode = 64; // @
@@ -78,13 +78,32 @@ function tokenizeMention(eat, value, silent) {
   return validateURI(match, eat, self);
 }
 
+function onlyMatchingParens(string) {
+  if (!string) return null;
+  let parens = 0;
+
+  let i;
+  for (i = 0; i < string.length; i++) {
+    switch (string[i]) {
+      case '(':
+        parens++;
+        break;
+      case ')':
+        parens--;
+        break;
+    }
+    if (parens < 0) break;
+  }
+  return string.slice(0, i);
+}
+
 // Generate a markdown link from lbry url
 function tokenizeURI(eat, value, silent) {
   if (silent) {
     return true;
   }
 
-  const match = value.match(uriRegex);
+  const match = onlyMatchingParens(value.match(uriRegex));
 
   return validateURI(match, eat);
 }


### PR DESCRIPTION
Only links with either matching, or open LEFT parentheses are allowed. These are the same rules that github use for this as well.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
Links are not allowed to have parentheses, which breaks some links which do have them

## What is the new behavior?
Parentheses are allowed in links in certain cases: there must be equal or more opening parentheses to closing parentheses. This is the same way that github deals with this issue

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
