### PR TITLE
fetch continent cookie on server-side and clean up video effects

### DIFF
--- a/lbrytv/package.json
+++ b/lbrytv/package.json
@@ -32,7 +32,9 @@
     "koa-send": "^5.0.0",
     "koa-static": "^5.0.0",
     "lbry-redux": "lbryio/lbry-redux#87ae7faf1c1d5ffa86feb578899596f6ea2a5fd9",
-    "mysql": "^2.17.1"
+    "lbryinc": "lbryio/lbryinc#0addc624db54000b0447f4539f91f5758d26eef3",
+    "mysql": "^2.17.1",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/lbrytv/src/routes.js
+++ b/lbrytv/src/routes.js
@@ -23,6 +23,7 @@ function getStreamUrl(ctx) {
 function getSupportedCDN(continent) {
   switch (continent) {
     case 'NA':
+    case 'AS':
     case 'EU':
       return continent;
     default:

--- a/lbrytv/src/routes.js
+++ b/lbrytv/src/routes.js
@@ -1,6 +1,11 @@
 const { getHtml } = require('./html');
+const { Lbryio } = require('lbryinc/dist/bundle.es.js');
 const { generateStreamUrl, CONTINENT_COOKIE } = require('../../ui/util/lbrytv');
+const fetch = require('node-fetch');
 const Router = require('@koa/router');
+
+// So any code from 'lbry-redux'/'lbryinc' that uses `fetch` can be run on the server
+global.fetch = fetch;
 
 const router = new Router();
 
@@ -15,6 +20,23 @@ function getStreamUrl(ctx) {
   return streamUrl;
 }
 
+function getSupportedCDN(continent) {
+  switch (continent) {
+    case 'NA':
+    case 'EU':
+      return continent;
+    default:
+      return 'NA';
+  }
+}
+
+async function fetchContinentCookie() {
+  return Lbryio.call('locale', 'get', {}, 'post').then(result => {
+    const userContinent = getSupportedCDN(result.continent);
+    return userContinent;
+  });
+}
+
 router.get(`/$/download/:claimName/:claimId`, async ctx => {
   const streamUrl = getStreamUrl(ctx);
   const downloadUrl = `${streamUrl}?download=1`;
@@ -27,6 +49,11 @@ router.get(`/$/stream/:claimName/:claimId`, async ctx => {
 });
 
 router.get('*', async ctx => {
+  const hasContinentCookie = ctx.cookies.get(CONTINENT_COOKIE);
+  if (!hasContinentCookie) {
+    const continentValue = await fetchContinentCookie();
+    ctx.cookies.set(CONTINENT_COOKIE, continentValue, { httpOnly: false });
+  }
   const html = await getHtml(ctx);
   ctx.body = html;
 });

--- a/lbrytv/yarn.lock
+++ b/lbrytv/yarn.lock
@@ -3341,6 +3341,12 @@ lbry-redux@lbryio/lbry-redux#87ae7faf1c1d5ffa86feb578899596f6ea2a5fd9:
     reselect "^3.0.0"
     uuid "^3.3.2"
 
+lbryinc@lbryio/lbryinc#546ecd1f775925d771c4f86fe0e260ba38c25a02:
+  version "0.0.1"
+  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/546ecd1f775925d771c4f86fe0e260ba38c25a02"
+  dependencies:
+    reselect "^3.0.0"
+
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -3745,6 +3751,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-forge@0.9.0:
   version "0.9.0"

--- a/lbrytv/yarn.lock
+++ b/lbrytv/yarn.lock
@@ -3341,9 +3341,9 @@ lbry-redux@lbryio/lbry-redux#87ae7faf1c1d5ffa86feb578899596f6ea2a5fd9:
     reselect "^3.0.0"
     uuid "^3.3.2"
 
-lbryinc@lbryio/lbryinc#546ecd1f775925d771c4f86fe0e260ba38c25a02:
+lbryinc@lbryio/lbryinc#0addc624db54000b0447f4539f91f5758d26eef3:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/546ecd1f775925d771c4f86fe0e260ba38c25a02"
+  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/0addc624db54000b0447f4539f91f5758d26eef3"
   dependencies:
     reselect "^3.0.0"
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
     "lbry-redux": "lbryio/lbry-redux#1097a63d44a20b87e443fbaa48f95fe3ea5e3f70",
-    "lbryinc": "lbryio/lbryinc#19260fac560daaa4be2d4af372f28109ea96ebf9",
+    "lbryinc": "lbryio/lbryinc#0addc624db54000b0447f4539f91f5758d26eef3",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",
     "lodash-es": "^4.17.14",

--- a/ui/util/lbrytv.js
+++ b/ui/util/lbrytv.js
@@ -1,6 +1,5 @@
-const { Lbryio } = require('lbryinc/dist/bundle.es.js');
 const { URL, LBRY_TV_STREAMING_API } = require('../../config');
-const { getCookie, setCookie } = require('../../ui/util/saved-passwords');
+const { getCookie } = require('../../ui/util/saved-passwords');
 
 const CONTINENT_COOKIE = 'continent';
 
@@ -10,24 +9,9 @@ function generateStreamUrl(claimName, claimId, apiUrl, streamingContinent) {
 
   if (continent && prefix.split('//').length > 1) {
     prefix = prefix.replace('//', '//' + continent + '.');
-  } else {
-    Lbryio.call('locale', 'get', {}, 'post').then(result => {
-      const userContinent = getSupportedCDN(result.continent);
-      setCookie(CONTINENT_COOKIE, userContinent, 1);
-    });
   }
 
   return `${prefix}/content/claims/${claimName}/${claimId}/stream`;
-}
-
-function getSupportedCDN(continent) {
-  switch (continent) {
-    case 'NA':
-    case 'EU':
-      return continent;
-    default:
-      return 'NA';
-  }
 }
 
 function generateEmbedUrl(claimName, claimId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6147,9 +6147,9 @@ lbry-redux@lbryio/lbry-redux#1097a63d44a20b87e443fbaa48f95fe3ea5e3f70:
     reselect "^3.0.0"
     uuid "^3.3.2"
 
-lbryinc@lbryio/lbryinc#546ecd1f775925d771c4f86fe0e260ba38c25a02:
+lbryinc@lbryio/lbryinc#0addc624db54000b0447f4539f91f5758d26eef3:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/546ecd1f775925d771c4f86fe0e260ba38c25a02"
+  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/0addc624db54000b0447f4539f91f5758d26eef3"
   dependencies:
     reselect "^3.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6147,9 +6147,9 @@ lbry-redux@lbryio/lbry-redux#1097a63d44a20b87e443fbaa48f95fe3ea5e3f70:
     reselect "^3.0.0"
     uuid "^3.3.2"
 
-lbryinc@lbryio/lbryinc#19260fac560daaa4be2d4af372f28109ea96ebf9:
+lbryinc@lbryio/lbryinc#546ecd1f775925d771c4f86fe0e260ba38c25a02:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/19260fac560daaa4be2d4af372f28109ea96ebf9"
+  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/546ecd1f775925d771c4f86fe0e260ba38c25a02"
   dependencies:
     reselect "^3.0.0"
 


### PR DESCRIPTION
fixes #3856
fixes #3961

View events weren't firing because the streaming URL changed after the first render for new users, which caused the player to re-render and the listeners weren't added correctly. 

I thought I just needed to move the continent cookie stuff to the server, but the actual issue was that those listeners weren't being attached properly from the beginning.