### PR TITLE
Changed how 'Blocked channels' are displayed on settings

### DIFF
--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -480,13 +480,15 @@ class SettingsPage extends React.PureComponent<Props, State> {
               <Card
                 title={__('Blocked Channels')}
                 actions={
-                  <p>
-                    {__('You have %count% blocked %channels%.', {
-                      count: userBlockedChannelsCount,
-                      channels: userBlockedChannelsCount === 1 ? __('channel') : __('channels'),
-                    })}{' '}
-                    <Button button="link" label={__('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />
-                  </p>
+                    <p>
+                    <React.Fragment>
+                        {__( '%count% %channels%. ', {
+                          count: userBlockedChannelsCount === 0 ? __("You don't have") : __('You have') + ' ' + userBlockedChannelsCount + ' ',
+                          channels: userBlockedChannelsCount === 1 ? __('blocked channel') : __('blocked channels'),
+                        })}
+                        {<Button button="link" label={userBlockedChannelsCount === 0 ? null : __('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />}
+                    </React.Fragment>
+                   </p>
                 }
               />
             )}


### PR DESCRIPTION
Problems solved:
1. In other languages the message 'blocked channels' need to be displayed as 'channels blocked'.
Now translators can choose the order according to their language needs. The word 'blocked' should not be hard coded for that.
2. In the case there are no blocked channel there is no need to show the 0 value also the link to manage de channels, because there is no channel to manage.
Messages:
Case 0 blocked channels: **You don't have blocked channels.**  (No Manage button displayed)
Case 1 blocked channel:  **You have 1 blocked channel. Manage** (manage link)
Case 2 blocked channels: **You have 2 blocked channels. Manage** (manage link)

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

## What is the new behavior?

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
