### PR TITLE
Clear the internal file selector after `clearPublish`

### DIFF
--- a/ui/component/common/file-selector.jsx
+++ b/ui/component/common/file-selector.jsx
@@ -18,6 +18,14 @@ type Props = {
 };
 
 class FileSelector extends React.PureComponent<Props> {
+  componentDidUpdate(prevProps: Props) {
+    // If the form has just been cleared,
+    // clear the file input
+    if (prevProps.currentPath && !this.props.currentPath) {
+      this.fileInput.current.value = null;
+    }
+  }
+
   static defaultProps = {
     type: 'file',
   };


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #3490 

## What is the current behavior?
If you select a file (on the publish screen), then clear the form and try to select it again, it won't select

## What is the new behavior?
You are able to select it on the second try now.

## Other information

I've checked that these changes don't break any other places that the FileSelector component is used.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
