### PR TITLE
Hide cursor on fullscreen

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -35,9 +35,13 @@
     height: 100%;
     object-fit: contain;
   }
-
   video {
     cursor: pointer;
+  }
+  .video-js.vjs-fullscreen.vjs-user-inactive.vjs-playing {
+    video {
+      cursor: none;
+    }
   }
 }
 


### PR DESCRIPTION
## PR Checklist

- [ x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [ x] Bugfix

## What is the current behavior?
When a video is fullscreen the cursor stays there. Also it changes to a hand.

## What is the new behavior?
The cursor is now hidden on full screen video playback as long as the mouse is inactive. The cursor only changes from a pointer to the hand when over the playback menu or when hovering over the big play button in center of screen.
