### PR TITLE
Show "unmute" option on videos automatically muted by browser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add "tap to unmute" button for videos that start with audio muted _community pr!_ ([#4365](https://github.com/lbryio/lbry-desktop/pull/4365))
+
 ### Changed
 
 - Merged Tip and Support Buttons into one UI on file page ([#4382](https://github.com/lbryio/lbry-desktop/pull/4382))

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1228,6 +1228,7 @@
   "Sharing information with LBRY, Inc. allows us to report to publishers how their content is doing, as\n                well as track basic usage and performance. This is the minimum required to earn rewards from LBRY, Inc.": "Sharing information with LBRY, Inc. allows us to report to publishers how their content is doing, as\n                well as track basic usage and performance. This is the minimum required to earn rewards from LBRY, Inc.",
   "No information will be sent directly to LBRY, Inc. or third-parties about your usage. Note that as\n                peer-to-peer software, your IP address and potentially other system information can be sent to other\n                users, though this information is not stored permanently.": "No information will be sent directly to LBRY, Inc. or third-parties about your usage. Note that as\n                peer-to-peer software, your IP address and potentially other system information can be sent to other\n                users, though this information is not stored permanently.",
   "%view_count% Views": "%view_count% Views",
+  "Tap to unmute": "Tap to unmute",
   "0 Bytes": "0 Bytes",
   "Bytes": "Bytes",
   "KB": "KB",

--- a/ui/component/common/icon-custom.jsx
+++ b/ui/component/common/icon-custom.jsx
@@ -370,6 +370,13 @@ export const icons = {
       <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z" />
     </g>
   ),
+  [ICONS.VOLUME_MUTED]: buildIcon(
+    <g>
+      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+      <line x1="23" y1="9" x2="17" y2="15" />
+      <line x1="17" y1="9" x2="23" y2="15" />
+    </g>
+  ),
   [ICONS.IMAGE]: buildIcon(
     <g>
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -7,7 +7,6 @@ import videojs from 'video.js/dist/alt/video.core.novtt.min.js';
 import 'video.js/dist/alt/video-js-cdn.min.css';
 import eventTracking from 'videojs-event-tracking';
 import isUserTyping from 'util/detect-typing';
-import isDev from 'electron-is-dev';
 
 export type Player = {
   on: (string, (any) => void) => void,
@@ -107,7 +106,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       if (newState !== curState) {
         tapToUnmuteRef.current.style.visibility = newState ? 'visible' : 'hidden';
       }
-    } else if (isDev) {
+    } else if (process.env.NODE_ENV === 'development') {
       throw new Error('[videojs.jsx] Empty video ref should not happen');
     }
   }

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -114,12 +114,15 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   function unmuteAndHideHint() {
     if (player) {
       player.muted(false);
+      if (player.volume() === 0) {
+        player.volume(1.0);
+      }
     }
     showTapToUnmute(false);
   }
 
   function onInitialPlay() {
-    if (player && player.muted()) {
+    if (player && (player.muted() || player.volume() === 0)) {
       // The css starts as "hidden". We make it visible here without
       // re-rendering the whole thing.
       showTapToUnmute(true);

--- a/ui/constants/icons.js
+++ b/ui/constants/icons.js
@@ -90,6 +90,7 @@ export const MORE_VERTICAL = 'MoreVertical';
 export const IMAGE = 'Image';
 export const AUDIO = 'HeadPhones';
 export const VIDEO = 'Video';
+export const VOLUME_MUTED = 'VolumeX';
 export const TEXT = 'FileText';
 export const DOWNLOADABLE = 'Downloadable';
 export const REPOST = 'Repeat';

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -349,8 +349,8 @@
   visibility: hidden; // Start off as hidden.
   z-index: 2;
   position: absolute;
-  top: 5%;
-  left: 5%;
+  top: var(--spacing-xs);
+  left: var(--spacing-xs);
   padding: var(--spacing-xs) var(--spacing-m); // Make it comfy for touch.
   color: var(--color-gray-1);
   background: black;

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -345,6 +345,19 @@
   }
 }
 
+.video-js--tap-to-unmute {
+  visibility: hidden; // Start off as hidden.
+  z-index: 2;
+  position: absolute;
+  top: 5%;
+  left: 5%;
+  padding: var(--spacing-xs) var(--spacing-m); // Make it comfy for touch.
+  color: var(--color-gray-1);
+  background: black;
+  border: 1px solid var(--color-gray-4);
+  opacity: 0.7;
+}
+
 .file-render {
   .video-js {
     display: flex;


### PR DESCRIPTION
## PR Type
- [x] Feature -- Fixes #4325 `Show "unmute" option on videos automatically muted by browser`

## What is the current behavior?
Per 4325:
>_Some users may not notice that the video is muted automatically and the overlay would alert them to this. Youtube does something similar._

## What is the new behavior?
![image](https://user-images.githubusercontent.com/64950861/84276012-68b51a80-ab64-11ea-873e-bd3bce844a5f.png)

## Other information
**Implementation:**
- The code is placed in `VideoJs` instead of `VideoViewer` as we need to control the video itself. It's more self-contained here, rather than trying to pass refs around between parent and child.
(_actually, I don't know how to control the player from the parent. I'd be curious to know how to do it in React as a side discussion_)
- useState cannot be used as it will cause a re-render when the hint it clicked and dismissed. The DOM is used to hide the button.

**Dev testing notes:**
[x] When manually unmute using regular button, the hint should go away.
[ ] When manually unmute using 'm', the hint should go away.
          This is actually #4358 `The mute icon sometimes does not reflect actual state.`.  It's either a videojs bug, or an issue with the redux dispatch.  I'm not sure how to address this corner-case. `player.muted()` is always `true` in this scenario.
[x] Should not appear if video failed to load.
[x] Don't show the button when in full screen (following Twitch)
[x] Test with "autoplay" on and off
[x] Test on floating player
[x] Test with entering via "back" vs. direct entry.
[x] Test with dev:web
[x] When video ends, hide it if still present.
[x] Add proper icon
[x] Hint sometimes doesn't appear on fresh lbry.tv. lbryTV: Doesn't appear when random-autoplay next clip. (fixed by changing to `player.one('play')` instead since `player.on('loadstart')` isn't the right event to use for this.)