### PR TITLE
Prevent Space Bar from Toggling Full-Screen on Firefox

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -204,6 +204,11 @@ function VideoViewer(props: Props) {
     if (player) {
       player.on('tracking:buffered', (e, d) => doTrackingBuffered(e, d));
       player.on('tracking:firstplay', (e, d) => doTrackingFirstPlay(e, d));
+
+      // fixes #3498 (https://github.com/lbryio/lbry-desktop/issues/3498)
+      // summary: on firefox the focus would stick to the fullscreen button which caused buggy behavior with spacebar
+      // $FlowFixMe
+      player.on('fullscreenchange', () => document.activeElement && document.activeElement.blur());
     }
     return () => {
       if (player) {


### PR DESCRIPTION
## PR Checklist
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type
- [x] Bugfix

## Fixes
Issue Number: #3498 

## What is the current behavior?
On Firefox the video player's full-screen button maintains the focus after being clicked. This means that subsequent presses of the space bar will toggle full-screen mode. This behavior is inconsistent with both the app and chrome-based browsers.

## What is the new behavior?
Blur the active element after entering or exiting full-screen mode. This means that after pressing the full-screen button in Firefox, the space bar will control whether the video is paused or playing.