### PR TITLE
Fixes #3383 by formatting lbry links differently

### DIFF
--- a/ui/component/common/markdown-preview-internal.jsx
+++ b/ui/component/common/markdown-preview-internal.jsx
@@ -36,7 +36,7 @@ const SimpleLink = (props: SimpleLinkProps) => {
   let { href } = props;
   if (href && href.startsWith('lbry://')) {
     href = formatLbryUrlForWeb(href);
-    // using NavLink after format to handle "/" vs "#/"
+    // using Link after formatLbryUrl to handle "/" vs "#/"
     // for web and desktop scenarios respectively
     return (
       <Link

--- a/ui/component/common/markdown-preview-internal.jsx
+++ b/ui/component/common/markdown-preview-internal.jsx
@@ -8,6 +8,8 @@ import reactRenderer from 'remark-react';
 import ExternalLink from 'component/externalLink';
 import defaultSchema from 'hast-util-sanitize/lib/github.json';
 import { formatedLinks, inlineLinks } from 'util/remark-lbry';
+import { Link } from 'react-router-dom';
+import { formatLbryUrlForWeb } from 'util/url';
 
 type SimpleTextProps = {
   children?: React.Node,
@@ -30,7 +32,24 @@ const SimpleText = (props: SimpleTextProps) => {
 };
 
 const SimpleLink = (props: SimpleLinkProps) => {
-  const { href, title, children } = props;
+  const { title, children } = props;
+  let { href } = props;
+  if (href && href.startsWith('lbry://')) {
+    href = formatLbryUrlForWeb(href);
+    // using NavLink after format to handle "/" vs "#/"
+    // for web and desktop scenarios respectively
+    return (
+      <Link
+        title={title}
+        to={href}
+        onClick={e => {
+          e.stopPropagation();
+        }}
+      >
+        {children}
+      </Link>
+    );
+  }
   return (
     <a href={href} title={title}>
       {children}


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
  - **Read as: I clicked a bunch of links on the desktop and web apps, please review carefully**

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix

## Fixes

Issue Number: #3383

## What is the current behavior?
Please see the image below as a reference for the inspection images to follow.
![example](https://user-images.githubusercontent.com/15717854/71759013-8cb15900-2e6c-11ea-80a5-80d4052955cd.png)


When using @(some_user) in a comment, both the desktop app and lbry.tv use the following style.
![both-before](https://user-images.githubusercontent.com/15717854/71758965-d0f02980-2e6b-11ea-8a14-e514ecff7085.png)

This works on the desktop app but prompts the lbry.tv user to open up the desktop app which is not the desired behavior.

## What is the new behavior?
The desktop app continues to open these links in the desktop app, though the link path is different.
![desktop-app-after](https://user-images.githubusercontent.com/15717854/71758987-32b09380-2e6c-11ea-9247-aec74455880f.png)

The lbry.tv app now opens these links in the user's browser.
![web-app-after](https://user-images.githubusercontent.com/15717854/71758992-48be5400-2e6c-11ea-8a0b-7d3e92bac5f2.png)


## Other information

I've got three concerns.
1. With the added code, I don't know if "SimpleLink" is fitting anymore.
2. I've got a hunch that there is a more elegant solution, but I'll post this for now to favor results over perfection. I welcome all feedback.
3. A separate issue exists. When @(some_user) is specified in a comment, it doesn't give the full path to the user. In my example above, @(mh) is trying to reply to the user @(OzFlor:367e8ca0bcd353126212947982ae0aee29a0d880). However, when using @(OzFlor), the user is routed to [OzFlor](https://lbry.tv/@OzFlor:7) which is a channel for a different user. In my opinion this is a separate issue from #3383 but I figured I'd bring it up here.
