### PR TITLE
Change text displayed for blocked channels

### DIFF
--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -471,8 +471,11 @@ class SettingsPage extends React.PureComponent<Props, State> {
                 title={__('Blocked Channels')}
                 actions={
                   <p>
-                    {__('Blocked Channels')}: {userBlockedChannelsCount} {' '}
-                    <Button button="link" label={__('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />.
+                    {__('You have %count% blocked %channels%.', {
+                      count: userBlockedChannelsCount,
+                      channels: userBlockedChannelsCount === 1 ? __('channel') : __('channels'),
+                    })}{' '}
+                    <Button button="link" label={__('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />
                   </p>
                 }
               />

--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -471,9 +471,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
                 title={__('Blocked Channels')}
                 actions={
                   <p>
-                    {__('You have')} {userBlockedChannelsCount} {__('blocked')}{' '}
-                    {userBlockedChannelsCount === 1 && __('channel')}
-                    {userBlockedChannelsCount !== 1 && __('channels')}.{' '}
+                    {__('Blocked Channels')}: {userBlockedChannelsCount} {' '}
                     <Button button="link" label={__('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />.
                   </p>
                 }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe:

## Fixes
Fix the text displayed in other languages
Issue Number:

## What is the current behavior?
With the current english string there is a problem with the translation in other languages. For example in other languages current english text would be: "You have blocked channels 10" instead of "You have 10 channels blocked." Also, what happen when there si no blocked channel? So, I think the simpler form is better in this situation.
## What is the new behavior?
Instead of "You have x blocked channles. Manage" will be displayed "Blocked channels: x Manage"
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
