### PR TITLE
Added Download Button on hover for the thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.39.1] - [Unreleased]
+## [0.40.0] - [Unreleased]
+
+### Added
+
+- Download buttons on file cards ([#3546](https://github.com/lbryio/lbry-desktop/pull/3546))
+
+### Changed
+
+### Fixed
+
+## [0.39.1] - [2019-1-24]
 
 ### Added
 

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -13,6 +13,8 @@ import { formatLbryUrlForWeb } from 'util/url';
 import { parseURI } from 'lbry-redux';
 import FileProperties from 'component/fileProperties';
 
+import FileDownloadLink from 'component/fileDownloadLink';
+
 type Props = {
   uri: string,
   claim: ?Claim,
@@ -61,6 +63,8 @@ function ClaimPreviewTile(props: Props) {
     onClick: e => e.stopPropagation(),
   };
 
+  const [isHovering, setHovering] = React.useState(false);
+
   let isChannel;
   let isValid = false;
   if (uri) {
@@ -85,6 +89,14 @@ function ClaimPreviewTile(props: Props) {
     if (navigateUrl) {
       history.push(navigateUrl);
     }
+  }
+
+  function handleOnMouseOver(e) {
+    setHovering(true);
+  }
+
+  function handleOnMouseOut(e) {
+    setHovering(false);
   }
 
   React.useEffect(() => {
@@ -146,6 +158,8 @@ function ClaimPreviewTile(props: Props) {
       className={classnames('card claim-preview--tile', {
         'claim-preview--channel': isChannel,
       })}
+      onMouseOver={handleOnMouseOver}
+      onMouseOut={handleOnMouseOut}
     >
       <NavLink {...navLinkProps}>
         <FileThumbnail thumbnail={thumbnailUrl}>

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -63,8 +63,6 @@ function ClaimPreviewTile(props: Props) {
     onClick: e => e.stopPropagation(),
   };
 
-  const [isHovering, setHovering] = React.useState(false);
-
   let isChannel;
   let isValid = false;
   if (uri) {
@@ -89,14 +87,6 @@ function ClaimPreviewTile(props: Props) {
     if (navigateUrl) {
       history.push(navigateUrl);
     }
-  }
-
-  function handleOnMouseOver(e) {
-    setHovering(true);
-  }
-
-  function handleOnMouseOut(e) {
-    setHovering(false);
   }
 
   React.useEffect(() => {
@@ -158,15 +148,20 @@ function ClaimPreviewTile(props: Props) {
       className={classnames('card claim-preview--tile', {
         'claim-preview--channel': isChannel,
       })}
-      onMouseOver={handleOnMouseOver}
-      onMouseOut={handleOnMouseOut}
     >
       <NavLink {...navLinkProps}>
         <FileThumbnail thumbnail={thumbnailUrl}>
           {!isChannel && (
-            <div className="claim-tile__file-properties">
-              <FileProperties uri={uri} small />
-            </div>
+            <React.Fragment>
+              {/* @if TARGET='app' */}
+              <div className="claim-tile__hover-actions">
+                <FileDownloadLink uri={uri} hideOpenButton />
+              </div>
+              {/* @endif */}
+              <div className="claim-tile__file-properties">
+                <FileProperties uri={uri} small />
+              </div>
+            </React.Fragment>
           )}
         </FileThumbnail>
       </NavLink>

--- a/ui/component/fileDownloadLink/view.jsx
+++ b/ui/component/fileDownloadLink/view.jsx
@@ -3,7 +3,6 @@ import * as ICONS from 'constants/icons';
 import * as MODALS from 'constants/modal_types';
 import React from 'react';
 import Button from 'component/button';
-import ToolTip from 'component/common/tooltip';
 
 type Props = {
   uri: string,
@@ -18,6 +17,7 @@ type Props = {
   download: string => void,
   triggerViewEvent: string => void,
   costInfo: ?{ cost: string },
+  hideOpenButton: boolean,
 };
 
 function FileDownloadLink(props: Props) {
@@ -33,6 +33,7 @@ function FileDownloadLink(props: Props) {
     claim,
     triggerViewEvent,
     costInfo,
+    hideOpenButton = false,
   } = props;
   const cost = costInfo ? Number(costInfo.cost) : 0;
   const isPaidContent = cost > 0;
@@ -40,7 +41,9 @@ function FileDownloadLink(props: Props) {
   const fileName = value && value.source && value.source.name;
   const downloadUrl = `/$/download/${name}/${claimId}`;
 
-  function handleDownload() {
+  function handleDownload(e) {
+    e.preventDefault();
+
     // @if TARGET='app'
     download(uri);
     // @endif;
@@ -58,36 +61,34 @@ function FileDownloadLink(props: Props) {
     const label =
       fileInfo && fileInfo.written_bytes > 0 ? progress.toFixed(0) + __('% downloaded') : __('Connecting...');
 
-    return <span>{label}</span>;
+    return <span className="download-text">{label}</span>;
   }
 
   if (fileInfo && fileInfo.download_path && fileInfo.completed) {
-    return (
-      <ToolTip label={__('Open file')}>
-        <Button
-          button="alt"
-          icon={ICONS.EXTERNAL}
-          onClick={() => {
-            pause();
-            openModal(MODALS.CONFIRM_EXTERNAL_RESOURCE, { path: fileInfo.download_path, isMine: claimIsMine });
-          }}
-        />
-      </ToolTip>
+    return hideOpenButton ? null : (
+      <Button
+        button="alt"
+        title={__('Open file')}
+        icon={ICONS.EXTERNAL}
+        onClick={() => {
+          pause();
+          openModal(MODALS.CONFIRM_EXTERNAL_RESOURCE, { path: fileInfo.download_path, isMine: claimIsMine });
+        }}
+      />
     );
   }
 
   return (
-    <ToolTip label={IS_WEB ? __('Download') : __('Add to your library')}>
-      <Button
-        button="alt"
-        icon={ICONS.DOWNLOAD}
-        onClick={handleDownload}
-        // @if TARGET='web'
-        download={fileName}
-        href={downloadUrl}
-        // @endif
-      />
-    </ToolTip>
+    <Button
+      button="alt"
+      title={IS_WEB ? __('Download') : __('Add to your library')}
+      icon={ICONS.DOWNLOAD}
+      onClick={handleDownload}
+      // @if TARGET='web'
+      download={fileName}
+      href={downloadUrl}
+      // @endif
+    />
   );
 }
 

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -384,11 +384,32 @@
   bottom: var(--spacing-miniscule);
   right: var(--spacing-miniscule);
   background-color: var(--color-black);
-  color: var(--color-white);
   padding: 0.2rem;
   border-radius: var(--border-radius);
 
   .file-properties {
     color: var(--color-white);
+  }
+}
+
+.claim-preview--tile {
+  .claim-tile__hover-actions {
+    display: none;
+    position: absolute;
+    top: var(--spacing-miniscule);
+    right: var(--spacing-miniscule);
+
+    & > * {
+      color: var(--color-black);
+      background-color: var(--color-white);
+      padding: var(--spacing-xsmall);
+      border-radius: var(--border-radius);
+    }
+  }
+
+  &:hover {
+    .claim-tile__hover-actions {
+      display: block;
+    }
   }
 }

--- a/ui/scss/init/_gui.scss
+++ b/ui/scss/init/_gui.scss
@@ -247,3 +247,7 @@ a {
 .emoji {
   font-size: 1.3em;
 }
+
+.download-text {
+  font-size: var(--font-xsmall);
+}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:  #1676

## What is the current behavior?
There's no easy way to prepare content for later. Say I'm on the Explore page and I discover several videos I want to watch, but before watching I want to scroll through the Explore page to see if there's anything else I want to watch too. I either have to try to remember everything so I can click through it later, or I have to click into each video and press download so it gets stored in the Downloads of My LBRY. That's a lot of unnecessary back and forth clicking though.

## What is the new behavior?
When hovering over thumbnails a 'download' button should appear, clicking it downloads the content in the background while you continue exploring.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
