### PR TITLE
Add "No Results" Message When Searching Channel Content

### DIFF
--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -19,10 +19,10 @@ import * as ICONS from 'constants/icons';
 import classnames from 'classnames';
 import * as MODALS from 'constants/modal_types';
 import { Form, FormField } from 'component/common/form';
-import ClaimPreview from 'component/claimPreview';
 import Icon from 'component/common/icon';
 import HelpLink from 'component/common/help-link';
 import { DEBOUNCE_WAIT_DURATION_MS } from 'constants/search';
+import ClaimList from 'component/claimList';
 
 const PAGE_VIEW_QUERY = `view`;
 const ABOUT_PAGE = `about`;
@@ -250,7 +250,14 @@ function ChannelPage(props: Props) {
         <TabPanels>
           <TabPanel>
             {searchResults ? (
-              searchResults.map(url => <ClaimPreview key={url} uri={url} />)
+              <ClaimList
+                header={false}
+                headerAltControls={null}
+                id={`search-results-for-${claimId}`}
+                loading={false}
+                showHiddenByUser={false}
+                uris={searchResults}
+              />
             ) : (
               <ChannelContent uri={uri} channelIsBlackListed={channelIsBlackListed} />
             )}


### PR DESCRIPTION
## PR Checklist
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type
- [x] Bugfix

## Fixes
Issue Number: #3507

## What is the current behavior?
When no results are returned, the user just sees an empty section.
![no-results-before](https://user-images.githubusercontent.com/15717854/72677409-a43e3380-3a61-11ea-92e1-51bf7bf222f5.png)

## What is the new behavior?
When no results are returned, the user will see a message saying "no results".
![no-results](https://user-images.githubusercontent.com/15717854/72677376-680ad300-3a61-11ea-9568-006cb282393e.png)

## Bonus
I noticed the styling of returned results was off when searching a channel. I dug around and saw that we could use ClaimList here, this fixes both the styling and the 'no results' issue.

*Current Search Styling*
![results-no-style](https://user-images.githubusercontent.com/15717854/72687265-c5367100-3ac1-11ea-83d1-258beb2921ff.png)

*New Search Styling*
![results-with-style2](https://user-images.githubusercontent.com/15717854/72687291-0595ef00-3ac2-11ea-92ca-f77a0a45e528.png)