### PR TITLE
Make sure native controls appear on touch devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only show "start at" on share modal for video/audio _community pr!_ ([#4194](https://github.com/lbryio/lbry-desktop/pull/4194))
 - Clear media position after video has played to the end _community pr!_ ([#4193](https://github.com/lbryio/lbry-desktop/pull/4193))
 - Text casing on publish page _community pr!_ ([#4186](https://github.com/lbryio/lbry-desktop/pull/4186))
+- Enable videos to play on iPad _community pr!_ ([#4223](https://github.com/lbryio/lbry-desktop/pull/4223))
 
 ## [0.45.1] - [2020-05-06]
 

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -87,6 +87,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     autoplay: false,
     poster: poster, // thumb looks bad in app, and if autoplay, flashing poster is annoying
     plugins: { eventTracking: true },
+    html5: { nativeControlsForTouch: true },
   };
 
   videoJsOptions.muted = startMuted;


### PR DESCRIPTION
Closes #4150

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #4150

## What is the current behavior?
Videos on iPad are not playable. They do not autoplay and there are no controls to play.

## What is the new behavior?
Native controls for video appear on iPad allowing user to play a video.

## Other information
This should also be tested on Android, which I don't have.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
