### PR TITLE
Make embeds work without sesion or local storage

### DIFF
--- a/ui/index.jsx
+++ b/ui/index.jsx
@@ -275,7 +275,9 @@ function AppWrapper() {
 
   useEffect(() => {
     if (readyToLaunch && persistDone) {
+      // @if TARGET='app'
       sessionStorage.setItem('startup', true);
+      // @endif
       app.store.dispatch(doUpdateIsNightAsync());
       app.store.dispatch(doDaemonReady());
       app.store.dispatch(doBlackListedOutpointsSubscribe());

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -329,7 +329,7 @@ export function doDaemonReady() {
     const state = getState();
 
     // TODO: call doFetchDaemonSettings, then get usage data, and call doAuthenticate once they are loaded into the store
-    const shareUsageData = window.localStorage.getItem(SHARE_INTERNAL) === 'true' || IS_WEB;
+    const shareUsageData = IS_WEB || window.localStorage.getItem(SHARE_INTERNAL) === 'true';
 
     dispatch(
       doAuthenticate(appVersion, undefined, undefined, shareUsageData, status => {


### PR DESCRIPTION
Closes #4017

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #4017

## What is the current behavior?
Embeds don't work in Brave with shields up because session and local storage is trying to be accessed.

## What is the new behavior?
Embeds work in Brave with shields because session and local storage access is avoided.

## Other information
I tested this by creating a new local web site with an embedded iframe from a share link. I then modified the host from lbry.tv to localhost:9090. Without my changes I got errors and the video wouldn't load, but with my changes, the errors went away and the video played.

Note on changes: the 'startup' sesionStorage item is only used on the app, so I made that code that sets this item only appear in the app code.

The second change where I move IS_WEB to the front of the || will short circuit the || if it is web and hence the window.localStorage.getItem() code will not run on the web.

When testing, I did still get this error:
```
createPersistoid.js?d203:97 Error storing data Error: No available storage method found.
    at driverPromiseLoop (localforage.js?69ae:2714)
```
but the video played fine, so I am assuming we can ignore it?


<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
