### PR TITLE
[WIP] Img exif

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "auto-launch": "^5.0.5",
+    "blueimp-load-image": "^2.26.0",
     "electron-dl": "^1.11.0",
     "electron-log": "^2.2.12",
     "electron-notarize": "^0.1.1",

--- a/ui/component/viewers/imageViewer.jsx
+++ b/ui/component/viewers/imageViewer.jsx
@@ -1,17 +1,30 @@
 // @flow
 import React from 'react';
+import loadImage from 'blueimp-load-image';
 
 type Props = {
   source: string,
 };
 
+function loadPic(source) {
+  loadImage(
+    source,
+    function(img, data) {
+      if (img.type === 'error') {
+        console.error('Cannot load image');
+      } else {
+        document.getElementsByClassName('file-render__viewer')[0].appendChild(img);
+      }
+    },
+    {
+      orientation: true,
+    }
+  );
+}
+
 function ImageViewer(props: Props) {
   const { source } = props;
-  return (
-    <div className="file-render__viewer">
-      <img src={source} />
-    </div>
-  );
+  return <div className="file-render__viewer">{loadPic(source)}</div>;
 }
 
 export default ImageViewer;

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -30,7 +30,8 @@
 
   iframe,
   webview,
-  img {
+  img,
+  canvas {
     width: 100%;
     height: 100%;
     object-fit: contain;


### PR DESCRIPTION
## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [ x] Bugfix

## Fixes

Issue Number: #3435

## What is the current behavior?
EXIF data is ignored, this leads to photos been shown with the wrong orientation. This can be a problem as people take photos with their smart phones upside down and sideways.

## What is the new behavior?
The orientation of the photo is honoured using EXIF data.

## Other information
At the time of writing this PR this patch only works for the preview, I still need to implement this for the thumbnails.
I thought I would submit this now because I was wondering if it was okay to use the `blueimp-load-image` library.
https://github.com/blueimp/JavaScript-Load-Image

In the future, it might be a good idea if the client could remove such meta data on upload. Especially since it can contain Geo data.
