### PR TITLE
Save media position to local storage.

### DIFF
--- a/ui/component/viewers/videoViewer/index.js
+++ b/ui/component/viewers/videoViewer/index.js
@@ -16,7 +16,7 @@ const select = (state, props) => {
     autoplayParam: autoplay,
     volume: selectVolume(state),
     muted: selectMute(state),
-    position: position,
+    positionParam: position,
     hasFileInfo: Boolean(makeSelectFileInfoForUri(props.uri)(state)),
     thumbnail: makeSelectThumbnailForUri(props.uri)(state),
     claim: makeSelectClaimForUri(props.uri)(state),


### PR DESCRIPTION
Closes #2775

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2775

## What is the current behavior?
The media player always starts at the beginning of the video

## What is the new behavior?
The position of the media player is saved to local storage and the next time that video is played, the video will start at the position it was last played at.

## Other information

The following is a screenshot of what the local storage will start to look like with this solution:
![Screen Shot 2020-04-29 at 12 10 12 AM](https://user-images.githubusercontent.com/1240484/80569998-de976500-89ae-11ea-8b46-9e740a4f7390.png)



<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
