### PR TITLE
fixed a variable conflict for embed play button

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -181,7 +181,7 @@
   .video-js:hover {
     
     .vjs-big-play-button {
-      background-color: rgba(var(--color-primary),0.6);
+      background-color: var(--color-primary);
     }
   }
 }


### PR DESCRIPTION
This fix addresses a problem with the color variable "var(--color-primary)" being used in the hover element. The output of the variable is not compatible with the rgba modification from the previous code. This commit fixes this bug in relation to Issue #3706

## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #3706

## What is the current behavior?
color-primary variable is not compatible with the rgba element so the bug is that it disables the icon background.

## What is the new behavior?
This fixes so the LBRY branding color is used correctly for the icon background.