### PR TITLE
Fix channel reply switching channels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add fallback when images fail to load _community pr!_ ([#4019](https://github.com/lbryio/lbry-desktop/pull/4019))
 - Fetch new content when clicking LBRY logo while on homepage _community pr!_ ([#4031](https://github.com/lbryio/lbry-desktop/pull/4031))
 - Aligns text across browsers and desktop _community pr!_ ([#4050](https://github.com/lbryio/lbry-desktop/pull/4050))
-- Reselect channel as "replying as" when switching channels ([#3926](https://github.com/lbryio/lbry-desktop/issues/3926))
+- Reselect channel as "replying as" when switching channels _community pr!_ ([#3926](https://github.com/lbryio/lbry-desktop/issues/3926))
 
 ## [0.45.0] - [2020-04-21]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add fallback when images fail to load _community pr!_ ([#4019](https://github.com/lbryio/lbry-desktop/pull/4019))
 - Fetch new content when clicking LBRY logo while on homepage _community pr!_ ([#4031](https://github.com/lbryio/lbry-desktop/pull/4031))
 - Aligns text across browsers and desktop _community pr!_ ([#4050](https://github.com/lbryio/lbry-desktop/pull/4050))
+- Reselect channel as "replying as" when switching channels ([#3926](https://github.com/lbryio/lbry-desktop/issues/3926))
 
 ## [0.45.0] - [2020-04-21]
 

--- a/ui/component/fileRenderFloating/view.jsx
+++ b/ui/component/fileRenderFloating/view.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as ICONS from 'constants/icons';
 import * as RENDER_MODES from 'constants/file_render_modes';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Button from 'component/button';
 import classnames from 'classnames';
 import LoadingScreen from 'component/common/loading-screen';
@@ -39,7 +39,7 @@ export default function FileRenderFloating(props: Props) {
     setPlayingUri,
   } = props;
   const isMobile = useIsMobile();
-  const [fileViewerRect, setFileViewerRect] = usePersistedState('inline-file-viewer:rect');
+  const [fileViewerRect, setFileViewerRect] = useState();
   const [position, setPosition] = usePersistedState('floating-file-viewer:position', {
     x: -25,
     y: window.innerHeight - 400,
@@ -60,7 +60,7 @@ export default function FileRenderFloating(props: Props) {
       }
 
       const rect = element.getBoundingClientRect();
-      // @FlowFixMe
+      // $FlowFixMe
       setFileViewerRect(rect);
     }
 

--- a/ui/effects/use-persisted-state.js
+++ b/ui/effects/use-persisted-state.js
@@ -1,9 +1,20 @@
 import { useState, useEffect } from 'react';
 
+const listeners = {};
+
+function getSetAllValues(key, setValue) {
+  if (!key) {
+    // If no key just return the normal setValue function
+    return setValue;
+  }
+  return value => listeners[key].forEach(fn => fn(value));
+}
+
 export default function usePersistedState(key, firstTimeDefault) {
   // If no key is passed in, act as a normal `useState`
   let defaultValue;
   let localStorageAvailable;
+
   try {
     localStorageAvailable = Boolean(window.localStorage);
   } catch (e) {
@@ -32,11 +43,25 @@ export default function usePersistedState(key, firstTimeDefault) {
 
   const [value, setValue] = useState(defaultValue);
 
+  if (key && !Array.isArray(listeners[key])) {
+    listeners[key] = [];
+  }
+
   useEffect(() => {
     if (key && localStorageAvailable) {
       localStorage.setItem(key, typeof value === 'object' ? JSON.stringify(value) : value);
     }
+    if (key) {
+      // add hook on mount
+      listeners[key].push(setValue);
+    }
+    return () => {
+      if (key) {
+        // remove hook on unmount
+        listeners[key] = listeners[key].filter(listener => listener !== setValue);
+      }
+    };
   }, [key, value, localStorageAvailable]);
 
-  return [value, setValue];
+  return [value, getSetAllValues(key, setValue)];
 }


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3926 

## What is the current behavior?

Currently, the usePersistedState acts just like a normal useState call and would be different in each component. So if you are on the channel comment page, hit reply on an existing comment, then change the top-level comment dropdown it doesn't change the same state in the reply comment. This doesn't seem to be correct as this seems to be a way to persist and share state globally.

## What is the new behavior?

The change was to make it a global state if you use the same key. Since it is storing in local storage if it exists was the desired outcome. It also passes a setValue function back that if a key is passed in will set all components currently mounted states not just one.

## Other information

I wasn't 100% on if you wanted to do it this way or use a context instead.