### PR TITLE
Fixed the checkbox and radio button for dark theme to make more visible

### DIFF
--- a/ui/scss/component/_form-field.scss
+++ b/ui/scss/component/_form-field.scss
@@ -126,6 +126,23 @@ fieldset-group {
   margin-top: var(--spacing-large);
 }
 
+.checkbox label:after {
+  border-left-color: var(--color-input);
+  border-bottom-color: var(--color-input);
+  border-right-color: var(--color-input);
+  border-top-color: var(--color-input);
+}
+
+.radio label:after {
+  background-color: var(--color-input);
+}
+
+.checkbox label:hover:before,
+.radio label:hover:before {
+  background-color: var(--color-input-bg-hover);
+  border-color: var(--color-input-bg-hover);
+}
+
 .form-field__conjuction {
   padding-top: 1rem;
 }

--- a/ui/scss/themes/dark.scss
+++ b/ui/scss/themes/dark.scss
@@ -55,6 +55,7 @@
   --color-input-placeholder: #f4f4f5;
   --color-input-bg: #5d6772;
   --color-input-bg-copyable: #434b53;
+  --color-input-bg-hover: #444444;
   --color-input-border: var(--color-border);
   --color-input-border-active: var(--color-secondary);
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3608 

## What is the current behavior?
Currently the checkboxes and radio buttons have --color-secondary as their attributes, they aren't contrasted enough with their backgrounds.
## What is the new behavior?
### Checkbox
Default:
![image](https://user-images.githubusercontent.com/6563959/73911293-85390180-48a9-11ea-9182-6ea9e742439c.png)

Hovering:
![image](https://user-images.githubusercontent.com/6563959/73911348-9d108580-48a9-11ea-978d-66ef0e845ae3.png)
### Radio Button
Default:
![image](https://user-images.githubusercontent.com/6563959/73911433-ca5d3380-48a9-11ea-9981-c227c4baf776.png)

Hovering:
![image](https://user-images.githubusercontent.com/6563959/73911450-d21cd800-48a9-11ea-9335-6ddc96f92ec1.png)


## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
