### PR TITLE
use claim_id for reposts page instead of uri so we don't have to resolve before

### DIFF
--- a/ui/component/fileActions/view.jsx
+++ b/ui/component/fileActions/view.jsx
@@ -52,7 +52,7 @@ function FileActions(props: Props) {
         <Button
           button="alt"
           label={__('(%count%)', { count: claim.meta.reposted })}
-          navigate={`/$/${PAGES.DISCOVER}?${CS.REPOSTED_URI_KEY}=${encodeURIComponent(uri)}`}
+          navigate={`/$/${PAGES.DISCOVER}?${CS.REPOSTED_CLAIM_ID_KEY}=${claim.claim_id}`}
         />
       </Fragment>
     );

--- a/ui/constants/claim_search.js
+++ b/ui/constants/claim_search.js
@@ -5,7 +5,7 @@ export const ORDER_BY_KEY = 'order';
 export const DURATION_KEY = 'duration';
 export const TAGS_KEY = 't';
 export const CONTENT_KEY = 'content';
-export const REPOSTED_URI_KEY = 'reposted_uri';
+export const REPOSTED_CLAIM_ID_KEY = 'reposted_claim_id';
 
 export const TAGS_ALL = 'tags_any';
 export const TAGS_FOLLOWED = 'tags_followed';

--- a/ui/page/discover/index.js
+++ b/ui/page/discover/index.js
@@ -1,24 +1,21 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, selectFollowedTags, doResolveUri } from 'lbry-redux';
+import { selectFollowedTags } from 'lbry-redux';
 import { selectUserVerifiedEmail } from 'lbryinc';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
 import * as CS from 'constants/claim_search';
-import Tags from './view';
+import Discover from './view';
 
 const select = (state, props) => {
   const urlParams = new URLSearchParams(props.location.search);
-  const repostedUriInUrl = urlParams.get(CS.REPOSTED_URI_KEY);
-  const repostedUri = repostedUriInUrl ? decodeURIComponent(repostedUriInUrl) : undefined;
+  const repostedClaimId = urlParams.get(CS.REPOSTED_CLAIM_ID_KEY);
 
   return {
     followedTags: selectFollowedTags(state),
-    repostedUri: repostedUri,
-    repostedClaim: repostedUri ? makeSelectClaimForUri(repostedUri)(state) : null,
+    repostedClaimId: repostedClaimId,
     isAuthenticated: selectUserVerifiedEmail(state),
   };
 };
 
 export default connect(select, {
   doToggleTagFollowDesktop,
-  doResolveUri,
-})(Tags);
+})(Discover);

--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -14,10 +14,8 @@ import Ads from 'lbrytv/component/ads';
 type Props = {
   location: { search: string },
   followedTags: Array<Tag>,
-  repostedUri: string,
-  repostedClaim: ?GenericClaim,
+  repostedClaimId: string,
   doToggleTagFollowDesktop: string => void,
-  doResolveUri: string => void,
   isAuthenticated: boolean,
 };
 
@@ -25,10 +23,8 @@ function DiscoverPage(props: Props) {
   const {
     location: { search },
     followedTags,
-    repostedClaim,
-    repostedUri,
+    repostedClaimId,
     doToggleTagFollowDesktop,
-    doResolveUri,
     isAuthenticated,
   } = props;
   const buttonRef = useRef();
@@ -38,7 +34,6 @@ function DiscoverPage(props: Props) {
   const claimType = urlParams.get('claim_type');
   const tagsQuery = urlParams.get('t') || null;
   const tags = tagsQuery ? tagsQuery.split(',') : null;
-  const repostedClaimIsResolved = repostedUri && repostedClaim;
 
   // Eventually allow more than one tag on this page
   // Restricting to one to make follow/unfollow simpler
@@ -50,12 +45,6 @@ function DiscoverPage(props: Props) {
     label = __('Unfollow');
   }
 
-  React.useEffect(() => {
-    if (repostedUri && !repostedClaimIsResolved) {
-      doResolveUri(repostedUri);
-    }
-  }, [repostedUri, repostedClaimIsResolved, doResolveUri]);
-
   function handleFollowClick() {
     if (tag) {
       doToggleTagFollowDesktop(tag);
@@ -66,8 +55,8 @@ function DiscoverPage(props: Props) {
   }
 
   let headerLabel;
-  if (repostedClaim) {
-    headerLabel = __('Reposts of %uri%', { uri: repostedUri });
+  if (repostedClaimId) {
+    headerLabel = __('Reposts');
   } else if (tag) {
     headerLabel = (
       <span>
@@ -91,7 +80,7 @@ function DiscoverPage(props: Props) {
         headerLabel={headerLabel}
         tags={tags}
         hiddenNsfwMessage={<HiddenNsfw type="page" />}
-        repostedClaimId={repostedClaim ? repostedClaim.claim_id : null}
+        repostedClaimId={repostedClaimId}
         injectedItem={!isAuthenticated && IS_WEB && <Ads type="video" />}
         meta={
           tag && (


### PR DESCRIPTION
quick fix because the page isn't working

we were doing a claim_search before the reposted uri was resolved, which was causing issues. It would be nice to accept a reposted_uri too, but merging this since it fixes the page