### PR TITLE
Fix css "--spacing-?" renaming that recent PRs missed during the merge.

### DIFF
--- a/ui/scss/component/_markdown-preview.scss
+++ b/ui/scss/component/_markdown-preview.scss
@@ -124,7 +124,7 @@
     word-break: break-all;
 
     code {
-      margin-bottom: var(--spacing-medium);
+      margin-bottom: var(--spacing-m);
       padding: var(--spacing-s) var(--spacing-s) calc(var(--spacing-s) - 2px);
       display: block;
       white-space: pre-wrap;

--- a/ui/scss/component/_status-bar.scss
+++ b/ui/scss/component/_status-bar.scss
@@ -9,9 +9,9 @@
   bottom: 0;
   font-size: var(--font-small);
   padding-top: 2px;
-  padding-left: var(--spacing-xsmall);
-  padding-right: var(--spacing-xsmall);
-  border-top-right-radius: var(--spacing-xsmall);
+  padding-left: var(--spacing-xs);
+  padding-right: var(--spacing-xs);
+  border-top-right-radius: var(--spacing-xs);
   opacity: 0;
   transition: opacity 0.3s ease;
   transition-delay: 400ms;


### PR DESCRIPTION
The status-bar merge did not include the css spacing variable rename that happened in the moonpay merge.