### PR TITLE
Open hyperlinks in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show 'elapsed/total' instead of countdown timer on video player _community pr!_ ([#4049](https://github.com/lbryio/lbry-desktop/pull/4049))
 - Modified app strings about wallet backup, to emphasize that the wallet also controls claims _community pr!_ ([#4056](https://github.com/lbryio/lbry-desktop/pull/4056))
 - Add confirmation when sending tip respecting "Purchase and Tip Confirmation" (formerly "Purchase Confirmation") setting, now visible in lbry.tv _community pr!_ ([#4051](https://github.com/lbryio/lbry-desktop/pull/4051))
+- Hyperlinks in markdown now open in new tab _community pr!_ ([#4111](https://github.com/lbryio/lbry-desktop/pull/4111))
 
 ### Fixed
 

--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -42,7 +42,7 @@ const SimpleLink = (props: SimpleLinkProps) => {
 
   if (!href.startsWith('lbry://')) {
     return (
-      <a href={href} title={title}>
+      <a href={href} title={title} target={'_blank'} rel={'noreferrer noopener'}>
         {children}
       </a>
     );


### PR DESCRIPTION
Closes #3467

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3467

## What is the current behavior?
Hyperlinks in markdown (markdown files, content description, about page) open in same tab

## What is the new behavior?
Hyperlinks in markdown open in new tab

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
