### PR TITLE
Add grab cursor to pop out player header

### DIFF
--- a/ui/scss/component/_content.scss
+++ b/ui/scss/component/_content.scss
@@ -57,6 +57,7 @@
 }
 
 .content__floating-header {
+  cursor: grab;
   visibility: hidden;
   position: absolute;
   top: 0;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe:
Improvement: Makes it clearer that the pop out player can be moved around

## Fixes

Issue Number: Partially fixes #2750, specifically the checkbox that says "make it clearer on how to drag around"

## What is the current behavior?
When hovering over the header of the pop out player, a pointer cursor is shown.

## What is the new behavior?
When hovering over the header of the pop out player, a hand cursor is shown, similar to the footer of the pop out player.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
