### PR TITLE
Better Infinite Scroll (Proposal)

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -77,7 +77,7 @@ function ClaimListDiscover(props: Props) {
     header,
     name,
     claimType,
-    pageSize,
+    pageSize = CS.PAGE_SIZE,
     hideBlock,
     defaultClaimType,
     streamType,
@@ -143,7 +143,7 @@ function ClaimListDiscover(props: Props) {
     reposted_claim_id?: string,
     stream_types?: any,
   } = {
-    page_size: pageSize || CS.PAGE_SIZE,
+    page_size: pageSize,
     page,
     name,
     claim_type: claimType || undefined,
@@ -267,8 +267,8 @@ function ClaimListDiscover(props: Props) {
     didNavigateForward ||
     (!loading &&
       claimSearchResult &&
-      claimSearchResult.length < CS.PAGE_SIZE * page &&
-      claimSearchResult.length % CS.PAGE_SIZE === 0);
+      claimSearchResult.length < pageSize * page &&
+      claimSearchResult.length % pageSize === 0);
 
   // Don't use the query from createNormalizedClaimSearchKey for the effect since that doesn't include page & release_time
   const optionsStringForEffect = JSON.stringify(options);
@@ -372,7 +372,7 @@ function ClaimListDiscover(props: Props) {
     return `?${newUrlParams.toString()}`;
   }
 
-  function handleScrollBottom() {
+  function handleLoadNewContent() {
     if (!loading && infiniteScroll) {
       setPage(page + 1);
     }
@@ -601,9 +601,9 @@ function ClaimListDiscover(props: Props) {
         header={header || defaultHeader}
         headerLabel={headerLabel}
         headerAltControls={meta}
-        onScrollBottom={handleScrollBottom}
+        onLoadNewContent={handleLoadNewContent}
         page={page}
-        pageSize={CS.PAGE_SIZE}
+        pageSize={pageSize}
         timedOutMessage={timedOutMessage}
         renderProperties={renderProperties}
         includeSupportAction={includeSupportAction}
@@ -613,7 +613,7 @@ function ClaimListDiscover(props: Props) {
 
       {loading && (
         <div className="card">
-          {new Array(pageSize || CS.PAGE_SIZE).fill(1).map((x, i) => (
+          {new Array(pageSize).fill(1).map((x, i) => (
             <ClaimPreview key={i} placeholder="loading" />
           ))}
         </div>

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -58,6 +58,7 @@ type Props = {
   customShouldHide?: Claim => boolean,
   showUnresolvedClaim?: boolean,
   includeSupportAction?: boolean,
+  hidden?: boolean,
 };
 
 const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
@@ -90,6 +91,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     customShouldHide,
     showUnresolvedClaim,
     includeSupportAction,
+    hidden = false,
   } = props;
   const shouldFetch =
     claim === undefined || (claim !== null && claim.value_type === 'channel' && isEmpty(claim.meta) && !pending);
@@ -218,6 +220,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
   return (
     <li
       ref={ref}
+      style={hidden ? { display: 'none' } : {}}
       role="link"
       onClick={pending || type === 'inline' ? undefined : handleOnClick}
       onContextMenu={handleContextMenu}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
- Loads claim previews in the background and hides them for a better experience.
- A small offset is added to the scrollBottom condition to fix #3071.
- Truly infinite?

Issue Number: https://github.com/lbryio/lbry-desktop/issues/3071

## Other Details
Indefinitely Infinite?
![indefinitely-infintie](https://user-images.githubusercontent.com/34770591/80532608-0a6c1800-89ba-11ea-8e31-49fe6a1c6c1a.gif)

Look at the scrollbar in the above GIF, it's at the bottom. It's caching claim previews and loading them as the user scrolls.
But as of now, the addition of a new DOM element causes the scrolling to lat a little bit. I need suggestions on how this can be improved/optimized.