### PR TITLE
Revert "Make sure native controls appear on touch devices"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only show "start at" on share modal for video/audio _community pr!_ ([#4194](https://github.com/lbryio/lbry-desktop/pull/4194))
 - Clear media position after video has played to the end _community pr!_ ([#4193](https://github.com/lbryio/lbry-desktop/pull/4193))
 - Text casing on publish page _community pr!_ ([#4186](https://github.com/lbryio/lbry-desktop/pull/4186))
-- Enable videos to play on iPad _community pr!_ ([#4223](https://github.com/lbryio/lbry-desktop/pull/4223))
 
 ## [0.45.1] - [2020-05-06]
 

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -88,7 +88,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     autoplay: false,
     poster: poster, // thumb looks bad in app, and if autoplay, flashing poster is annoying
     plugins: { eventTracking: true },
-    html5: { nativeControlsForTouch: true },
   };
 
   videoJsOptions.muted = startMuted;


### PR DESCRIPTION
Reverts lbryio/lbry-desktop#4223

@jeffslofish reverting this because it appears to mess with lbry.tv in some cases and messes up android (I should have tested this). 

Maybe this should only be added for iOS devices?