### PR TITLE
Navigate Channel Search with Arrow Keys

### DIFF
--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -29,6 +29,8 @@ const PAGE_VIEW_QUERY = `view`;
 const ABOUT_PAGE = `about`;
 const DISCUSSION_PAGE = `discussion`;
 const LIGHTHOUSE_URL = 'https://lighthouse.lbry.com/search';
+const ARROW_LEFT_KEYCODE = 37;
+const ARROW_RIGHT_KEYCODE = 39;
 
 type Props = {
   uri: string,
@@ -146,6 +148,17 @@ function ChannelPage(props: Props) {
     setSearchQuery(value);
   }
 
+  /*
+    Since the search is inside of TabList, the left and right arrow keys change the tabIndex.
+    This results in the user not being able to navigate the search string by using arrow keys.
+    This function allows the event to change cursor position and then stops propagation to prevent tab changing.
+  */
+  function handleSearchArrowKeys(e) {
+    if (e.keyCode === ARROW_LEFT_KEYCODE || e.keyCode === ARROW_RIGHT_KEYCODE) {
+      e.stopPropagation();
+    }
+  }
+
   let channelIsBlackListed = false;
 
   if (claim && blackListedOutpoints) {
@@ -235,6 +248,7 @@ function ChannelPage(props: Props) {
                 className="wunderbar__input"
                 value={searchQuery}
                 onChange={handleInputChange}
+                onKeyDown={handleSearchArrowKeys}
                 type="text"
                 placeholder={__('Search')}
               />


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #3303

## What is the current behavior?
User cannot navigate text in a channel search field due to the left and right arrow keys changing tabs.

*Image displaying the search field*
![search](https://user-images.githubusercontent.com/15717854/72410801-f5cb8300-372e-11ea-8e6b-129f0a3eb32f.png)



## What is the new behavior?
User can navigate text in a channel search field using the left and right arrow keys.