### PR TITLE
Adding tooltip to share, block, and follow buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Channel content preview on custom invite link page _community pr!_ ([#4040](https://github.com/lbryio/lbry-desktop/pull/4040))
+- Add Tooltips To Channel Action Buttons _community pr!_ ([#4090](https://github.com/lbryio/lbry-desktop/pull/4090))
 
 ### Changed
 

--- a/ui/component/blockButton/view.jsx
+++ b/ui/component/blockButton/view.jsx
@@ -21,6 +21,7 @@ export default function BlockButton(props: Props) {
   const blockRef = useRef();
   const isHovering = useHover(blockRef);
   const blockLabel = channelIsBlocked ? __('Blocked') : __('Block');
+  const blockTitlePrefix = channelIsBlocked ? __('Unblock') : __('Block');
   const blockedOverride = channelIsBlocked && isHovering && __('Unblock');
 
   return permanentUrl && !claimIsMine ? (
@@ -29,6 +30,7 @@ export default function BlockButton(props: Props) {
       icon={ICONS.BLOCK}
       button={'alt'}
       label={blockedOverride || blockLabel}
+      title={`${blockTitlePrefix} ${__('this channel')}`}
       requiresAuth={IS_WEB}
       onClick={e => {
         e.stopPropagation();

--- a/ui/component/shareButton/view.jsx
+++ b/ui/component/shareButton/view.jsx
@@ -17,6 +17,7 @@ export default function ShareButton(props: Props) {
       button="alt"
       icon={ICONS.SHARE}
       label={__('Share')}
+      title={__('Share this channel')}
       onClick={() => doOpenModal(MODALS.SOCIAL_SHARE, { uri, webShareable: true })}
     />
   );

--- a/ui/component/subscribeButton/view.jsx
+++ b/ui/component/subscribeButton/view.jsx
@@ -50,6 +50,7 @@ export default function SubscribeButton(props: Props) {
   const unfollowOverride = isSubscribed && isHovering && __('Unfollow');
 
   const label = isMobile && shrinkOnMobile ? '' : unfollowOverride || subscriptionLabel;
+  const titlePrefix = isSubscribed ? __('Unfollow') : __('Follow');
 
   return permanentUrl ? (
     <Button
@@ -60,6 +61,7 @@ export default function SubscribeButton(props: Props) {
       button={'alt'}
       requiresAuth={IS_WEB}
       label={label}
+      title={`${titlePrefix} ${__('this channel')}`}
       onClick={e => {
         e.stopPropagation();
 


### PR DESCRIPTION
## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Improvement

## Fixes

Issue Number: #4085 

## What is the current behavior?
No tooltip displayed for share, follow/unfollow, block/unblock buttons.

## What is the new behavior?
Tooltip is now displayed for share, follow/unfollow, block/unblock buttons.

![tooltip](https://user-images.githubusercontent.com/13416244/80447246-c3085d80-88cd-11ea-869d-c71d8f1e0677.gif)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
