### PR TITLE
Add email to header and only save passwords if they are correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
     "lbry-redux": "lbryio/lbry-redux#a2be979986dc93be4c2c596846109f5394f64fa1",
-    "lbryinc": "lbryio/lbryinc#4cb26d81849a6c36cab0d7770f1ed87497f66ccf",
+    "lbryinc": "lbryio/lbryinc#dd4d01b42b3d7dc00ce9d137bf078e1b09ac4d37",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",
     "lodash-es": "^4.17.14",

--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -136,8 +136,9 @@ export default function ClaimList(props: Props) {
           ))}
         </ul>
       )}
-
-      {urisLength === 0 && !loading && <div className="card main--empty empty">{empty || __('No results')}</div>}
+      {urisLength === 0 && !loading && (
+        <div className="card--section main--empty empty">{empty || __('No results')}</div>
+      )}
     </section>
   );
 }

--- a/ui/component/header/index.js
+++ b/ui/component/header/index.js
@@ -2,7 +2,7 @@ import * as SETTINGS from 'constants/settings';
 import * as MODALS from 'constants/modal_types';
 import { connect } from 'react-redux';
 import { selectBalance, formatCredits } from 'lbry-redux';
-import { selectUserVerifiedEmail, selectGetSyncErrorMessage } from 'lbryinc';
+import { selectUserVerifiedEmail, selectGetSyncErrorMessage, selectUserEmail } from 'lbryinc';
 import { doSetClientSetting } from 'redux/actions/settings';
 import { doSignOut, doOpenModal } from 'redux/actions/app';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
@@ -15,7 +15,8 @@ const select = state => ({
   currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),
   automaticDarkModeEnabled: makeSelectClientSetting(SETTINGS.AUTOMATIC_DARK_MODE_ENABLED)(state),
   hideBalance: makeSelectClientSetting(SETTINGS.HIDE_BALANCE)(state),
-  email: selectUserVerifiedEmail(state),
+  authenticated: selectUserVerifiedEmail(state),
+  email: selectUserEmail(state),
   syncError: selectGetSyncErrorMessage(state),
 });
 

--- a/ui/component/header/view.jsx
+++ b/ui/component/header/view.jsx
@@ -24,6 +24,7 @@ type Props = {
   setClientSetting: (string, boolean | string) => void,
   hideBalance: boolean,
   email: ?string,
+  authenticated: boolean,
   authHeader: boolean,
   syncError: ?string,
   signOut: () => void,
@@ -40,13 +41,13 @@ const Header = (props: Props) => {
     automaticDarkModeEnabled,
     hideBalance,
     email,
+    authenticated,
     authHeader,
     signOut,
     syncError,
     openMobileNavigation,
     openChannelCreate,
   } = props;
-  const authenticated = Boolean(email);
 
   // on the verify page don't let anyone escape other than by closing the tab to keep session data consistent
   const isVerifyPage = history.location.pathname.includes(PAGES.AUTH_VERIFY);
@@ -188,9 +189,12 @@ const Header = (props: Props) => {
                     </MenuItem> */}
 
                     {authenticated ? (
-                      <MenuItem className="menu__link" onSelect={signOut}>
-                        <Icon aria-hidden icon={ICONS.SIGN_OUT} />
-                        {__('Sign Out')}
+                      <MenuItem onSelect={signOut}>
+                        <div className="menu__link">
+                          <Icon aria-hidden icon={ICONS.SIGN_OUT} />
+                          {__('Sign Out')}
+                        </div>
+                        <span className="menu__link-help">{email}</span>
                       </MenuItem>
                     ) : (
                       <MenuItem className="menu__link" onSelect={() => history.push(`/$/${PAGES.AUTH}`)}>

--- a/ui/component/syncPassword/index.js
+++ b/ui/component/syncPassword/index.js
@@ -11,7 +11,7 @@ const select = state => ({
 });
 
 const perform = dispatch => ({
-  getSync: password => dispatch(doGetSync(password)),
+  getSync: (password, cb) => dispatch(doGetSync(password, cb)),
   setClientSetting: (key, value) => dispatch(doSetClientSetting(key, value)),
   signOut: () => dispatch(doSignOut()),
 });

--- a/ui/component/syncPassword/view.jsx
+++ b/ui/component/syncPassword/view.jsx
@@ -8,7 +8,7 @@ import usePersistedState from 'effects/use-persisted-state';
 import I18nMessage from 'component/i18nMessage';
 
 type Props = {
-  getSync: (?string) => void,
+  getSync: (?string, (any) => void) => void,
   getSyncIsPending: boolean,
   email: string,
   passwordError: boolean,
@@ -21,8 +21,11 @@ function SyncPassword(props: Props) {
   const [rememberPassword, setRememberPassword] = usePersistedState(true);
 
   function handleSubmit() {
-    setSavedPassword(password, rememberPassword);
-    getSync(password);
+    getSync(password, error => {
+      if (!error) {
+        setSavedPassword(password, rememberPassword);
+      }
+    });
   }
 
   return (

--- a/ui/scss/component/menu-button.scss
+++ b/ui/scss/component/menu-button.scss
@@ -62,13 +62,18 @@
   align-items: center;
   padding: var(--spacing-medium);
   padding-right: var(--spacing-large);
-}
 
-.menu__link {
   .icon {
     stroke: var(--color-menu-icon);
     margin-right: var(--spacing-small);
   }
+}
+
+.menu__link-help {
+  @extend .menu__link;
+  color: var(--color-text-help);
+  font-size: var(--font-small);
+  padding-top: 0;
 }
 
 .menu__title {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7110,9 +7110,9 @@ lbry-redux@lbryio/lbry-redux#a2be979986dc93be4c2c596846109f5394f64fa1:
     reselect "^3.0.0"
     uuid "^3.3.2"
 
-lbryinc@lbryio/lbryinc#4cb26d81849a6c36cab0d7770f1ed87497f66ccf:
+lbryinc@lbryio/lbryinc#dd4d01b42b3d7dc00ce9d137bf078e1b09ac4d37:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/4cb26d81849a6c36cab0d7770f1ed87497f66ccf"
+  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/dd4d01b42b3d7dc00ce9d137bf078e1b09ac4d37"
   dependencies:
     reselect "^3.0.0"
 


### PR DESCRIPTION
Before, we were always saving passwords to be used later, even if the sync call ended up failing, which would cause them to need to enter the password again.