### PR TITLE
Hide Text Overflow for Long URLs in Mini Player

### DIFF
--- a/ui/scss/component/_media.scss
+++ b/ui/scss/component/_media.scss
@@ -49,6 +49,8 @@
   @extend .media__uri;
   position: relative;
   transform: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .media__uri--large {


### PR DESCRIPTION
## PR Checklist
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type
- [x] Bugfix

## Fixes
Issue Number: #3563 

## What is the current behavior?
URL overflows, preventing the user from accessing buttons.
![no-buttons](https://user-images.githubusercontent.com/15717854/73323704-e7d93000-420d-11ea-8f7b-de7fe84ecb22.png)

## What is the new behavior?
Text overflow is hidden, allowing user to access buttons.
![ellipsis](https://user-images.githubusercontent.com/15717854/73323564-78fbd700-420d-11ea-899b-44bc4b6af8b3.png)