### PR TITLE
Make strings from fileDetails translatable

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1211,5 +1211,15 @@
   "Select your country": "Select your country",
   "LBRY, Inc. partners with Moonpay to provide the option to purchase LBC. %learn_more%.": "LBRY, Inc. partners with Moonpay to provide the option to purchase LBC. %learn_more%.",
   "Your browser does not support iframes.": "Your browser does not support iframes.",
-  "Change Inviter": "Change Inviter"
+  "Change Inviter": "Change Inviter",
+  "0 Bytes": "0 Bytes",
+  "Bytes": "Bytes",
+  "KB": "KB",
+  "MB": "MB",
+  "GB": "GB",
+  "TB": "TB",
+  "PB": "PB",
+  "EB": "EB",
+  "ZB": "ZB",
+  "YB": "YB"
 }

--- a/ui/component/fileDetails/view.jsx
+++ b/ui/component/fileDetails/view.jsx
@@ -37,7 +37,7 @@ class FileDetails extends PureComponent<Props> {
     // Create path from name so the folder opens on click.
     if (fileInfo && fileInfo.blobs_completed >= 1 && fileInfo.download_path === null) {
       downloadPath = `${fileInfo.download_directory}/${fileInfo.file_name}`;
-      downloadNote = 'This file may have been streamed, moved or deleted';
+      downloadNote = __('This file may have been streamed, moved or deleted');
     }
 
     return (
@@ -113,11 +113,11 @@ class FileDetails extends PureComponent<Props> {
 }
 // move this with other helper functions when we re-use it
 function formatBytes(bytes, decimals = 2) {
-  if (bytes === 0) return '0 Bytes';
+  if (bytes === 0) return __('0 Bytes');
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const sizes = [__('Bytes'), __('KB'), __('MB'), __('GB'), __('TB'), __('PB'), __('EB'), __('ZB'), __('YB')];
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 


### PR DESCRIPTION
Text  for files sizes can be translated as Mo (from Mega octet) so KB, MB, GB etc will be Ko, Mo, Go etc. in other languages.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

## What is the new behavior?

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
