### PR TITLE
Fix <i18nMessage> not localizing the message.

### DIFF
--- a/ui/component/i18nMessage/view.jsx
+++ b/ui/component/i18nMessage/view.jsx
@@ -15,7 +15,7 @@ export default function I18nMessage(props: Props) {
     return message;
   }
 
-  const messageSubstrings = props.children.split(regexp),
+  const messageSubstrings = message.split(regexp),
     tokens = props.tokens;
 
   return (


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: Fixed #4173 

## What is the current behavior?
Messages under `<i18nMessage>` weren't localized although the translation is available. However, the tokens for these messages are localized, causing a mixed-language final string.

## What is the new behavior?
Localizations using `<i18nMessage>` now works.

It appears that the original message (instead of the localized) was used in the token-substitution process.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
