### PR TITLE
A bunch of cosmetic changes surrounding "text" files.

### DIFF
--- a/static/index-electron.html
+++ b/static/index-electron.html
@@ -4,8 +4,64 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="ui.js" async></script>
-    <link rel="stylesheet" href="font/font.css" />
     <title>LBRY</title>
+
+    <link rel="preload" href="font/v1/300.woff" as="font" type="font/woff" />
+    <link rel="preload" href="font/v1/300i.woff" as="font" type="font/woff" />
+    <link rel="preload" href="font/v1/400.woff" as="font" type="font/woff" />
+    <link rel="preload" href="font/v1/400i.woff" as="font" type="font/woff" />
+    <link rel="preload" href="font/v1/700.woff" as="font" type="font/woff" />
+    <link rel="preload" href="font/v1/700i.woff" as="font" type="font/woff" />
+
+    <style>
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 300;
+        font-display: swap;
+        src: url('font/v1/300.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style: italic;
+        font-weight: 300;
+        font-display: swap;
+        src: url('font/v1/300i.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url('font/v1/400.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style: italic;
+        font-weight: 400;
+        font-display: swap;
+        src: url('font/v1/400i.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 700;
+        font-display: swap;
+        src: url('font/v1/700.woff') format('woff');
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style: italic;
+        font-weight: 700;
+        font-display: swap;
+        src: url('font/v1/700i.woff') format('woff');
+      }
+    </style>
   </head>
 
   <body>

--- a/ui/component/layoutWrapperText/view.jsx
+++ b/ui/component/layoutWrapperText/view.jsx
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { normalizeURI } from 'lbry-redux';
+import classNames from 'classnames';
 import FilePrice from 'component/filePrice';
 import FileAuthor from 'component/fileAuthor';
 import FileViewCount from 'component/fileViewCount';
@@ -28,11 +29,11 @@ function LayoutWrapperText(props: Props) {
   const { uri, claim, title, nsfw, contentType, fileType } = props;
 
   const markdownType = ['md', 'markdown'];
-  const isMd = markdownType.includes(fileType) || contentType === 'text/markdown' || contentType === 'text/md';
+  const isMarkdown = markdownType.includes(fileType) || contentType === 'text/markdown' || contentType === 'text/md';
 
   return (
     <div>
-      <div className={`main__document-wrapper${isMd ? '-md' : ''}`}>
+      <div className={classNames('main__document-wrapper', { 'main__document-wrapper--markdown': isMarkdown })}>
         <ClaimUri uri={uri} />
 
         <div className="media__title">

--- a/ui/component/layoutWrapperText/view.jsx
+++ b/ui/component/layoutWrapperText/view.jsx
@@ -20,14 +20,19 @@ type Props = {
   nsfw: boolean,
   claim: StreamClaim,
   thumbnail: ?string,
+  contentType: string,
+  fileType: string,
 };
 
 function LayoutWrapperText(props: Props) {
-  const { uri, claim, title, nsfw } = props;
+  const { uri, claim, title, nsfw, contentType, fileType } = props;
+
+  const markdownType = ['md', 'markdown'];
+  const isMd = markdownType.includes(fileType) || contentType === 'text/markdown' || contentType === 'text/md';
 
   return (
     <div>
-      <div className="main__document-wrapper">
+      <div className={`main__document-wrapper${isMd ? '-md' : ''}`}>
         <ClaimUri uri={uri} />
 
         <div className="media__title">

--- a/ui/component/viewers/codeViewer.jsx
+++ b/ui/component/viewers/codeViewer.jsx
@@ -35,13 +35,14 @@ class CodeViewer extends React.PureComponent<Props> {
     if (prevProps.theme === this.props.theme) return;
 
     // This code is duplicated with componentDidMount
-    const theme = this.props.theme === 'dark' ? 'monokai' : 'default';
+    const theme = this.props.theme === 'dark' ? 'monokai' : 'ttcn';
     this.codeMirror.setOption('theme', theme);
   }
 
   componentDidMount() {
     const me = this;
     const { theme, contentType } = me.props;
+    alert(theme);
     // Init CodeMirror
     import(
       /* webpackChunkName: "codemirror" */
@@ -51,7 +52,7 @@ class CodeViewer extends React.PureComponent<Props> {
         // Auto detect syntax with file contentType
         mode: contentType,
         // Adaptive theme
-        theme: theme === 'dark' ? 'monokai' : 'default',
+        theme: theme === 'dark' ? 'monokai' : 'ttcn',
         // Hide the cursor
         readOnly: true,
         // Styled text selection

--- a/ui/component/viewers/codeViewer.jsx
+++ b/ui/component/viewers/codeViewer.jsx
@@ -31,6 +31,14 @@ class CodeViewer extends React.PureComponent<Props> {
     this.codeMirror = null;
   }
 
+  componentDidUpdate(prevProps: Props): * {
+    if (prevProps.theme === this.props.theme) return;
+
+    // This code is duplicated with componentDidMount
+    const theme = this.props.theme === 'dark' ? 'monokai' : 'default';
+    this.codeMirror.setOption('theme', theme);
+  }
+
   componentDidMount() {
     const me = this;
     const { theme, contentType } = me.props;

--- a/ui/component/viewers/codeViewer.jsx
+++ b/ui/component/viewers/codeViewer.jsx
@@ -43,7 +43,7 @@ class CodeViewer extends React.PureComponent<Props> {
         // Auto detect syntax with file contentType
         mode: contentType,
         // Adaptive theme
-        theme: theme === 'dark' ? 'one-dark' : 'default',
+        theme: theme === 'dark' ? 'monokai' : 'default',
         // Hide the cursor
         readOnly: true,
         // Styled text selection

--- a/ui/component/viewers/codeViewer.jsx
+++ b/ui/component/viewers/codeViewer.jsx
@@ -42,7 +42,7 @@ class CodeViewer extends React.PureComponent<Props> {
   componentDidMount() {
     const me = this;
     const { theme, contentType } = me.props;
-    alert(theme);
+
     // Init CodeMirror
     import(
       /* webpackChunkName: "codemirror" */

--- a/ui/component/viewers/htmlViewer.jsx
+++ b/ui/component/viewers/htmlViewer.jsx
@@ -1,21 +1,47 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { stopContextMenu } from 'util/context-menu';
 
 type Props = {
   source: string,
 };
 
-class HtmlViewer extends React.PureComponent<Props> {
+type State = {
+  loading: boolean,
+};
+
+class HtmlViewer extends React.PureComponent<Props, State> {
+  iframe: React.ElementRef<any>;
+  constructor(props: Props) {
+    super(props);
+    this.state = { loading: true };
+    this.iframe = React.createRef();
+  }
+
+  componentDidMount() {
+    const resize = () => {
+      const { scrollHeight, scrollWidth } = this.iframe.current.contentDocument.body;
+      this.iframe.current.style.height = `${scrollHeight}px`;
+      this.iframe.current.style.width = `${scrollWidth}px`;
+    };
+    this.iframe.current.onload = () => {
+      this.setState({ loading: false });
+      resize();
+    };
+    this.iframe.current.resize = () => resize();
+  }
+
   render() {
     const { source } = this.props;
+    const { loading } = this.state;
     return (
       <div className="file-render__viewer" onContextMenu={stopContextMenu}>
+        {loading && <div className="placeholder--text-document" />}
         {/* @if TARGET='app' */}
-        <iframe sandbox="" title={__('File preview')} src={`file://${source}`} />
+        <iframe ref={this.iframe} hidden={loading} sandbox="" title={__('File preview')} src={`file://${source}`} />
         {/* @endif */}
         {/* @if TARGET='web' */}
-        <iframe sandbox="" title={__('File preview')} src={source} />
+        <iframe ref={this.iframe} hidden={loading} sandbox="" title={__('File preview')} src={source} />
         {/* @endif */}
       </div>
     );

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -132,7 +132,7 @@ export const makeSelectIsText = (uri: string) =>
   createSelector(
     makeSelectMediaTypeForUri(uri),
     mediaType => {
-      const isText = ['document', 'script'].includes(mediaType);
+      const isText = ['text', 'document', 'script'].includes(mediaType);
       return isText;
     }
   );

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -132,7 +132,7 @@ export const makeSelectIsText = (uri: string) =>
   createSelector(
     makeSelectMediaTypeForUri(uri),
     mediaType => {
-      const isText = ['text', 'document'].includes(mediaType);
+      const isText = ['document', 'script'].includes(mediaType);
       return isText;
     }
   );

--- a/ui/scss/component/_main.scss
+++ b/ui/scss/component/_main.scss
@@ -104,8 +104,7 @@
 .main__document-wrapper {
   max-width: 100%;
   min-width: 80%;
-  /* margin: auto needs a set width */
-  width: 0;
+  width: fit-content;
   margin: auto;
   margin-bottom: var(--spacing-xlarge);
 

--- a/ui/scss/component/_main.scss
+++ b/ui/scss/component/_main.scss
@@ -102,7 +102,10 @@
 }
 
 .main__document-wrapper {
-  width: 40em;
+  max-width: 100%;
+  min-width: 80%;
+  /* margin: auto needs a set width */
+  width: 0;
   margin: auto;
   margin-bottom: var(--spacing-xlarge);
 

--- a/ui/scss/component/_main.scss
+++ b/ui/scss/component/_main.scss
@@ -103,7 +103,7 @@
 
 .main__document-wrapper {
   max-width: 100%;
-  min-width: 80%;
+  min-width: 40em;
   width: fit-content;
   margin: auto;
   margin-bottom: var(--spacing-xlarge);
@@ -111,4 +111,11 @@
   @media (max-width: $breakpoint-small) {
     width: 100%;
   }
+}
+
+.main__document-wrapper-md {
+  @extend .main__document-wrapper;
+  width: 40em;
+  max-width: unset;
+  min-width: unset;
 }

--- a/ui/scss/component/_main.scss
+++ b/ui/scss/component/_main.scss
@@ -113,7 +113,7 @@
   }
 }
 
-.main__document-wrapper-md {
+.main__document-wrapper--markdown {
   @extend .main__document-wrapper;
   width: 40em;
   max-width: unset;

--- a/ui/scss/component/_markdown-editor.scss
+++ b/ui/scss/component/_markdown-editor.scss
@@ -1,8 +1,5 @@
 .CodeMirror {
-  border-top: none;
-  border-right: 1px solid var(--color-input-border);
-  border-bottom: 1px solid var(--color-input-border);
-  border-left: 1px solid var(--color-input-border);
+  border: 1px solid var(--color-input-border);
   border-bottom-left-radius: var(--border-radius);
   border-bottom-right-radius: var(--border-radius);
   background: var(--color-input-bg);
@@ -11,6 +8,10 @@
   .CodeMirror-placeholder {
     opacity: 0.5;
   }
+}
+
+.CodeMirror-wrap {
+  overflow: hidden;
 }
 
 .editor-toolbar {

--- a/ui/scss/component/_syntax-highlighter.scss
+++ b/ui/scss/component/_syntax-highlighter.scss
@@ -1,114 +1,100 @@
-// Name: one-dark 1.1.1
-// Author: Török Ádám (http://github.com/Aerobird98)
-// Original Atom One Dark Theme (https://github.com/atom/one-dark-ui & https://github.com/atom/one-dark-syntax)
+/* Based on Sublime Text's Monokai theme */
 
-// basic
-.CodeMirror {
-  &.cm-s-one-dark {
-    color: #abb2bf;
+.cm-s-monokai.CodeMirror {
+  background: #212529;
+  color: #f8f8f2;
+}
+.cm-s-monokai div.CodeMirror-selected {
+  background: #717273;
+}
+.cm-s-monokai .CodeMirror-gutters {
+  background: #212529;
+  border-right: 0px;
+}
+.cm-s-monokai .CodeMirror-guttermarker {
+  color: white;
+}
+.cm-s-monokai .CodeMirror-guttermarker-subtle {
+  color: #d0d0d0;
+}
+.cm-s-monokai .CodeMirror-linenumber {
+  color: #d0d0d0;
+}
+.cm-s-monokai .CodeMirror-cursor {
+  border-left: 1px solid #f8f8f0;
+}
 
-    .CodeMirror-cursor {
-      border-left: 2px solid #56b6c2;
-    }
+.cm-s-monokai span.cm-comment {
+  color: #ada6a7;
+}
+.cm-s-monokai span.cm-atom {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-number {
+  color: #ae81ff;
+}
 
-    .CodeMirror-lines {
-      background-color: transparent;
-    }
+.cm-s-monokai span.cm-comment.cm-attribute {
+  color: #97b757;
+}
+.cm-s-monokai span.cm-comment.cm-def {
+  color: #bc9262;
+}
+.cm-s-monokai span.cm-comment.cm-tag {
+  color: #bc6283;
+}
+.cm-s-monokai span.cm-comment.cm-type {
+  color: #5998a6;
+}
 
-    // addon: edit/machingbrackets.js & addon: edit/matchtags.js
-    .CodeMirror-matchingbracket,
-    .CodeMirror-matchingtag {
-      border-bottom: 2px solid #56b6c2;
-      color: #abb2bf !important;
-      background-color: transparent;
-    }
+.cm-s-monokai span.cm-property,
+.cm-s-monokai span.cm-attribute {
+  color: #a6e22e;
+}
+.cm-s-monokai span.cm-keyword {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-builtin {
+  color: #66d9ef;
+}
+.cm-s-monokai span.cm-string {
+  color: #e6db74;
+}
 
-    .CodeMirror-nonmatchingbracket {
-      border-bottom: 2px solid #e06c75;
-      color: #abb2bf !important;
-      background-color: transparent;
-    }
+.cm-s-monokai span.cm-variable {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-variable-2 {
+  color: #9effff;
+}
+.cm-s-monokai span.cm-variable-3,
+.cm-s-monokai span.cm-type {
+  color: #66d9ef;
+}
+.cm-s-monokai span.cm-def {
+  color: #fd971f;
+}
+.cm-s-monokai span.cm-bracket {
+  color: #f8f8f2;
+}
+.cm-s-monokai span.cm-tag {
+  color: #f92672;
+}
+.cm-s-monokai span.cm-header {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-link {
+  color: #ae81ff;
+}
+.cm-s-monokai span.cm-error {
+  background: #f92672;
+  color: #f8f8f0;
+}
 
-    // addon: fold/foldgutter.js
-    .CodeMirror-foldmarker,
-    .CodeMirror-foldgutter,
-    .CodeMirror-foldgutter-open,
-    .CodeMirror-foldgutter-folded {
-      border: none;
-      text-shadow: none;
-      color: #5c6370 !important;
-      background-color: transparent;
-    }
-
-    // basic syntax
-    .cm-atom,
-    .cm-attribute,
-    .cm-number,
-    .cm-qualifier,
-    .cm-strong {
-      color: #d19a66;
-    }
-
-    .cm-bracket,
-    .cm-meta,
-    .cm-punctuation,
-    .cm-m-css.cm-property {
-      color: #abb2bf;
-    }
-
-    .cm-builtin,
-    .cm-error,
-    .cm-header,
-    .cm-negative,
-    .cm-positive,
-    .cm-tag,
-    .cm-variable {
-      color: #e06c75;
-    }
-
-    .cm-comment,
-    .cm-quote {
-      color: #5c6370;
-    }
-
-    .cm-def {
-      color: #e5c07b;
-    }
-
-    .cm-em,
-    .cm-keyword {
-      color: #c678dd;
-    }
-
-    .cm-comment,
-    .cm-em,
-    .cm-quote {
-      font-style: italic;
-    }
-
-    .cm-link,
-    .cm-string {
-      color: #98c379;
-    }
-
-    .cm-link {
-      border-bottom: 1px solid #98c379;
-    }
-
-    .cm-operator,
-    .cm-property,
-    .cm-m-css.cm-atom,
-    .cm-m-css.cm-builtin,
-    .cm-m-lua.cm-variable {
-      color: #56b6c2;
-    }
-
-    .cm-strong {
-      font-weight: bold;
-    }
-
-    .cm-m-css.cm-variable {
-      color: #828997;
-    }
-  }
+.cm-s-monokai .CodeMirror-activeline-background {
+  background: #373831;
+}
+.cm-s-monokai .CodeMirror-matchingbracket {
+  text-decoration: underline;
+  color: white !important;
 }

--- a/ui/scss/component/_syntax-highlighter.scss
+++ b/ui/scss/component/_syntax-highlighter.scss
@@ -1,4 +1,5 @@
 /* Based on Sublime Text's Monokai theme */
+/* Customised slightly for LBRY dark theme */
 
 .cm-s-monokai.CodeMirror {
   background: #212529;

--- a/ui/scss/component/_syntax-highlighter.scss
+++ b/ui/scss/component/_syntax-highlighter.scss
@@ -5,22 +5,28 @@
   background: #212529;
   color: #f8f8f2;
 }
+
 .cm-s-monokai div.CodeMirror-selected {
   background: #717273;
 }
+
 .cm-s-monokai .CodeMirror-gutters {
   background: #212529;
   border-right: 0px;
 }
+
 .cm-s-monokai .CodeMirror-guttermarker {
   color: white;
 }
+
 .cm-s-monokai .CodeMirror-guttermarker-subtle {
   color: #d0d0d0;
 }
+
 .cm-s-monokai .CodeMirror-linenumber {
   color: #d0d0d0;
 }
+
 .cm-s-monokai .CodeMirror-cursor {
   border-left: 1px solid #f8f8f0;
 }
@@ -28,9 +34,11 @@
 .cm-s-monokai span.cm-comment {
   color: #ada6a7;
 }
+
 .cm-s-monokai span.cm-atom {
   color: #ae81ff;
 }
+
 .cm-s-monokai span.cm-number {
   color: #ae81ff;
 }
@@ -38,12 +46,15 @@
 .cm-s-monokai span.cm-comment.cm-attribute {
   color: #97b757;
 }
+
 .cm-s-monokai span.cm-comment.cm-def {
   color: #bc9262;
 }
+
 .cm-s-monokai span.cm-comment.cm-tag {
   color: #bc6283;
 }
+
 .cm-s-monokai span.cm-comment.cm-type {
   color: #5998a6;
 }
@@ -52,12 +63,15 @@
 .cm-s-monokai span.cm-attribute {
   color: #a6e22e;
 }
+
 .cm-s-monokai span.cm-keyword {
   color: #f92672;
 }
+
 .cm-s-monokai span.cm-builtin {
   color: #66d9ef;
 }
+
 .cm-s-monokai span.cm-string {
   color: #e6db74;
 }
@@ -65,28 +79,36 @@
 .cm-s-monokai span.cm-variable {
   color: #f8f8f2;
 }
+
 .cm-s-monokai span.cm-variable-2 {
   color: #9effff;
 }
+
 .cm-s-monokai span.cm-variable-3,
 .cm-s-monokai span.cm-type {
   color: #66d9ef;
 }
+
 .cm-s-monokai span.cm-def {
   color: #fd971f;
 }
+
 .cm-s-monokai span.cm-bracket {
   color: #f8f8f2;
 }
+
 .cm-s-monokai span.cm-tag {
   color: #f92672;
 }
+
 .cm-s-monokai span.cm-header {
   color: #ae81ff;
 }
+
 .cm-s-monokai span.cm-link {
   color: #ae81ff;
 }
+
 .cm-s-monokai span.cm-error {
   background: #f92672;
   color: #f8f8f0;
@@ -95,7 +117,221 @@
 .cm-s-monokai .CodeMirror-activeline-background {
   background: #373831;
 }
+
 .cm-s-monokai .CodeMirror-matchingbracket {
   text-decoration: underline;
   color: white !important;
+}
+
+/* From https://codemirror.net/theme/ttcn.css */
+/* Customised slightly for LBRY light theme */
+
+.cm-s-ttnc .CodeMirror {
+  background-color: var(--color-background);
+}
+
+.cm-s-ttnc .CodeMirror {
+  background-color: var(--color-background);
+  border: 0;
+}
+
+.cm-s-ttcn .cm-quote {
+  color: #090;
+}
+
+.cm-s-ttcn .cm-negative {
+  color: #d44;
+}
+
+.cm-s-ttcn .cm-positive {
+  color: #292;
+}
+
+.cm-s-ttcn .cm-header,
+.cm-strong {
+  font-weight: bold;
+}
+
+.cm-s-ttcn .cm-em {
+  font-style: italic;
+}
+
+.cm-s-ttcn .cm-link {
+  text-decoration: underline;
+}
+
+.cm-s-ttcn .cm-strikethrough {
+  text-decoration: line-through;
+}
+
+.cm-s-ttcn .cm-header {
+  color: #00f;
+  font-weight: bold;
+}
+
+.cm-s-ttcn .cm-atom {
+  color: #219;
+}
+
+.cm-s-ttcn .cm-attribute {
+  color: #00c;
+}
+
+.cm-s-ttcn .cm-bracket {
+  color: #997;
+}
+
+.cm-s-ttcn .cm-comment {
+  color: #333333;
+}
+
+.cm-s-ttcn .cm-def {
+  color: #00f;
+}
+
+.cm-s-ttcn .cm-em {
+  font-style: italic;
+}
+
+.cm-s-ttcn .cm-error {
+  color: #f00;
+}
+
+.cm-s-ttcn .cm-hr {
+  color: #999;
+}
+
+.cm-s-ttcn .cm-invalidchar {
+  color: #f00;
+}
+
+.cm-s-ttcn .cm-keyword {
+  font-weight: bold;
+}
+
+.cm-s-ttcn .cm-link {
+  color: #00c;
+  text-decoration: underline;
+}
+
+.cm-s-ttcn .cm-meta {
+  color: #555;
+}
+
+.cm-s-ttcn .cm-negative {
+  color: #d44;
+}
+
+.cm-s-ttcn .cm-positive {
+  color: #292;
+}
+
+.cm-s-ttcn .cm-qualifier {
+  color: #555;
+}
+
+.cm-s-ttcn .cm-strikethrough {
+  text-decoration: line-through;
+}
+
+.cm-s-ttcn .cm-string {
+  color: #006400;
+}
+
+.cm-s-ttcn .cm-string-2 {
+  color: #f50;
+}
+
+.cm-s-ttcn .cm-strong {
+  font-weight: bold;
+}
+
+.cm-s-ttcn .cm-tag {
+  color: #170;
+}
+
+.cm-s-ttcn .cm-variable {
+  color: #8b2252;
+}
+
+.cm-s-ttcn .cm-variable-2 {
+  color: #05a;
+}
+
+.cm-s-ttcn .cm-variable-3,
+.cm-s-ttcn .cm-type {
+  color: #085;
+}
+
+.cm-s-ttcn .cm-invalidchar {
+  color: #f00;
+}
+
+/* ASN */
+.cm-s-ttcn .cm-accessTypes,
+.cm-s-ttcn .cm-compareTypes {
+  color: #27408b;
+}
+
+.cm-s-ttcn .cm-cmipVerbs {
+  color: #8b2252;
+}
+
+.cm-s-ttcn .cm-modifier {
+  color: #d2691e;
+}
+
+.cm-s-ttcn .cm-status {
+  color: #8b4545;
+}
+
+.cm-s-ttcn .cm-storage {
+  color: #a020f0;
+}
+
+.cm-s-ttcn .cm-tags {
+  color: #006400;
+}
+
+/* CFG */
+.cm-s-ttcn .cm-externalCommands {
+  color: #8b4545;
+  font-weight: bold;
+}
+
+.cm-s-ttcn .cm-fileNCtrlMaskOptions,
+.cm-s-ttcn .cm-sectionTitle {
+  color: #2e8b57;
+  font-weight: bold;
+}
+
+/* TTCN */
+.cm-s-ttcn .cm-booleanConsts,
+.cm-s-ttcn .cm-otherConsts,
+.cm-s-ttcn .cm-verdictConsts {
+  color: #006400;
+}
+
+.cm-s-ttcn .cm-configOps,
+.cm-s-ttcn .cm-functionOps,
+.cm-s-ttcn .cm-portOps,
+.cm-s-ttcn .cm-sutOps,
+.cm-s-ttcn .cm-timerOps,
+.cm-s-ttcn .cm-verdictOps {
+  color: #0000ff;
+}
+
+.cm-s-ttcn .cm-preprocessor,
+.cm-s-ttcn .cm-templateMatch,
+.cm-s-ttcn .cm-ttcn3Macros {
+  color: #27408b;
+}
+
+.cm-s-ttcn .cm-types {
+  color: #a52a2a;
+  font-weight: bold;
+}
+
+.cm-s-ttcn .cm-visibilityModifiers {
+  font-weight: bold;
 }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Style changes

## Fixes

Issue Number: N/A

## What is the current behavior?

## What is the new behavior?

## Other information

Just a few changes for the text viewer (the one which looks similar to Medium)

List of changes:
- [x] Script files are now added to the list of human readable text files
- [x] The default width has been increased, and content with longer lines will increase even more to try fit each of it's line properly.
- [x] Added a better dark theme for the code viewer, designed to integrate with the LBRY dark theme. Also removed the static scrollbar from the bottom of most code editors / viewers.
- [x] The code viewer theme now changes when the LBRY theme changes.
- [x] Add a better light theme
- [x] HTML files now have the same look and feel as the other human readable text files
- [ ] ~~Change lbry files to do the same ^~~

Other things: (figured i'd put them in the same pr rather than making two new pr's)
- [x] Add proper links to fonts in `index-electron`
- [x] Fix link rendering on the same line in markdown 