### PR TITLE
remove manual override in formatting for credits in header

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#d2079111b3372eb926d2753991bed860e57a970a",
+    "lbry-redux": "lbryio/lbry-redux#82b1c8c51b505d9b7345897d3de9a1d171314d6c",
     "lbryinc": "lbryio/lbryinc#8bdf1ac44d03cef9d798df92e3192a4591845f17",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/ui/component/header/index.js
+++ b/ui/component/header/index.js
@@ -18,7 +18,7 @@ import Header from './view';
 const select = state => ({
   balance: selectBalance(state),
   language: makeSelectClientSetting(SETTINGS.LANGUAGE)(state), // trigger redraw on language change
-  roundedBalance: formatCredits(selectBalance(state) || 0, 2, true),
+  roundedBalance: formatCredits(selectBalance(state), 2, true),
   currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),
   automaticDarkModeEnabled: makeSelectClientSetting(SETTINGS.AUTOMATIC_DARK_MODE_ENABLED)(state),
   hideBalance: makeSelectClientSetting(SETTINGS.HIDE_BALANCE)(state),


### PR DESCRIPTION
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: resolves #4140 

## What is the current behavior?
Shows 0 in the header for credits while loading

## What is the new behavior?
Shows '--' in the header for credits while loading

## Other information
Change in function depends on lbryio/lbry-redux#317
