### PR TITLE
Download all transactions in CSV

### DIFF
--- a/ui/component/transactionList/index.js
+++ b/ui/component/transactionList/index.js
@@ -7,6 +7,7 @@ import {
   selectTransactionListFilter,
   doSetTransactionListFilter,
   selectIsFetchingTransactions,
+  selectTransactionItems,
 } from 'lbry-redux';
 import { withRouter } from 'react-router';
 import TransactionList from './view';
@@ -17,6 +18,7 @@ const select = state => ({
   myClaims: selectAllMyClaimsByOutpoint(state),
   filterSetting: selectTransactionListFilter(state),
   loading: selectIsFetchingTransactions(state),
+  allTransactions: selectTransactionItems(state),
 });
 
 const perform = dispatch => ({

--- a/ui/component/transactionList/view.jsx
+++ b/ui/component/transactionList/view.jsx
@@ -18,13 +18,24 @@ type Props = {
   setTransactionFilter: string => void,
   slim?: boolean,
   title: string,
+  allTransactions: Array<Transaction>,
   transactions: Array<Transaction>,
   transactionCount?: number,
   history: { replace: string => void },
 };
 
 function TransactionList(props: Props) {
-  const { emptyMessage, slim, filterSetting, title, transactions, loading, history, transactionCount } = props;
+  const {
+    emptyMessage,
+    slim,
+    filterSetting,
+    title,
+    transactions,
+    loading,
+    history,
+    transactionCount,
+    allTransactions,
+  } = props;
   // Flow offers little support for Object.values() typing.
   // https://github.com/facebook/flow/issues/2221
   // $FlowFixMe
@@ -49,7 +60,7 @@ function TransactionList(props: Props) {
             {/* @if TARGET='app' */}
             {!slim && (
               <FileExporter
-                data={transactions}
+                data={allTransactions}
                 label={__('Export')}
                 title={__('Export Transactions')}
                 filters={['nout']}


### PR DESCRIPTION
## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [x] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## What is the current behavior?
Currently exporting your transactions only exports the filtered list of transactions, or the first page.

## What is the new behavior?
All transactions are downloaded - ignoring any filtering.

## Other information
The breaking change here is that the export button exports all transactions, the previous functionality of filtering may be desired by some people.
I feel, however, that most people will want to download the whole data set and filter it themselves in an external program.
