### PR TITLE
Display tooltips for buttons, especially those without text

### DIFF
--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -37,6 +37,7 @@ type Props = {
   requiresAuth: ?boolean,
   myref: any,
   dispatch: any,
+  'aria-label'?: string,
 };
 
 // use forwardRef to allow consumers to pass refs to the button content if they want to
@@ -155,6 +156,17 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
     }
   }
 
+  // Try to generate a tooltip using available text and display it through
+  // the 'title' mechanism, but only if it isn't being used.
+  let defaultTooltip;
+  if (!title) {
+    if (props['aria-label']) {
+      defaultTooltip = props['aria-label'];
+    } else if (description) {
+      defaultTooltip = description;
+    }
+  }
+
   if (requiresAuth && !emailVerified) {
     return (
       <NavLink
@@ -163,7 +175,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
           e.stopPropagation();
         }}
         to={`/$/${PAGES.AUTH}?redirect=${pathname}`}
-        title={title}
+        title={title || defaultTooltip}
         disabled={disabled}
         className={combinedClassName}
         activeClassName={activeClass}
@@ -177,7 +189,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
     <NavLink
       exact
       to={path}
-      title={title}
+      title={title || defaultTooltip}
       disabled={disabled}
       onClick={e => {
         e.stopPropagation();
@@ -194,7 +206,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
   ) : (
     <button
       ref={combinedRef}
-      title={title}
+      title={title || defaultTooltip}
       aria-label={description || label || title}
       className={combinedClassName}
       onClick={e => {

--- a/ui/component/header/view.jsx
+++ b/ui/component/header/view.jsx
@@ -164,6 +164,7 @@ const Header = (props: Props) => {
                 <Menu>
                   <MenuButton
                     aria-label={__('Publish a file, or create a channel')}
+                    title={__('Publish a file, or create a channel')}
                     className="header__navigation-item menu__title header__navigation-item--icon"
                   >
                     <Icon size={18} icon={ICONS.PUBLISH} aria-hidden />
@@ -183,6 +184,7 @@ const Header = (props: Props) => {
                 <Menu>
                   <MenuButton
                     aria-label={__('Your account')}
+                    title={__('Your account')}
                     className="header__navigation-item menu__title header__navigation-item--icon"
                   >
                     <Icon size={18} icon={ICONS.ACCOUNT} aria-hidden />
@@ -236,6 +238,7 @@ const Header = (props: Props) => {
             <Menu>
               <MenuButton
                 aria-label={__('Settings')}
+                title={__('Settings')}
                 className="header__navigation-item menu__title header__navigation-item--icon"
               >
                 <Icon size={18} icon={ICONS.SETTINGS} aria-hidden />


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: Fixes #3465 

## What is the current behavior?
Some buttons (especially those without text) is lacking tooltips.

## What is the new behavior?
Display tooltips for those elements.

## Other information
The strings are already in place, so code was added to route the data to `title` for it to appear as tooltip.
Refer to commit message for full details.
<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
