### PR TITLE
Added download icon to Claim Previews

### DIFF
--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -18,6 +18,7 @@ import useGetThumbnail from 'effects/use-get-thumbnail';
 import ClaimPreviewTitle from 'component/claimPreviewTitle';
 import ClaimPreviewSubtitle from 'component/claimPreviewSubtitle';
 import ClaimRepostAuthor from 'component/claimRepostAuthor';
+import FileDownloadLink from 'component/fileDownloadLink';
 
 type Props = {
   uri: string,
@@ -230,7 +231,13 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
             <ChannelThumbnail uri={uri} obscure={channelIsBlocked} />
           </UriIndicator>
         ) : (
-          <FileThumbnail thumbnail={thumbnailUrl} />
+          <FileThumbnail thumbnail={thumbnailUrl}>
+            {/* @if TARGET='app' */}
+            <div className="claim-preview__hover-actions">
+              <FileDownloadLink uri={uri} hideOpenButton hideDownloadStatus />
+            </div>
+            {/* @endif */}
+          </FileThumbnail>
         )}
 
         <div className="claim-preview__text">

--- a/ui/component/fileDownloadLink/view.jsx
+++ b/ui/component/fileDownloadLink/view.jsx
@@ -19,6 +19,7 @@ type Props = {
   triggerViewEvent: string => void,
   costInfo: ?{ cost: string },
   hideOpenButton: boolean,
+  hideDownloadStatus: boolean,
 };
 
 function FileDownloadLink(props: Props) {
@@ -35,6 +36,7 @@ function FileDownloadLink(props: Props) {
     triggerViewEvent,
     costInfo,
     hideOpenButton = false,
+    hideDownloadStatus = false,
   } = props;
 
   const [viewEventSent, setViewEventSent] = useState(false);
@@ -67,7 +69,7 @@ function FileDownloadLink(props: Props) {
     const label =
       fileInfo && fileInfo.written_bytes > 0 ? progress.toFixed(0) + __('% downloaded') : __('Connecting...');
 
-    return <span className="download-text">{label}</span>;
+    return hideDownloadStatus ? null : <span className="download-text">{label}</span>;
   }
 
   if (fileInfo && fileInfo.download_path && fileInfo.completed) {

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -93,6 +93,26 @@
     margin-right: var(--spacing-medium);
   }
 
+  .claim-preview__hover-actions {
+    display: none;
+    position: absolute;
+    top: var(--spacing-miniscule);
+    right: var(--spacing-miniscule);
+
+    & > * {
+      color: var(--color-black);
+      background-color: var(--color-white);
+      padding: var(--spacing-xsmall);
+      border-radius: var(--border-radius);
+    }
+  }
+
+  &:hover {
+    .claim-preview__hover-actions {
+      display: block;
+    }
+  }
+
   @media (max-width: $breakpoint-small) {
     font-size: 14px;
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3623 

## What is the current behavior?
On hover of claim preview nothing happens

## What is the new behavior?
On hover the claim preview will show a download icon

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
