### PR TITLE
First attempt to fix #3993. 

### DIFF
--- a/ui/component/viewers/imageViewer.jsx
+++ b/ui/component/viewers/imageViewer.jsx
@@ -16,7 +16,6 @@ function ImageViewer(props: Props) {
       {loadingError && (
         <Card
           title={__('Error Displaying Image')}
-          defaultExpand
           actions={<ErrorText>There was an error displaying the image. You may still download it.</ErrorText>}
         />
       )}

--- a/ui/component/viewers/imageViewer.jsx
+++ b/ui/component/viewers/imageViewer.jsx
@@ -1,5 +1,7 @@
 // @flow
 import React from 'react';
+import Card from 'component/common/card';
+import ErrorText from 'component/common/error-text';
 
 type Props = {
   source: string,
@@ -7,10 +9,23 @@ type Props = {
 
 function ImageViewer(props: Props) {
   const { source } = props;
+  const [loadingError, setLoadingError] = React.useState(false);
+
   return (
-    <div className="file-render__viewer">
-      <img src={source} />
-    </div>
+    <React.Fragment>
+      {loadingError && (
+        <Card
+          title={__('Error Displaying Image')}
+          defaultExpand
+          actions={<ErrorText>There was an error displaying the image. You may still download it.</ErrorText>}
+        />
+      )}
+      {!loadingError && (
+        <div className="file-render__viewer">
+          <img src={source} onError={() => setLoadingError(true)} />
+        </div>
+      )}
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
Show error message if image is not able to be displayed by browser.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3993

## What is the current behavior?
If a browser cannot display an image (such as Safari and WebP images), then an empty box is displayed in place of the image.

## What is the new behavior?
If a browser cannot display an image, an error message is displayed in a Card.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
