### PR TITLE
Fix #2677 glitchy subscribe button

### DIFF
--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -14,6 +14,7 @@ type Props = {
   href: ?string,
   title: ?string,
   label: ?string,
+  largestLabel: ?string,
   icon: ?string,
   iconRight: ?string,
   disabled: ?boolean,
@@ -47,6 +48,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
     href,
     title,
     label,
+    largestLabel,
     icon,
     // This should rarely be used. Regular buttons should just use `icon`
     // `iconRight` is used for the header (home) button with the LBRY icon and external links that are displayed inline
@@ -90,8 +92,17 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
 
   const content = (
     <span className="button__content">
-      {icon && <Icon icon={icon} iconColor={iconColor} size={size} />}
-      {label && <span className="button__label">{label}</span>}
+      {icon && <Icon icon={icon} iconColor={iconColor} size={iconSize} />}
+      {
+        <p style={{ visibility: 'hidden' }}>
+          {largestLabel}
+          {label && (
+            <span className="button__label" style={{ visibility: 'visible' }}>
+              {label}
+            </span>
+          )}
+        </p>
+      }
       {children && children}
       {iconRight && <Icon icon={iconRight} iconColor={iconColor} size={size} />}
     </span>
@@ -127,7 +138,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
     return (
       <NavLink
         exact
-        onClick={e => {
+        onClick={(e) => {
           e.stopPropagation();
         }}
         to={`/$/${PAGES.AUTH}?redirect=${pathname}`}
@@ -147,7 +158,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
       to={path}
       title={title}
       disabled={disabled}
-      onClick={e => {
+      onClick={(e) => {
         e.stopPropagation();
         if (onClick) {
           onClick();
@@ -165,7 +176,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
       title={title}
       aria-label={description || label || title}
       className={combinedClassName}
-      onClick={e => {
+      onClick={(e) => {
         if (onClick) {
           e.stopPropagation();
           onClick(e);

--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -91,17 +91,33 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
   const size = iconSize || (!label && !children) ? 18 : undefined; // Fall back to default
 
   const content = (
-    <span className="button__content">
-      {icon && <Icon icon={icon} iconColor={iconColor} size={iconSize} />}
+    <div className="button__content" style={{ border: `1px solid white` }}>
+      {/* style={{ border: `1px solid white` }} */}
+      <div style={{ border: `1px solid green` }}>
+        {icon && <Icon icon={icon} iconColor={iconColor} size={iconSize} />}
+      </div>
       {
-        <p style={{ visibility: 'hidden' }}>
-          {largestLabel}
-          {label && (
-            <span className="button__label" style={{ visibility: 'visible' }}>
-              {label}
-            </span>
-          )}
-        </p>
+        <div style={{ border: `1px solid blue` }}>
+          <span style={{ visibility: 'hidden' }}>
+            {largestLabel || label}
+            {label && (
+              //   <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, top: 0, margin: 'auto' }}>
+              <div
+                style={{
+                  position: 'relative',
+                  left: '50%',
+                  right: '50%',
+                  transform: `translate(-50%, -50%)`,
+                  border: `1px solid red`,
+                }}
+              >
+                <span className="button__label" style={{ visibility: 'visible' }}>
+                  {label}
+                </span>
+              </div>
+            )}
+          </span>
+        </div>
       }
       {children && children}
       {iconRight && <Icon icon={iconRight} iconColor={iconColor} size={size} />}

--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -95,7 +95,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
       {icon && <Icon icon={icon} iconColor={iconColor} size={iconSize} />}
 
       {label && (
-        <div style={{ position: 'relative' }}>
+        <div className="button__label" style={{ position: 'relative' }}>
           <div
             style={{
               position: 'relative',
@@ -114,9 +114,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
                   transform: `translate(-50%, -50%)`,
                 }}
               >
-                <span className="button__label" style={{ visibility: 'visible' }}>
-                  {label}
-                </span>
+                <span style={{ visibility: 'visible' }}>{label}</span>
               </div>
             </span>
           </div>

--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -95,7 +95,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
       {icon && <Icon icon={icon} iconColor={iconColor} size={size} />}
 
       {label && (
-        <div style={{ position: 'relative', border: `1px solid red`, padding: 0, margin: 0, float: 'left' }}>
+        <div style={{ position: 'relative', border: `1px solid red` }}>
           <div
             style={{
               position: 'relative',
@@ -103,8 +103,6 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
               top: '50%',
               transform: `translate(-50%, 0%)`,
               border: `1px solid white`,
-              padding: 0,
-              margin: 0,
             }}
           >
             <span style={{ visibility: 'hidden' }}>

--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -91,18 +91,17 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
   const size = iconSize || (!label && !children) ? 18 : undefined; // Fall back to default
 
   const content = (
-    <span className="button__content" style={{ border: `1px solid green` }}>
-      {icon && <Icon icon={icon} iconColor={iconColor} size={size} />}
+    <span className="button__content">
+      {icon && <Icon icon={icon} iconColor={iconColor} size={iconSize} />}
 
       {label && (
-        <div style={{ position: 'relative', border: `1px solid red` }}>
+        <div style={{ position: 'relative' }}>
           <div
             style={{
               position: 'relative',
               left: '50%',
               top: '50%',
               transform: `translate(-50%, 0%)`,
-              border: `1px solid white`,
             }}
           >
             <span style={{ visibility: 'hidden' }}>
@@ -113,8 +112,6 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
                   left: '50%',
                   top: '50%',
                   transform: `translate(-50%, -50%)`,
-                  visibility: 'visible',
-                  border: `1px solid blue`,
                 }}
               >
                 <span className="button__label" style={{ visibility: 'visible' }}>

--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -91,34 +91,43 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
   const size = iconSize || (!label && !children) ? 18 : undefined; // Fall back to default
 
   const content = (
-    <div className="button__content" style={{ border: `1px solid white` }}>
-      {/* style={{ border: `1px solid white` }} */}
-      <div style={{ border: `1px solid green` }}>
-        {icon && <Icon icon={icon} iconColor={iconColor} size={iconSize} />}
-      </div>
-      {
-        <div style={{ border: `1px solid blue` }}>
-          <span style={{ visibility: 'hidden' }}>
-            {largestLabel || label}
-            {label && (
-              //   <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, top: 0, margin: 'auto' }}>
+    <span className="button__content" style={{ border: `1px solid green` }}>
+      {icon && <Icon icon={icon} iconColor={iconColor} size={size} />}
+
+      {label && (
+        <div style={{ position: 'relative', border: `1px solid red`, padding: 0, margin: 0, float: 'left' }}>
+          <div
+            style={{
+              position: 'relative',
+              left: '50%',
+              top: '50%',
+              transform: `translate(-50%, 0%)`,
+              border: `1px solid white`,
+              padding: 0,
+              margin: 0,
+            }}
+          >
+            <span style={{ visibility: 'hidden' }}>
+              {largestLabel || label}
               <div
                 style={{
-                  position: 'relative',
+                  position: 'absolute',
                   left: '50%',
-                  right: '50%',
+                  top: '50%',
                   transform: `translate(-50%, -50%)`,
-                  border: `1px solid red`,
+                  visibility: 'visible',
+                  border: `1px solid blue`,
                 }}
               >
                 <span className="button__label" style={{ visibility: 'visible' }}>
                   {label}
                 </span>
               </div>
-            )}
-          </span>
+            </span>
+          </div>
         </div>
-      }
+      )}
+
       {children && children}
       {iconRight && <Icon icon={iconRight} iconColor={iconColor} size={size} />}
     </span>

--- a/ui/component/subscribeButton/view.jsx
+++ b/ui/component/subscribeButton/view.jsx
@@ -52,8 +52,6 @@ export default function SubscribeButton(props: Props) {
     longestStr = __('Unfollow');
   }
 
-  longestStr = longestStr + '-';
-
   return permanentUrl ? (
     <Button
       ref={buttonRef}

--- a/ui/component/subscribeButton/view.jsx
+++ b/ui/component/subscribeButton/view.jsx
@@ -46,11 +46,19 @@ export default function SubscribeButton(props: Props) {
   const unfollowOverride = isSubscribed && isHovering && __('Unfollow');
   const label = isMobile && shrinkOnMobile ? '' : unfollowOverride || subscriptionLabel;
 
+  let longestStr = __('Following');
+
+  if (__('Following').length < __('Unfollow').length) {
+    longestStr = __('Unfollow');
+  }
+
+  longestStr = longestStr + '-';
+
   return permanentUrl ? (
     <Button
       ref={buttonRef}
       iconColor="red"
-      largestLabel="TEST LABEL"
+      largestLabel={longestStr}
       icon={unfollowOverride ? ICONS.UNSUBSCRIBE : ICONS.SUBSCRIBE}
       button={'alt'}
       requiresAuth={IS_WEB}

--- a/ui/component/subscribeButton/view.jsx
+++ b/ui/component/subscribeButton/view.jsx
@@ -50,6 +50,7 @@ export default function SubscribeButton(props: Props) {
     <Button
       ref={buttonRef}
       iconColor="red"
+      largestLabel="TEST LABEL"
       icon={unfollowOverride ? ICONS.UNSUBSCRIBE : ICONS.SUBSCRIBE}
       button={'alt'}
       requiresAuth={IS_WEB}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [x] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2677 

## What is the current behavior?

When hovering over the unsubscribeButton it changes size. This leads to glitchy visual behavior when hovering over part of the unsubscribeButton's heart icon.

## What is the new behavior?

The unsubscribeButton stays the same size when hovered over.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

This PR introduces the following issues that must be fixed before this PR is merged:

- [x] Changes the default size of all buttons.
- [x] Adds visual borders around all buttons (for debugging)
- [x] Moves button Icons closer to button label-text than desired [example](https://github.com/lbryio/lbry-desktop/pull/3963#issuecomment-612286720)

