### PR TITLE
disables page scroll when pressing spacebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix inconsistent relative-date string for claims, comments, etc. ([#4172](https://github.com/lbryio/lbry-desktop/pull/4172))
 - Error opening certain files with special characters in name #2777 _community pr!_ ([#4161](https://github.com/lbryio/lbry-desktop/pull/4161))
 - Comic-book file page shows download button first, and then viewer after download _community pr!_ ([#4161](https://github.com/lbryio/lbry-desktop/pull/4161))
+<<<<<<< 3e4debf403c7e6707f8513bafe003a3ec42f0899
 - Only show "start at" on share modal for video/audio _community pr!_ ([#4194](https://github.com/lbryio/lbry-desktop/pull/4194))
 - Clear media position after video has played to the end _community pr!_ ([#4193](https://github.com/lbryio/lbry-desktop/pull/4193))
 - Text casing on publish page _community pr!_ ([#4186](https://github.com/lbryio/lbry-desktop/pull/4186))
 - Some strings not translating properly _community pr!_ ([#4238](https://github.com/lbryio/lbry-desktop/pull/4238))
+=======
+- Prevents page from scrolling while pressing the spacebar when the miniplayer is out of focus _community pr!_ ([#4204](https://github.com/lbryio/lbry-desktop/pull/4204))
+>>>>>>> updates  changelog with description and PR link
 
 ## [0.45.1] - [2020-05-06]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only show "start at" on share modal for video/audio _community pr!_ ([#4194](https://github.com/lbryio/lbry-desktop/pull/4194))
 - Clear media position after video has played to the end _community pr!_ ([#4193](https://github.com/lbryio/lbry-desktop/pull/4193))
 - Text casing on publish page _community pr!_ ([#4186](https://github.com/lbryio/lbry-desktop/pull/4186))
+- Prevents page from scrolling while pressing the spacebar when the miniplayer is out of focus _community pr!_ ([#4204](https://github.com/lbryio/lbry-desktop/pull/4204))
 
 ## [0.45.1] - [2020-05-06]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix inconsistent relative-date string for claims, comments, etc. ([#4172](https://github.com/lbryio/lbry-desktop/pull/4172))
 - Error opening certain files with special characters in name #2777 _community pr!_ ([#4161](https://github.com/lbryio/lbry-desktop/pull/4161))
 - Comic-book file page shows download button first, and then viewer after download _community pr!_ ([#4161](https://github.com/lbryio/lbry-desktop/pull/4161))
-<<<<<<< 3e4debf403c7e6707f8513bafe003a3ec42f0899
 - Only show "start at" on share modal for video/audio _community pr!_ ([#4194](https://github.com/lbryio/lbry-desktop/pull/4194))
 - Clear media position after video has played to the end _community pr!_ ([#4193](https://github.com/lbryio/lbry-desktop/pull/4193))
 - Text casing on publish page _community pr!_ ([#4186](https://github.com/lbryio/lbry-desktop/pull/4186))
 - Some strings not translating properly _community pr!_ ([#4238](https://github.com/lbryio/lbry-desktop/pull/4238))
-=======
 - Prevents page from scrolling while pressing the spacebar when the miniplayer is out of focus _community pr!_ ([#4204](https://github.com/lbryio/lbry-desktop/pull/4204))
->>>>>>> updates  changelog with description and PR link
+- Only show "start at" on share modal for video/audio _community pr!_ ([#4194](https://github.com/lbryio/lbry-desktop/pull/4194))
+- Clear media position after video has played to the end _community pr!_ ([#4193](https://github.com/lbryio/lbry-desktop/pull/4193))
+- Text casing on publish page _community pr!_ ([#4186](https://github.com/lbryio/lbry-desktop/pull/4186))
 
 ## [0.45.1] - [2020-05-06]
 

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -161,6 +161,17 @@ function App(props: Props) {
     return () => window.removeEventListener('mouseup', handleForwardAndBackButtons);
   });
 
+  // allows user to pause miniplayer using the spacebar without the page scrolling down
+  useEffect(() => {
+    const handleKeyPress = e => {
+      if (e.key === ' ' && e.target === document.body) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('keydown', handleKeyPress);
+    return () => window.removeEventListener('keydown', handleKeyPress);
+  });
+
   useEffect(() => {
     if (referredRewardAvailable && sanitizedReferrerParam && isRewardApproved) {
       setReferrer(sanitizedReferrerParam, true);

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -170,7 +170,7 @@ function App(props: Props) {
     };
     window.addEventListener('keydown', handleKeyPress);
     return () => window.removeEventListener('keydown', handleKeyPress);
-  });
+  }, []);
 
   useEffect(() => {
     if (referredRewardAvailable && sanitizedReferrerParam && isRewardApproved) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #3870 

## What is the current behavior?
If playing a video and then navigating to a new page to cause the miniplayer to appear out of focus, pressing spacebar causes the video to pause and the page to scroll down in the background.

## What is the new behavior?
Ensures that pressing spacebar only pauses the video on the miniplayer and doesn't cause the page to scroll.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
