### PR TITLE
Save media position in video viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Tooltips To Channel Action Buttons _community pr!_ ([#4090](https://github.com/lbryio/lbry-desktop/pull/4090))
 - Reenabled repost hiding with corresponding repost email suppression ([#4025](https://github.com/lbryio/lbry-desktop/pull/4025))
 - Enabled embeds in markdown posts ([#4060](https://github.com/lbryio/lbry-desktop/pull/4060))
+- Save media position in video viewer _community pr!_ ([#4104](https://github.com/lbryio/lbry-desktop/pull/4104))
 
 ### Changed
 

--- a/ui/component/viewers/videoViewer/index.js
+++ b/ui/component/viewers/videoViewer/index.js
@@ -3,6 +3,7 @@ import { makeSelectClaimForUri, makeSelectFileInfoForUri, makeSelectThumbnailFor
 import { doChangeVolume, doChangeMute, doAnalyticsView } from 'redux/actions/app';
 import { selectVolume, selectMute } from 'redux/selectors/app';
 import { savePosition } from 'redux/actions/content';
+import { makeSelectContentPositionForUri } from 'redux/selectors/content';
 import VideoViewer from './view';
 import { withRouter } from 'react-router';
 import { doClaimEligiblePurchaseRewards } from 'lbryinc';
@@ -13,7 +14,7 @@ const select = (state, props) => {
   const { search } = props.location;
   const urlParams = new URLSearchParams(search);
   const autoplay = urlParams.get('autoplay');
-  const position = urlParams.get('t');
+  const position = urlParams.get('t') !== null ? urlParams.get('t') : makeSelectContentPositionForUri(props.uri)(state);
 
   return {
     autoplayIfEmbedded: Boolean(autoplay),

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -15,7 +15,7 @@ export type Player = {
   volume: (?number) => number,
   muted: (?boolean) => boolean,
   dispose: () => void,
-  currentTime: number => void,
+  currentTime: (?number) => number,
 };
 
 type Props = {

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -106,10 +106,6 @@ function VideoViewer(props: Props) {
     setIsEndededEmbed(false);
   }
 
-  function onPause() {
-    setIsPlaying(false);
-  }
-
   const onPlayerReady = useCallback(
     (player: Player) => {
       if (!embedded) {
@@ -144,7 +140,10 @@ function VideoViewer(props: Props) {
       player.on('tracking:firstplay', doTrackingFirstPlay);
       player.on('ended', onEnded);
       player.on('play', onPlay);
-      player.on('pause', onPause);
+      player.on('pause', () => {
+        setIsPlaying(false);
+        savePosition(uri, player.currentTime());
+      });
       player.on('volumechange', () => {
         if (player && player.volume() !== volume) {
           changeVolume(player.volume());
@@ -157,7 +156,7 @@ function VideoViewer(props: Props) {
       if (position) {
         player.currentTime(position);
       }
-      player.on('timeupdate', () => savePosition(uri, player.currentTime()));
+      player.on('dispose', () => savePosition(uri, player.currentTime()));
     },
     [uri]
   );

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -31,6 +31,7 @@ type Props = {
   autoplayIfEmbedded: boolean,
   doAnalyticsView: (string, number) => Promise<any>,
   claimRewards: () => void,
+  savePosition: (string, number) => void,
 };
 
 /*
@@ -54,6 +55,7 @@ function VideoViewer(props: Props) {
     autoplayIfEmbedded,
     doAnalyticsView,
     claimRewards,
+    savePosition,
   } = props;
   const claimId = claim && claim.claim_id;
   const isAudio = contentType.includes('audio');
@@ -155,6 +157,7 @@ function VideoViewer(props: Props) {
       if (position) {
         player.currentTime(position);
       }
+      player.on('timeupdate', () => savePosition(uri, player.currentTime()));
     },
     [uri]
   );


### PR DESCRIPTION
PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #2775

## What is the current behavior?
Videos start playing at beginning of the video.

## What is the new behavior?
Video position is saved when being played. If a previously viewed video is played again, it starts at the saved location.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
