### PR TITLE
Fix Repost input field being off-screen

### DIFF
--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -57,6 +57,8 @@
 
 .comment__message {
   white-space: pre-line;
+  word-wrap: break-word;
+  word-break: break-all;
   margin-top: var(--spacing-s);
 }
 

--- a/ui/scss/component/_form-field.scss
+++ b/ui/scss/component/_form-field.scss
@@ -71,8 +71,12 @@ fieldset-group {
     }
 
     fieldset-section:first-child {
+      max-width: 40%;
+
       .form-field__prefix {
         white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
         padding: 0.5rem;
         padding-right: var(--spacing-s);
         height: var(--height-input);

--- a/ui/scss/component/_form-field.scss
+++ b/ui/scss/component/_form-field.scss
@@ -94,6 +94,13 @@ fieldset-group {
     fieldset-section:last-child {
       width: 100%;
 
+      label {
+        // Overwrite the input's label to wrap instead. This is usually
+        // an error message, which could be long in other languages.
+        width: 100%;
+        white-space: normal;
+      }
+
       input {
         border-left: 0;
         border-top-left-radius: 0;


### PR DESCRIPTION
## PR Checklist
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type
- [x] Bugfix

## Fixes
Fixes #3697 

## What is the current behavior? What is the new behavior?
![image](https://user-images.githubusercontent.com/64950861/83999971-6309da00-a996-11ea-85e8-b463f91bed20.png)

## Other information
See commit messages for rationale and decisions.

One minor "side effect" is that it pushes all the elements down when there is a need to wrap, but I think it's an ok compromise for a rare corner-case.