### PR TITLE
Choosing "New Publish" Now Clears the Publish Form

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -910,5 +910,7 @@
   "Did something go wrong? Have a look in your log file, or send it to %support_link%.": "Did something go wrong? Have a look in your log file, or send it to %support_link%.",
   "%amount% LBC": "%amount% LBC",
   "%amount% fee": "%amount% fee",
-  "1 file hidden due to your %content_viewing_preferences_link%": "1 file hidden due to your %content_viewing_preferences_link%"
+  "1 file hidden due to your %content_viewing_preferences_link%": "1 file hidden due to your %content_viewing_preferences_link%",
+  "Thumbnail": "Thumbnail",
+  "spee.ch": "spee.ch"
 }

--- a/ui/component/header/view.jsx
+++ b/ui/component/header/view.jsx
@@ -147,7 +147,7 @@ const Header = (props: Props) => {
                   <MenuList className="menu__list--header">
                     <MenuItem className="menu__link" onSelect={() => history.push(`/$/${PAGES.PUBLISH}`)}>
                       <Icon aria-hidden icon={ICONS.PUBLISH} />
-                      {__('New Publish')}
+                      {__('Publish')}
                     </MenuItem>
                     <MenuItem className="menu__link" onSelect={openChannelCreate}>
                       <Icon aria-hidden icon={ICONS.CHANNEL} />

--- a/ui/page/fileListPublished/index.js
+++ b/ui/page/fileListPublished/index.js
@@ -3,6 +3,7 @@ import {
   selectIsFetchingClaimListMine,
   makeSelectMyStreamUrlsForPage,
   selectMyStreamUrlsCount,
+  doClearPublish,
   doFetchClaimListMine,
 } from 'lbry-redux';
 import { doCheckPendingPublishesApp } from 'redux/actions/publish';
@@ -24,11 +25,7 @@ const select = (state, props) => {
 const perform = dispatch => ({
   checkPendingPublishes: () => dispatch(doCheckPendingPublishesApp()),
   fetchClaimListMine: () => dispatch(doFetchClaimListMine()),
+  clearPublish: () => dispatch(doClearPublish()),
 });
 
-export default withRouter(
-  connect(
-    select,
-    perform
-  )(FileListPublished)
-);
+export default withRouter(connect(select, perform)(FileListPublished));

--- a/ui/page/fileListPublished/view.jsx
+++ b/ui/page/fileListPublished/view.jsx
@@ -36,7 +36,9 @@ function FileListPublished(props: Props) {
             loading={fetching}
             persistedStorageKey="claim-list-published"
             uris={urls}
-            headerAltControls={<Button button="link" label={__('New Publish')} navigate="/$/publish" />}
+            headerAltControls={
+              <Button button="link" label={__('New Publish')} navigate="/$/publish" onClick={() => clearPublish()} />
+            }
           />
           <Paginate totalPages={Math.ceil(Number(urlTotal) / Number(PAGE_SIZE))} loading={fetching} />
         </React.Fragment>

--- a/ui/page/fileListPublished/view.jsx
+++ b/ui/page/fileListPublished/view.jsx
@@ -10,6 +10,7 @@ import Spinner from 'component/spinner';
 
 type Props = {
   checkPendingPublishes: () => void,
+  clearPublish: () => void,
   fetchClaimListMine: () => void,
   fetching: boolean,
   urls: Array<string>,
@@ -19,7 +20,7 @@ type Props = {
 };
 
 function FileListPublished(props: Props) {
-  const { checkPendingPublishes, fetchClaimListMine, fetching, urls, urlTotal } = props;
+  const { checkPendingPublishes, clearPublish, fetchClaimListMine, fetching, urls, urlTotal } = props;
   useEffect(() => {
     checkPendingPublishes();
     fetchClaimListMine();
@@ -47,7 +48,12 @@ function FileListPublished(props: Props) {
               <div className=" section--small">
                 <h2 className="section__title--large">{__('Nothing published to LBRY yet.')}</h2>
                 <div className="section__actions">
-                  <Button button="primary" navigate="/$/publish" label={__('Publish something new')} />
+                  <Button
+                    button="primary"
+                    navigate="/$/publish"
+                    label={__('Publish something new')}
+                    onClick={() => clearPublish()}
+                  />
                 </div>
               </div>
             </section>

--- a/ui/scss/component/_button.scss
+++ b/ui/scss/component/_button.scss
@@ -27,7 +27,12 @@
   transition: all var(--transition-duration) var(--transition-style);
   border-radius: var(--card-radius);
   color: var(--color-text);
-  font-size: var(--font-small);
+  font-size: var(--font-body);
+
+  svg {
+    height: 1rem;
+    width: 1rem;
+  }
 
   &:hover {
     color: var(--color-button-primary-text);

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -145,6 +145,15 @@
   .section__subtitle {
     margin-bottom: 0;
   }
+
+  .button {
+    font-size: var(--font-large);
+
+    .icon {
+      height: 20px;
+      width: 20px;
+    }
+  }
 }
 
 .card__body {

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -145,15 +145,6 @@
   .section__subtitle {
     margin-bottom: 0;
   }
-
-  .button {
-    font-size: var(--font-large);
-
-    .icon {
-      height: 20px;
-      width: 20px;
-    }
-  }
 }
 
 .card__body {


### PR DESCRIPTION
## PR Checklist

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix

## Fixes

Issue Number: #3348

## What is the current behavior?
Font size of cancel button set to `--font-small`.
![cancel](https://user-images.githubusercontent.com/15717854/72314205-951b4800-3653-11ea-849e-3be50e12a3a3.png)

The publish form is **not** cleared by the following actions.

1. User clicks the "New Publish" drop-down item from the Navigation bar.
![publish-navbar](https://user-images.githubusercontent.com/15717854/72031153-24d68600-3251-11ea-96f2-f7b6c5c8e3d4.png)

2. User clicks the "Publish something new" button when they go to their publishes and have not published previously.
![publish-button](https://user-images.githubusercontent.com/15717854/72031164-299b3a00-3251-11ea-8223-29a8ec5dc27d.png)

3. User clicks the "New Publish" link when they go to their publishes and have already published content.
![publish-link](https://user-images.githubusercontent.com/15717854/72031178-34ee6580-3251-11ea-80b9-c4b9f427b34c.png)

## What is the new behavior?
Font size of cancel button set to `--font-large`.
![cancel-updated](https://user-images.githubusercontent.com/15717854/72314182-803eb480-3653-11ea-8ada-80f2857859b2.png)

1. Has changed to just "Publish" and continues its behavior of not clearing the form.
![publish-navbar-updated](https://user-images.githubusercontent.com/15717854/72313243-6059c180-3650-11ea-8ad2-c8f7aaeddb1f.png)

2. Now clears form on click.
3. Now clears form on click.

