### PR TITLE
fix: remove double border on single cards with not title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Some strings not translating properly _community pr!_ ([#4238](https://github.com/lbryio/lbry-desktop/pull/4238))
 - Prevents page from scrolling while pressing the spacebar when the miniplayer is out of focus _community pr!_ ([#4204](https://github.com/lbryio/lbry-desktop/pull/4204))
 - Fixed some string translations _community pr!_ ([#4238](https://github.com/lbryio/lbry-desktop/pull/4238))
+- Fixed Publish page card double border _community pr!_ ([#4254](https://github.com/lbryio/lbry-desktop/pull/4254)
 
 ## [0.45.1] - [2020-05-06]
 

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -247,6 +247,10 @@
   padding-bottom: 0;
   margin-bottom: var(--spacing-large);
   border-top: 1px solid var(--color-border);
+
+  &:only-child {
+    border-top: none;
+  }
 }
 
 .card__body-actions {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
There is a double border on cards with no title portion. 

## What is the new behavior?
Cards without title portion now have a single border.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
