### PR TITLE
Corrected the message for blocked channels in settings

### DIFF
--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -481,11 +481,16 @@ class SettingsPage extends React.PureComponent<Props, State> {
                 title={__('Blocked Channels')}
                 actions={
                   <p>
-                    {__('You have %count% blocked %channels%.', {
-                      count: userBlockedChannelsCount,
-                      channels: userBlockedChannelsCount === 1 ? __('channel') : __('channels'),
-                    })}{' '}
-                    <Button button="link" label={__('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />
+                    {
+                    if userBlockedChannelsCount > 0 {
+                      __('You have %count% %channels%.', {
+                        count: userBlockedChannelsCount,
+                        channels: userBlockedChannelsCount === 1 ? __('blocked channel') : __('blocked channels'),
+                      ){' '}
+                      <Button button="link" label={__('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />}}
+                    else {
+                      __('You don\'t have blocked channels.')
+                    }}
                   </p>
                 }
               />


### PR DESCRIPTION
Problems to be solved:
1. In other languages the message 'blocked channels' need to be displayed as 'channels blocked'. N
Now translators can choose the order according to their language needs. The word 'blocked' should not be hard coded for that.
2. In the case there are no blocked channel there is no need to show the 0 value also the link to manage de channels, because there is no channel to manage.

Case 0 channels blocked: You don't have blocked channels.  (No Manage button displayed)
Case 1 channel blocked: You have 1 blocked channel. Manage (manage link)
Case 2 channel blocked: You have 2 blocked channels. Manage (manage link)

**If somebody can make it work, because I can't. It seems as it is now it can't compile.**

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

