### PR TITLE
fix selection on firefox

### DIFF
--- a/ui/scss/init/_gui.scss
+++ b/ui/scss/init/_gui.scss
@@ -96,10 +96,6 @@ dd {
   }
 }
 
-label {
-  user-select: none;
-}
-
 blockquote {
   margin-bottom: 1rem;
   padding: 0.8rem;

--- a/ui/scss/init/_gui.scss
+++ b/ui/scss/init/_gui.scss
@@ -96,7 +96,6 @@ dd {
   }
 }
 
-input,
 label {
   user-select: none;
 }


### PR DESCRIPTION
@seanyesmunt I spent a minute or two and couldn't think of or find a good reason why `user-select: none` was on all inputs. 

Do you know? It's not (at least anymore) for the copyable inputs. So I just removed it.