### PR TITLE
Show elapsed/total instead of the countdown to the end in video player.

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -170,6 +170,18 @@
     // Make sure no videojs message interferes with overlaying buttons
     pointer-events: none;
   }
+
+  .vjs-control-bar {
+    .vjs-remaining-time {
+      display: none;
+    }
+
+    .vjs-current-time,
+    .vjs-time-divider,
+    .vjs-duration {
+      display: flex;
+    }
+  }
 }
 
 .vjs-paused .vjs-big-play-button,


### PR DESCRIPTION
Closes #3813

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe:
Improves existing functionality.

## Fixes

Issue Number: #3813

## What is the current behavior?
Displays remaining time of video 

## What is the new behavior?
Displays the elapsed time along with the total time with a "/" in between

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
