### PR TITLE
Made text translatable

### DIFF
--- a/ui/component/errorBoundary/view.jsx
+++ b/ui/component/errorBoundary/view.jsx
@@ -90,8 +90,7 @@ class ErrorBoundary extends React.Component<Props, State> {
                   ),
                 }}
               >
-                There was an error. Try %refreshing_the_app_link% to fix it. If that doesn't work, try pressing
-                Ctrl+R/Cmd+R.
+                There was an error. Try %refreshing_the_app_link% to fix it. If that doesn't work, try pressing Ctrl+R/Cmd+R.
               </I18nMessage>
             }
           />


### PR DESCRIPTION
Removed end of the line that make text untranslatable

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
Text is not translated because of the end of line that broke the string
## What is the new behavior?
Text will be translated now
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
