### PR TITLE
Header Logo Reloads At "/"

### DIFF
--- a/ui/component/header/view.jsx
+++ b/ui/component/header/view.jsx
@@ -133,7 +133,9 @@ const Header = (props: Props) => {
             className="header__navigation-item header__navigation-item--lbry header__navigation-item--button-mobile"
             label={__('LBRY')}
             icon={ICONS.LBRY}
-            onClick={() => window.scrollTo(0, 0)}
+            onClick={() => {
+              if (history.location.pathname === '/') window.location.reload();
+            }}
             {...homeButtonNavigationProps}
           />
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
- Clicking the header logo will refresh the page if location is `/`, otherwise, redirect to `/`.

Issue Number: #3710 

## What is the current behavior?
- Header logo redirects to `/` if the location is not `/` and scrolls to the top of the page.

## What is the new behavior?
- Header logo refreshes the page if the location is `/`, otherwise, redirect to `/`.
![header-reload-lbry](https://user-images.githubusercontent.com/34770591/79868151-20e40380-83fd-11ea-8cf8-139f236e5b66.gif)


## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
