### PR TITLE
Fix flow error.

### DIFF
--- a/ui/component/fileRender/view.jsx
+++ b/ui/component/fileRender/view.jsx
@@ -168,7 +168,7 @@ class FileRender extends React.PureComponent<Props, State> {
           />
         );
       case RENDER_MODES.COMIC:
-        return <ComicBookViewer source={{ fileExtension, downloadPath }} theme={currentTheme} />;
+        return <ComicBookViewer source={downloadPath} theme={currentTheme} />;
       case RENDER_MODES.APPLICATION:
         return <AppViewer uri={uri} />;
     }

--- a/ui/component/viewers/comicBookViewer.jsx
+++ b/ui/component/viewers/comicBookViewer.jsx
@@ -5,10 +5,7 @@ import 'villain-react/dist/style.css';
 
 type Props = {
   theme: string,
-  source: {
-    fileType: string,
-    downloadPath: string,
-  },
+  source: string,
 };
 
 let workerUrl = 'webworkers/worker-bundle.js';
@@ -20,9 +17,9 @@ if (process.env.NODE_ENV !== 'production') {
 
 class ComicBookViewer extends React.PureComponent<Props> {
   render() {
-    const { downloadPath } = this.props.source || {};
+    const { source } = this.props || {};
     // Archive source
-    const file = `file://${downloadPath}`;
+    const file = `file://${source}`;
     // Villain options
     const opts = {
       theme: this.props.theme === 'dark' ? 'Dark' : 'Light',


### PR DESCRIPTION
Partial fix for #2024

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: Partial fix for #2024

## What is the current behavior?
Flow errors.

## What is the new behavior?
No more flow error for this part of the code.

## Other information
Note that "fileExtension" was not being used in ComicBookViewer, so I removed it and now pass downloadPath directly instead of as part of an object, for simplicity.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
