### PR TITLE
Add ability to support language subsets, with only CT and CS enabled for now

### DIFF
--- a/ui/constants/languages.js
+++ b/ui/constants/languages.js
@@ -181,6 +181,8 @@ const LANGUAGES = {
   yo: ['Yoruba', 'Yorùbá'],
   za: ['Zhuang', 'Cuengh / Tôô / 壮语'],
   zh: ['Chinese', '中文'],
+  'zh-CN': ['Chinese (Simplified)', '中文 (简体)'],
+  'zh-TW': ['Chinese (Traditional)', '中文 (繁體)'],
   zu: ['Zulu', 'isiZulu'],
 };
 

--- a/ui/constants/supported_languages.js
+++ b/ui/constants/supported_languages.js
@@ -3,7 +3,8 @@ import LANGUAGES from './languages';
 const SUPPORTED_LANGUAGES = {
   en: LANGUAGES.en[1],
   da: LANGUAGES.da[1],
-  zh: LANGUAGES.zh[1],
+  'zh-CN': LANGUAGES['zh-CN'][1],
+  'zh-TW': LANGUAGES['zh-TW'][1],
   hr: LANGUAGES.hr[1],
   nl: LANGUAGES.nl[1],
   fr: LANGUAGES.fr[1],
@@ -33,4 +34,6 @@ const SUPPORTED_LANGUAGES = {
   uk: LANGUAGES.uk[1],
 };
 
+// Properties: language code (e.g. 'ja')
+// Values: name of the language in native form (e.g. '日本語')
 export default SUPPORTED_LANGUAGES;

--- a/ui/constants/supported_sub_languages.js
+++ b/ui/constants/supported_sub_languages.js
@@ -1,0 +1,8 @@
+// https://www.electronjs.org/docs/api/locales
+
+export const SUB_LANG_CODE_LEN = 5;
+
+export const SUPPORTED_SUB_LANGUAGE_CODES = [
+  'zh-CN',
+  'zh-TW',
+];


### PR DESCRIPTION
**CT** - Chinese Traditional, **CS** - Chinese Simplified

## PR Type
- [x] Feature -- Fixes #4225 `Add ability to support language subsets i18n`

## What is the current behavior?
Per Julie:
> _We have Chinese in our language selection (zh) but a community member really wants to add Taiwanese (zh_tw) to the app and gave a good description how it differs and is a legit request. Right now we don't support the languages on Transifex that have the underscore in their language code._

I agree.  All translated products almost always support these 2 distinct languages.
If LBRY wants to support it, then this PR attempts to enable that.  

## What is the new behavior?
- "Chinese" will be split into "Chinese (Traditional)" and "Chinese (Simplified").
- It will be easier to split other common subsets like `pt-BR/pt-PT` and `en-US/en-GB` if there is demand and translator availability.

## Remaining Work Required
I don't have access nor the knowledge for the Transifex side:
- [ ] Create `zh-TW.json` and `zh-CN.json` in `https://lbry.com/i18n/get/lbry-desktop/app-strings/`
_It seems like the current Chinese translation is mixed.  But I'm not 100% sure, so we'll need to ask the translator.  If it's not mixed, we can just rename to the new format._

## Code changes (approach)
I don't think we need to support all subsets, so we should selectively choose what we want to support.  Given that, a whiltelist array `SUPPORTED_SUB_LANGUAGE_CODES` is added.  If the user's OS locale is a subset but not in this list, it will be "consolidated" (i.e. 'en-US' --> 'en'), which is the behavior of the existing version.

The change also involves using a string for the property name in order to handle the dashes.  I hope there is no rule in the coding standard that prohibits this.

## Notes for posterity
Note that if English subsets like `en-GB` is enabled in the future, the default `'en'` value used throughout the code (including in `redux.git`) needs to be changed to `'en-US'`.

## Testing notes
Anything I missed?
[x] Change OS locale to `zh-CN` and `zh-TW`.  Clear the Electron settings to really start from scratch.  The selection language in `Settings` should be the same as the locale.  The GUI will still be in English since the json doesn't exist.
[x] Test on Web
[x] Try hardcode `zh-CN.json` to `zh.json` to see if translation still works.
[x] Test the non-supported subset case. Switch the OS to `en-GB` to try.