### PR TITLE
Don't Show Edit Screen for Other Channels

### DIFF
--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -161,6 +161,12 @@ function ChannelPage(props: Props) {
     fetchSubCount(claimId);
   }, [uri, fetchSubCount, claimId]);
 
+  React.useEffect(() => {
+    if (!channelIsMine && editing) {
+      setEditing(false);
+    }
+  }, [channelIsMine, editing]);
+
   return (
     <Page>
       <ClaimUri uri={uri} />


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix

## Fixes

Issue Number: #3306

## What is the current behavior?
When a user is editing their own channel and clicks on a channel they're subscribed to, it looks like they're editing the channel they don't own. This appears to only happen if the other channel is already "cached" (if user has already clicked on this channel during app execution).

**Editing own channel**
![self-edit-screen](https://user-images.githubusercontent.com/15717854/72127292-d13d6880-3334-11ea-9d99-fccad7987b51.png)

**"Editing" other user's channel**
![editing-other-channel](https://user-images.githubusercontent.com/15717854/72127321-e914ec80-3334-11ea-8cce-54db5e81304c.png)


## What is the new behavior?
Once you click on a channel you don't own, you'll be taken out of editing.

## Other information
@kcseb mentions the possibility of prompting a user to save or discard their changes. If this is preferred over just navigating to the selected channel (current behavior), I'd be happy to add this.

