### PR TITLE
PATCH: Fix [ff0cc861] that broke regular word-wrap in comments.

### DIFF
--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -57,8 +57,7 @@
 
 .comment__message {
   white-space: pre-line;
-  word-wrap: break-word;
-  word-break: break-all;
+  word-break: break-word;
   margin-top: var(--spacing-s);
 }
 


### PR DESCRIPTION
## PR Type
- [x] Bugfix
Fixes #4350 `comments getting cut off mid word instead of being wrapped properly`

## What is the new behavior?
![image](https://user-images.githubusercontent.com/64950861/84120982-21962f00-aa69-11ea-9e14-e62da4806e9b.png)

## Other Information
My bad ... was pretty sure I tested all cases in the original PR.  But here's another attempt.