### PR TITLE
Fix purchase confirmation logic

### DIFF
--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -197,13 +197,17 @@ export function doPlayUri(
       return;
     }
 
-    if (instantPurchaseEnabled || instantPurchaseMax.currency === 'LBC') {
-      attemptPlay(instantPurchaseMax.amount);
+    if (instantPurchaseEnabled) {
+      if (instantPurchaseMax.currency === 'LBC') {
+        attemptPlay(instantPurchaseMax.amount);
+      } else {
+        // Need to convert currency of instant purchase maximum before trying to play
+        Lbryio.getExchangeRates().then(({ LBC_USD }) => {
+          attemptPlay(instantPurchaseMax.amount / LBC_USD);
+        });
+      }
     } else {
-      // Need to convert currency of instant purchase maximum before trying to play
-      Lbryio.getExchangeRates().then(({ LBC_USD }) => {
-        attemptPlay(instantPurchaseMax.amount / LBC_USD);
-      });
+      attemptPlay();
     }
   };
 }


### PR DESCRIPTION
Closes #4057

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #4057

## What is the current behavior?
If "Always confirm before purchasing content" is selected in settings and the currency for "Only confirm purchases over a certain price" was previously set to USD, then an unnecessary check for exchange rates is occurring.

## What is the new behavior?
The exchange rate is only checked if "Only confirm purchases over a certain price" is selected and the currency set to USD.

## Other information
Thanks to @seanyesmunt for commit https://github.com/lbryio/lbry-desktop/commit/dcb79685bc25cf3bc77d434255063fc4933cdf44 which fixes part of #4057 as well.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
