### PR TITLE
Remove max-width channel header padding for small screens

### DIFF
--- a/ui/scss/component/_channel.scss
+++ b/ui/scss/component/_channel.scss
@@ -112,7 +112,6 @@ $metadata-z-index: 1;
 
   @media (max-width: $breakpoint-small) {
     padding-left: var(--spacing-medium);
-    padding-top: calc(2 * var(--spacing-xlarge));
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
Currently for channels with long names (Lbry.social) when the name wraps to 3 lines, the quick-action buttons become unclickable - specifically on mobile.

## What is the new behavior?
Clickable quick-actions on small screens

## Other information
Not sure if the padding was fixing a specific issue? I can't find any issues with various length channel names.
