### PR TITLE
improved color scheme for embed player

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -167,6 +167,7 @@
     .vjs-big-play-button {
       @extend .button--icon;
       @extend .button--play;
+      background-color: rgba(0,0,0,0.6);
       border: none;
       position: static;
       z-index: 2;
@@ -174,6 +175,13 @@
       .vjs-icon-placeholder {
         display: none;
       }
+    }
+  }
+  
+  .video-js:hover {
+    
+    .vjs-big-play-button {
+      background-color: rgba(var(--color-primary),0.6);
     }
   }
 }


### PR DESCRIPTION
This commit changes the colors of the play button on the embed video player to blend better with other websites. This relates to Issue #3706

## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature - this is a design change

Issue Number: #3706

## What is the current behavior?
uses LBRY branding always

## What is the new behavior?
neutral color for the play button and then LBRY branding on hover

## Other information
I would point out that the portion for the Hover color applying the opacity should work if the variable output is RGB but if it is HEX then it likely wont work. I didnt find the main variable location in my scan so its on an assumption.

If the variable color uses HEX then I would suggest putting it hardcoded like the following:

 background-color: rgba(37, 119, 97,0.6);

I am not sure if this is the best approach based on your structure and I also don't know if the way I added it was how you wanted the structure of the CSS to be but I tried to match it. :sunglasses: 
