### PR TITLE
Changed code for "Blocked channels" settings

### DIFF
--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -488,13 +488,11 @@ class SettingsPage extends React.PureComponent<Props, State> {
                 actions={
                   <p>
                     <React.Fragment>
-                      {__('%count% %channels%. ', {
-                        count:
-                          userBlockedChannelsCount === 0
-                            ? __("You don't have")
-                            : __('You have') + ' ' + (userBlockedChannelsCount || 0) + ' ',
-                        channels: userBlockedChannelsCount === 1 ? __('blocked channel') : __('blocked channels'),
-                      })}
+				              {
+                        userBlockedChannelsCount === 0 ? __("You don't have blocked channels.")
+				                : userBlockedChannelsCount === 1 ? __('You have one blocked channel.') +' '
+				                : __('You have %channels% blocked channels.', {channels: userBlockedChannelsCount})+' '
+                      }
                       {
                         <Button
                           button="link"


### PR DESCRIPTION
Because in some languages, like Japanese, the text start with the number first (as it mentioned in https://github.com/lbryio/lbry-desktop/pull/4215#issuecomment-633264851) I rewrote the code to be more easy and clear for translators to translate the text.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

## What is the new behavior?

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
