### PR TITLE
save optimize check to fix publish navigation file reloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#430f989809fed1ac310dbcacef926eb41bf6e6e5",
+    "lbry-redux": "lbryio/lbry-redux#aa6830d9f34db295ae4f3dbc56f616584f155778",
     "lbryinc": "lbryio/lbryinc#19260fac560daaa4be2d4af372f28109ea96ebf9",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#625a624b9c2d5839e25c1a592d69b9f312944fe0",
+    "lbry-redux": "lbryio/lbry-redux#430f989809fed1ac310dbcacef926eb41bf6e6e5",
     "lbryinc": "lbryio/lbryinc#19260fac560daaa4be2d4af372f28109ea96ebf9",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/ui/component/publishFile/index.js
+++ b/ui/component/publishFile/index.js
@@ -18,6 +18,9 @@ const select = state => ({
   balance: selectBalance(state),
   publishing: makeSelectPublishFormValue('publishing')(state),
   ffmpegStatus: selectFfmpegStatus(state),
+  size: makeSelectPublishFormValue('fileSize')(state),
+  duration: makeSelectPublishFormValue('fileDur')(state),
+  isVid: makeSelectPublishFormValue('fileVid')(state),
 });
 
 const perform = dispatch => ({
@@ -26,7 +29,4 @@ const perform = dispatch => ({
   showToast: message => dispatch(doToast({ message, isError: true })),
 });
 
-export default connect(
-  select,
-  perform
-)(PublishPage);
+export default connect(select, perform)(PublishPage);

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -22,6 +22,9 @@ type Props = {
   clearPublish: () => void,
   ffmpegStatus: any,
   optimize: boolean,
+  size: number,
+  duration: number,
+  isVid: boolean,
 };
 
 function PublishFile(props: Props) {
@@ -37,13 +40,13 @@ function PublishFile(props: Props) {
     clearPublish,
     optimize,
     ffmpegStatus = {},
+    size,
+    duration,
+    isVid,
   } = props;
 
   const { available } = ffmpegStatus;
-  const [duration, setDuration] = useState(0);
-  const [size, setSize] = useState(0);
   const [oversized, setOversized] = useState(false);
-  const [isVid, setIsVid] = useState(false);
   const RECOMMENDED_BITRATE = 6000000;
   const TV_PUBLISH_SIZE_LIMIT: number = 1073741824;
   const UPLOAD_SIZE_MESSAGE = 'Lbrytv uploads are limited to 1 GB. Download the app for unrestricted publishing.';
@@ -56,10 +59,8 @@ function PublishFile(props: Props) {
 
   // clear warnings
   useEffect(() => {
-    if (!filePath || filePath === '' || filePath.name === '') {
-      setDuration(0);
-      setSize(0);
-      setIsVid(false);
+    if (!filePath || filePath === '') {
+      updateOptimizeState(0, 0, false);
       setOversized(false);
     }
   }, [filePath]);
@@ -71,6 +72,10 @@ function PublishFile(props: Props) {
     } else {
       currentFile = filePath.name;
     }
+  }
+
+  function updateOptimizeState(duration, size, isvid) {
+    updatePublishForm({ fileDur: duration, fileSize: size, fileVid: isvid });
   }
 
   function getBitrate(size, duration) {
@@ -177,8 +182,6 @@ function PublishFile(props: Props) {
     // if electron, we'll set filePath to the path string because SDK is handling publishing.
     // if web, we set the filePath (dumb name) to the File() object
     // File.path will be undefined from web due to browser security, so it will default to the File Object.
-    setSize(file ? file.size : 0);
-    setDuration(0);
     setOversized(false);
 
     // select file, start to select a new one, then cancel
@@ -195,21 +198,15 @@ function PublishFile(props: Props) {
         const video = document.createElement('video');
         video.preload = 'metadata';
         video.onloadedmetadata = function() {
-          setDuration(video.duration);
-          setSize(file.size);
-          setIsVid(isVideo);
+          updateOptimizeState(video.duration, file.size, isVideo);
           window.URL.revokeObjectURL(video.src);
         };
         video.onerror = function() {
-          setDuration(0);
-          setSize(file.size);
-          setIsVid(isVideo);
+          updateOptimizeState(0, file.size, isVideo);
         };
         video.src = window.URL.createObjectURL(file);
       } else {
-        setSize(file.size);
-        setDuration(0);
-        setIsVid(isVideo);
+        updateOptimizeState(0, file.size, isVideo);
       }
     }
 


### PR DESCRIPTION
uses publish reducer instead of react hooks to store results from file checking across page navigations.