### PR TITLE
fix desktop overwriting subscriptions in shared prefs

### DIFF
--- a/ui/redux/reducers/subscriptions.js
+++ b/ui/redux/reducers/subscriptions.js
@@ -157,14 +157,7 @@ export default handleActions(
             channelName: `@${channelName}`,
           };
         });
-        if (!state.subscriptions || !state.subscriptions.length) {
-          newSubscriptions = parsedSubscriptions;
-        } else {
-          const map = {};
-          newSubscriptions = parsedSubscriptions.concat(state.subscriptions).filter(sub => {
-            return map[sub.uri] ? false : (map[sub.uri] = true);
-          }, {});
-        }
+        newSubscriptions = parsedSubscriptions;
       }
 
       return {


### PR DESCRIPTION
simply replaces subscriptions on populate
treat sdk preferences and sync as source of truth

