### PR TITLE
Better Hover, Subscribe Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Fixed the title of the subscribe button getting out of sync on fast hover movements _community pr!_ ([#4054](https://github.com/lbryio/lbry-desktop/pull/4054))
 
 - Add fallback when images fail to load _community pr!_ ([#4019](https://github.com/lbryio/lbry-desktop/pull/4019))
 - Fetch new content when clicking LBRY logo while on homepage _community pr!_ ([#4031](https://github.com/lbryio/lbry-desktop/pull/4031))

--- a/ui/component/subscribeButton/view.jsx
+++ b/ui/component/subscribeButton/view.jsx
@@ -36,27 +36,26 @@ export default function SubscribeButton(props: Props) {
     doToast,
     shrinkOnMobile = false,
   } = props;
+
   const buttonRef = useRef();
-  const isHovering = useHover(buttonRef);
   const isMobile = useIsMobile();
+  let isHovering = useHover(buttonRef);
+  isHovering = isMobile ? true : isHovering;
+
   const { channelName } = parseURI(permanentUrl);
   const claimName = '@' + channelName;
+
   const subscriptionHandler = isSubscribed ? doChannelUnsubscribe : doChannelSubscribe;
   const subscriptionLabel = isSubscribed ? __('Following') : __('Follow');
   const unfollowOverride = isSubscribed && isHovering && __('Unfollow');
+
   const label = isMobile && shrinkOnMobile ? '' : unfollowOverride || subscriptionLabel;
-
-  let longestStr = __('Following');
-
-  if (__('Following').length < __('Unfollow').length) {
-    longestStr = __('Unfollow');
-  }
 
   return permanentUrl ? (
     <Button
       ref={buttonRef}
       iconColor="red"
-      largestLabel={isSubscribed ? longestStr : undefined}
+      largestLabel={isMobile && shrinkOnMobile ? '' : subscriptionLabel}
       icon={unfollowOverride ? ICONS.UNSUBSCRIBE : ICONS.SUBSCRIBE}
       button={'alt'}
       requiresAuth={IS_WEB}

--- a/ui/effects/use-hover.js
+++ b/ui/effects/use-hover.js
@@ -3,18 +3,18 @@ import { useEffect, useState } from 'react';
 export default function useHover(ref) {
   const [isHovering, setIsHovering] = useState(false);
 
-  useEffect(() => {
-    function handleHover() {
-      setIsHovering(!isHovering);
-    }
+  const hoverFunc = () => setIsHovering(true);
+  const unHoverFunc = () => setIsHovering(false);
 
+  useEffect(() => {
     const refElement = ref.current;
     if (refElement) {
-      refElement.addEventListener('mouseenter', handleHover);
-      refElement.addEventListener('mouseleave', handleHover);
+      refElement.addEventListener('mouseenter', hoverFunc);
+      refElement.addEventListener('mouseleave', unHoverFunc);
+
       return () => {
-        refElement.removeEventListener('mouseenter', handleHover);
-        refElement.removeEventListener('mouseleave', handleHover);
+        refElement.removeEventListener('mouseenter', hoverFunc);
+        refElement.removeEventListener('mouseleave', unHoverFunc);
       };
     }
   }, [ref, isHovering]);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
- The hover `useEffect` hook in `/ui/effects` is now more reliable.
- The subscribe button is optimized for both desktop and mobile.
- Doesn't completely fix but improves the situation of the de-sync issue.
- Removed some redundant code and cleaned the subscribe button component.
```js
  if (__('Following').length < __('Unfollow').length) {
    longestStr = __('Unfollow');
  }
```
Issue Number: #4048 

## What is the current behavior?
- The title of the subscribe button may get out of sync if used too fast.
- It cannot recover from the de-sync.
- Hover events are fired on mobile devices too and they may affect the UX.

## What is the new behavior?
- It is much more difficult for the subscribe button to get out of sync.
- Even if it gets out of sync, it can recover leading to a much better UX.
- Mobile hover events cannot be stopped because of the way react hooks work but the events do not affect the state anymore.

## Other information
### GIFs

#### Desktop Hover
![better-hover-desktop](https://user-images.githubusercontent.com/34770591/80126542-e0c58200-85b0-11ea-9254-72c089edace8.gif)

#### Mobile Hover
![better-hover-mobile](https://user-images.githubusercontent.com/34770591/80126573-eb801700-85b0-11ea-80a0-aeeaafdfcff8.gif)

#### Simulated De-Sync (to demonstrate the recovery)
![simulated-hover-desync](https://user-images.githubusercontent.com/34770591/80126680-05215e80-85b1-11ea-93b3-54fdaf482a1e.gif)

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
