### PR TITLE
Only show "start at" on share page for videos/audio

### DIFF
--- a/ui/component/socialShare/view.jsx
+++ b/ui/component/socialShare/view.jsx
@@ -42,6 +42,10 @@ function SocialShare(props: Props) {
 
   const { canonical_url: canonicalUrl, permanent_url: permanentUrl, name, claim_id: claimId } = claim;
   const isChannel = claim.value_type === 'channel';
+  const isStream = claim.value_type === 'stream';
+  const isVideo = isStream && claim.value.stream_type === 'video';
+  const isAudio = isStream && claim.value.stream_type === 'audio';
+  const showStartAt = isVideo || isAudio;
   const rewardsApproved = user && user.is_reward_approved;
   const OPEN_URL = 'https://open.lbry.com/';
   const lbryUrl: string = generateLbryContentUrl(canonicalUrl, permanentUrl);
@@ -71,22 +75,24 @@ function SocialShare(props: Props) {
   return (
     <React.Fragment>
       <CopyableText label={__('LBRY Link')} copyable={openDotLbryDotComUrl} />
-      <div className="section__start-at">
-        <FormField
-          type="checkbox"
-          name="share_start_at_checkbox"
-          onChange={() => setincludeStartTime(!includeStartTime)}
-          checked={includeStartTime}
-          label={__('Start at')}
-        />
-        <FormField
-          type="text"
-          name="share_start_at"
-          value={startTime}
-          disabled={!includeStartTime}
-          onChange={event => setStartTime(event.target.value)}
-        />
-      </div>
+      {showStartAt && (
+        <div className="section__start-at">
+          <FormField
+            type="checkbox"
+            name="share_start_at_checkbox"
+            onChange={() => setincludeStartTime(!includeStartTime)}
+            checked={includeStartTime}
+            label={__('Start at')}
+          />
+          <FormField
+            type="text"
+            name="share_start_at"
+            value={startTime}
+            disabled={!includeStartTime}
+            onChange={event => setStartTime(event.target.value)}
+          />
+        </div>
+      )}
       <div className="section__actions">
         <Button
           className="share"


### PR DESCRIPTION
Closes #4177

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #4177

## What is the current behavior?
"Start at" is shown for all sharing modals

## What is the new behavior?
"Start at" is only shown for video and audio sharing modals

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
