### PR TITLE
Mouse Wheel to not Scroll Page While Editing LBC Amount

### DIFF
--- a/ui/component/channelCreate/view.jsx
+++ b/ui/component/channelCreate/view.jsx
@@ -147,6 +147,7 @@ class ChannelCreate extends React.PureComponent<Props, State> {
             error={newChannelBidError}
             value={newChannelBid}
             onChange={event => this.handleNewChannelBidChange(parseFloat(event.target.value))}
+            onWheel={e => e.stopPropagation()}
           />
           <div className="card__actions">
             <Button

--- a/ui/component/publishName/view.jsx
+++ b/ui/component/publishName/view.jsx
@@ -113,6 +113,7 @@ function PublishName(props: Props) {
             error={bidError}
             disabled={!name}
             onChange={event => updatePublishForm({ bid: parseFloat(event.target.value) })}
+            onWheel={e => e.stopPropagation()}
             helper={
               <BidHelpText
                 uri={'lbry://' + name}


### PR DESCRIPTION
## PR Checklist
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type
- [x] Bugfix

## Fixes
Issue Number: #3521

## What is the current behavior?
When editing the LBC amount on various forms by using the mouse wheel, the page scrolls along with the amount.

## What is the new behavior?
When the user is focusing on the LBC amount form element, don't scroll the page when the mouse wheel moves.

## Screen Shots
![create-channel](https://user-images.githubusercontent.com/15717854/73232334-8602c280-4148-11ea-9ab5-11715b729c14.png)

![new-publish](https://user-images.githubusercontent.com/15717854/73232339-87cc8600-4148-11ea-9434-82cfd054c90e.png)
