### PR TITLE
Changed how 'Blocked channels' are displayed on settings and a typo

### DIFF
--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -263,7 +263,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
       <Page className="card-stack">
         {!IS_WEB && noDaemonSettings ? (
           <section className="card card--section">
-            <div className="card__title card__t itle--deprecated">{__('Failed to load settings.')}</div>
+            <div className="card__title card__title--deprecated">{__('Failed to load settings.')}</div>
           </section>
         ) : (
           <div>
@@ -480,13 +480,15 @@ class SettingsPage extends React.PureComponent<Props, State> {
               <Card
                 title={__('Blocked Channels')}
                 actions={
-                  <p>
-                    {__('You have %count% blocked %channels%.', {
-                      count: userBlockedChannelsCount,
-                      channels: userBlockedChannelsCount === 1 ? __('channel') : __('channels'),
-                    })}{' '}
-                    <Button button="link" label={__('Manage')} navigate={`/$/${PAGES.BLOCKED}`} />
-                  </p>
+                <p>
+                  <React.Fragment>
+                    {__('%count% %channels%. ', {
+                      count: userBlockedChannelsCount === 0 ? __("You don't have") : __('You have') + ' ' + userBlockedChannelsCount + ' ',
+                      channels: userBlockedChannelsCount === 1 ? __('blocked channel') : __('blocked channels'),
+                    })}
+				            {<Button button="link" label={userBlockedChannelsCount === 0 ? null : __('Manage')} navigate={`/$/${PAGES.BLOCKED}`} /> }
+					       </React.Fragment>
+				        </p>
                 }
               />
             )}


### PR DESCRIPTION
Problems solved (second attempt):
A. Small typo for <div className="card__title card__t itle--deprecated"> (extra space in the word **t itle**)

B. More details about problems with languages:
1. The word blocked has two forms in other languages (one for plural and one for singular) and therefore must be put together with channel and channels words. Currently it can be translated in only one form.

2. In the case there are no blocked channels there is no need to show the 0 value and is more elegant the message 'You do not have blocked channels'

3.  The link to manage the channels should not be visible in the case that there is no channel blocked, because there is no channel that need to be managed.

And about your statement: "Your change would make it harder for other languages to change this sentence." 

It's quite the opossite, it's very clear and easy. They just have to translate (with examples in Romanian):
'%count% %channels%. ',     (leave it as it is)
'You don't have' = 'Nu aveți'
'You have' = 'Aveți'
'blocked channel' = 'canal blocat'
'blocked channels' = 'canale blocat**e**'  (see the change for plural forms for the word blocked, not only for channels word?)

I hope this time I explained better the need for the changes.
Thanks

Messages displayed:
Case with 0 blocked channels: You don't have blocked channels. (No Manage button displayed)
Case with 1 blocked channel: You have 1 blocked channel. **Manage** (manage link)
Case with 2 or more blocked channels: You have 2 blocked channels. **Manage** (manage link)

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

## What is the new behavior?

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
