### PR TITLE
Allow selecting of text by dragging the cursor over text

### DIFF
--- a/ui/scss/component/_wunderbar.scss
+++ b/ui/scss/component/_wunderbar.scss
@@ -52,6 +52,7 @@
   padding-right: var(--spacing-small);
   padding-left: 2.5rem;
   transition: all 0.2s;
+  -webkit-app-region: no-drag;
 
   &:focus {
     border-radius: var(--border-radius);


### PR DESCRIPTION
Closes #4209

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #4209

## What is the current behavior?
Attempting to select text in the wunderbar in the app will move the whole app window instead of selecting text.

## What is the new behavior?
Attempting to select text in the wunderbar in the app will actually let you select the text.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
