### PR TITLE
create more claim components to simplify ClaimPreview

### DIFF
--- a/ui/component/claimPreview/index.js
+++ b/ui/component/claimPreview/index.js
@@ -1,4 +1,3 @@
-import * as PAGES from 'constants/pages';
 import { connect } from 'react-redux';
 import {
   doResolveUri,
@@ -8,12 +7,9 @@ import {
   makeSelectClaimIsPending,
   makeSelectThumbnailForUri,
   makeSelectCoverForUri,
-  makeSelectTitleForUri,
   makeSelectClaimIsNsfw,
   selectBlockedChannels,
   selectChannelIsBlocked,
-  doClearPublish,
-  doPrepareEdit,
   doFileGet,
   makeSelectStreamingUrlForUri,
 } from 'lbry-redux';
@@ -21,8 +17,6 @@ import { selectBlackListedOutpoints, selectFilteredOutpoints } from 'lbryinc';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { makeSelectHasVisitedUri } from 'redux/selectors/content';
 import { makeSelectIsSubscribed } from 'redux/selectors/subscriptions';
-import { push } from 'connected-react-router';
-
 import ClaimPreview from './view';
 
 const select = (state, props) => ({
@@ -33,7 +27,6 @@ const select = (state, props) => ({
   isResolvingUri: props.uri && makeSelectIsUriResolving(props.uri)(state),
   thumbnail: props.uri && makeSelectThumbnailForUri(props.uri)(state),
   cover: props.uri && makeSelectCoverForUri(props.uri)(state),
-  title: props.uri && makeSelectTitleForUri(props.uri)(state),
   nsfw: props.uri && makeSelectClaimIsNsfw(props.uri)(state),
   blackListedOutpoints: selectBlackListedOutpoints(state),
   filteredOutpoints: selectFilteredOutpoints(state),
@@ -47,11 +40,6 @@ const select = (state, props) => ({
 const perform = dispatch => ({
   resolveUri: uri => dispatch(doResolveUri(uri)),
   getFile: uri => dispatch(doFileGet(uri, false)),
-  beginPublish: name => {
-    dispatch(doClearPublish());
-    dispatch(doPrepareEdit({ name }));
-    dispatch(push(`/$/${PAGES.PUBLISH}`));
-  },
 });
 
 export default connect(

--- a/ui/component/claimSubtitle/index.js
+++ b/ui/component/claimSubtitle/index.js
@@ -1,0 +1,23 @@
+import * as PAGES from 'constants/pages';
+import { connect } from 'react-redux';
+import { makeSelectClaimForUri, makeSelectClaimIsPending, doClearPublish, doPrepareEdit } from 'lbry-redux';
+import { push } from 'connected-react-router';
+import ClaimSubtitle from './view';
+
+const select = (state, props) => ({
+  claim: makeSelectClaimForUri(props.uri)(state),
+  pending: makeSelectClaimIsPending(props.uri)(state),
+});
+
+const perform = dispatch => ({
+  beginPublish: name => {
+    dispatch(doClearPublish());
+    dispatch(doPrepareEdit({ name }));
+    dispatch(push(`/$/${PAGES.PUBLISH}`));
+  },
+});
+
+export default connect(
+  select,
+  perform
+)(ClaimSubtitle);

--- a/ui/component/claimSubtitle/view.jsx
+++ b/ui/component/claimSubtitle/view.jsx
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react';
+import UriIndicator from 'component/uriIndicator';
+import DateTime from 'component/dateTime';
+import Button from 'component/button';
+import { parseURI } from 'lbry-redux';
+
+type Props = {
+  uri: string,
+  claim: ?Claim,
+  pending?: boolean,
+  type: string,
+  beginPublish: string => void,
+};
+
+function ClaimSubtitle(props: Props) {
+  const { pending, uri, claim, type, beginPublish } = props;
+  const claimsInChannel = (claim && claim.meta.claims_in_channel) || 0;
+
+  let isChannel;
+  let name;
+  try {
+    ({ streamName: name, isChannel } = parseURI(uri));
+  } catch (e) {}
+
+  return (
+    <div className="media__subtitle">
+      {claim ? (
+        <React.Fragment>
+          <UriIndicator uri={uri} link />{' '}
+          {pending
+            ? __('Pending...')
+            : claim &&
+              (isChannel ? (
+                type !== 'inline' && `${claimsInChannel} ${__('publishes')}`
+              ) : (
+                <DateTime timeAgo uri={uri} />
+              ))}
+        </React.Fragment>
+      ) : (
+        <React.Fragment>
+          <div>{__('Publish something and claim this spot!')}</div>
+          <div className="card__actions">
+            <Button onClick={() => beginPublish(name)} button="primary" label={__('Publish to %uri%', { uri })} />
+          </div>
+        </React.Fragment>
+      )}
+    </div>
+  );
+}
+
+export default ClaimSubtitle;

--- a/ui/component/claimTitle/index.js
+++ b/ui/component/claimTitle/index.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import { makeSelectClaimForUri, makeSelectTitleForUri } from 'lbry-redux';
+import ClaimPreview from './view';
+
+const select = (state, props) => ({
+  claim: makeSelectClaimForUri(props.uri)(state),
+  title: makeSelectTitleForUri(props.uri)(state),
+});
+
+export default connect(select)(ClaimPreview);

--- a/ui/component/claimTitle/view.jsx
+++ b/ui/component/claimTitle/view.jsx
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react';
+import TruncatedText from 'component/common/truncated-text';
+
+type Props = {
+  uri: string,
+  claim: ?Claim,
+  title: string,
+};
+
+function ClaimTitle(props: Props) {
+  const { title, claim } = props;
+
+  return (
+    <div className="claim-preview-title">
+      {claim ? <TruncatedText text={title || claim.name} lines={2} /> : <span>{__('Nothing here')}</span>}
+    </div>
+  );
+}
+
+export default ClaimTitle;


### PR DESCRIPTION
I'm going to be moving a few things around to add new labels/buttons for resposts so I figured I would create this now to make the actual repost PR smaller