### PR TITLE
Fix Forward and Backward Mouse Buttons

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -30,6 +30,10 @@ export const IS_MAC = process.platform === 'darwin';
 // @endif
 const SYNC_INTERVAL = 1000 * 60 * 5; // 5 minutes
 
+// button numbers pulled from https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+const MOUSE_BACK_BTN = 3;
+const MOUSE_FORWARD_BTN = 4;
+
 type Props = {
   alertError: (string | {}) => void,
   pageTitle: ?string,
@@ -38,7 +42,13 @@ type Props = {
   theme: string,
   user: ?{ id: string, has_verified_email: boolean, is_reward_approved: boolean },
   location: { pathname: string, hash: string, search: string },
-  history: { push: string => void },
+  history: {
+    goBack: () => void,
+    goForward: () => void,
+    index: number,
+    length: number,
+    push: string => void,
+  },
   fetchTransactions: (number, number) => void,
   fetchAccessToken: () => void,
   fetchChannelListMine: () => void,
@@ -126,6 +136,22 @@ function App(props: Props) {
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [uploadCount]);
+
+  // allows user to navigate history using the forward and backward buttons on a mouse
+  useEffect(() => {
+    const handleForwardAndBackButtons = e => {
+      switch (e.button) {
+        case MOUSE_BACK_BTN:
+          history.index > 0 && history.goBack();
+          break;
+        case MOUSE_FORWARD_BTN:
+          history.index < history.length - 1 && history.goForward();
+          break;
+      }
+    };
+    window.addEventListener('mouseup', handleForwardAndBackButtons);
+    return () => window.removeEventListener('mouseup', handleForwardAndBackButtons);
+  });
 
   useEffect(() => {
     if (referredRewardAvailable && sanitizedReferrerParam && isRewardApproved) {


### PR DESCRIPTION
## PR Checklist
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type
- [x] Bugfix

## Fixes
Issue Number: #3744 

## What is the current behavior?
Forward and backward mouse buttons do not navigate history.

## What is the new behavior?
Forward and backward mouse buttons *should* navigate history

## Other information
I don't have forward and backward mouse buttons so I tested using the middle button and right click button. After testing I updated the buttons to properly reflect forward and backward. I'm using [mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button) as a reference. **If someone can test this, it would be much appreciated**.

*Note: I'm not sure what other functionality these buttons are supposed to provide. For example if they can be used to fast-forward or rewind a video, I do not know.*
