### PR TITLE
navigate back after delete if abandoned

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -923,6 +923,7 @@
   "refreshing the app": "refreshing the app",
   "Follower": "Follower",
   "%repost_channel_link% reposted": "%repost_channel_link% reposted",
+  "Abandon on blockchain (reclaim %amount% LBC)": "Abandon on blockchain (reclaim %amount% LBC)",
   "This channel may have been unpublished.": "This channel may have been unpublished.",
   "There was an error. Try %refreshing_the_app_link% to fix it. If that doesn't work, try pressing Ctrl+R/Cmd+R.": "There was an error. Try %refreshing_the_app_link% to fix it. If that doesn't work, try pressing Ctrl+R/Cmd+R."
 }

--- a/ui/redux/actions/file.js
+++ b/ui/redux/actions/file.js
@@ -63,7 +63,6 @@ export function doDeleteFileAndMaybeGoBack(uri, deleteFromComputer, abandonClaim
     const { outpoint } = makeSelectFileInfoForUri(uri)(state) || '';
     const { nout, txid } = makeSelectClaimForUri(uri)(state);
     const claimOutpoint = `${txid}:${nout}`;
-
     const actions = [];
     actions.push(doHideModal());
     actions.push(doDeleteFile(outpoint || claimOutpoint, deleteFromComputer, abandonClaim));
@@ -71,13 +70,12 @@ export function doDeleteFileAndMaybeGoBack(uri, deleteFromComputer, abandonClaim
     if (playingUri === uri) {
       actions.push(doSetPlayingUri(null));
     }
-
     // it would be nice to stay on the claim if you just want to delete it
     // we need to alter autoplay to not start downloading again after you delete it
-    // if (abandonClaim) {
-    actions.push(goBack());
-    // }
 
     dispatch(batchActions(...actions));
+    if (abandonClaim) {
+      dispatch(goBack());
+    }
   };
 }


### PR DESCRIPTION
For whatever reason, dispatching connected-react-router.goBack() didn't work in batched actions.