### PR TITLE
Make images scale properly in lbry.tv.

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -86,6 +86,7 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
+    max-height: var(--inline-player-max-height);
   }
   video {
     cursor: pointer;


### PR DESCRIPTION
Closes #3948

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 3948

## What is the current behavior?
The bottom of portrait images get cut off.

## What is the new behavior?
The image is scaled to fit in the viewing area.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
