### PR TITLE
Fix wrong file types forced to render as video

### DIFF
--- a/ui/constants/claim.js
+++ b/ui/constants/claim.js
@@ -14,7 +14,6 @@ export const FORCE_CONTENT_TYPE_PLAYER = [
   'video/quicktime',
   'application/x-ext-mkv',
   'video/x-matroska',
-  'application/octet-stream',
   'video/x-ms-wmv',
   'video/x-msvideo',
   'video/mpeg',


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes
Incorrect render mode on some files #4075

## What is the current behavior?

> When I try `lbry://@mime#6/obj#6`, it looks like it tries to render the video player instead of the 3d viewer.
https://github.com/lbryio/lbry-desktop/pull/4076#issuecomment-620042207

`application/octet-stream` should not be forced to play as a video

> Generic binary data (or binary data whose true type is unknown) is application/octet-stream

> For text documents without a specific subtype, text/plain should be used. Similarly, for binary documents without a specific or known subtype, application/octet-stream should be used.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Types