### PR TITLE
PATCH:  Fix dev base-url being used when generating the hover URL.

### DIFF
--- a/electron/createWindow.js
+++ b/electron/createWindow.js
@@ -166,7 +166,24 @@ export default appState => {
 
   window.webContents.on('update-target-url', (event, url) => {
     // Change internal links to the lbry protocol. External (https) links should remain unchanged.
-    let dispUrl = url.replace(`http://localhost:${WEBPACK_ELECTRON_PORT}/`, lbryProto);
+    let hoverUrlBase = `http://localhost:${WEBPACK_ELECTRON_PORT}/`;
+    if (!isDev) {
+      // Return format of 'update-target-url':
+      //   Linux:   file:///@claim
+      //   Windows: file:///C:/@claim
+      // Use '__dirname' in case installation is not in C:
+      const path = require('path');
+      const exeRoot = path.parse(__dirname).root;
+
+      if (process.platform === 'win32') {
+        // Add extra "/" prefix. Convert "C:\" to "C:/"
+        hoverUrlBase = `file:///` + exeRoot.replace(/\\/g, '/');
+      } else {
+        hoverUrlBase = `file://` + exeRoot;
+      }
+    }
+
+    let dispUrl = url.replace(hoverUrlBase, lbryProto);
     // Non-claims don't need the lbry protocol:
     if (dispUrl === lbryProto)  {
       dispUrl = 'Home';


### PR DESCRIPTION
## PR Type
- [x] Bugfix

## Fixes
Fixes #4347 `[desktop] remove file://c: from status bar on hover LBRY urls`

## The Issue
1. The `isDev` version of the base URL was incorrectly used in the URL reconstruction, so it failed in the final build.
2. Even if the correct version was used, there is still some platform (win vs. linux) differences to handle.

## Other Information
If I'm correct, `update-target-url` returns in the following format:
```
Format:  file:// + "root of executable" + "claim address"
Linux:   file:///@claim
Windows: file:///C:/@claim (the root is /C:/)
```
I've tested `yarn build` on these 2 platforms, but I don't have a Mac to test on.  I assume it behaves the same as Linux.