### PR TITLE
Limit the Markdown Editor width in Edit (not New) Mode to prevent overflow

### DIFF
--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -41,6 +41,7 @@
 .comment__body_container {
   padding-right: var(--spacing-s);
   flex: 1;
+  width: 80%;
 }
 
 .comment__meta {


### PR DESCRIPTION
## PR Type
- [x] Bugfix - Fixes #4355 `Editing a published comment with long string causes width overflow`

## What is the current behavior?
The MDE width overflows as you type.  Affects Edit Mode only (New Mode works fine).

## What is the new behavior?
>_The MDE used in the "new" section has a parent width parameter to limit itself, while the MDE used in the "edit" section didn't._
>
>_Fix by limiting ".comment__body_container" to 80%, which takes into account the space taken by the author's avatar. This feels a little bit dirty since it's hard-coded.  If there's a way to calculate the avatar width from here, it will be more robust._

![image](https://user-images.githubusercontent.com/64950861/84131033-9de33f00-aa76-11ea-9056-b9b309044e18.png)


