### PR TITLE
If support/tip unlock action fails, don't grey out

### DIFF
--- a/ui/component/transactionListTable/internal/txo-list-item.jsx
+++ b/ui/component/transactionListTable/internal/txo-list-item.jsx
@@ -38,7 +38,7 @@ class TxoListItem extends React.PureComponent<Props, State> {
     if (tip && type === TXO.SUPPORT) {
       return (
         <Button
-          disabled={abandonState === ABANDON_STATES.DONE || abandonState === ABANDON_STATES.ERROR}
+          disabled={abandonState === ABANDON_STATES.DONE}
           button="secondary"
           icon={ICONS.UNLOCK}
           onClick={this.abandonClaim}
@@ -49,7 +49,7 @@ class TxoListItem extends React.PureComponent<Props, State> {
     const abandonTitle = type === TXO.SUPPORT ? 'Abandon Support' : 'Abandon Claim';
     return (
       <Button
-        disabled={abandonState === ABANDON_STATES.DONE || abandonState === ABANDON_STATES.ERROR}
+        disabled={abandonState === ABANDON_STATES.DONE}
         button="secondary"
         icon={ICONS.DELETE}
         onClick={this.abandonClaim}


### PR DESCRIPTION
## PR Type
- [x] Bugfix » Fixes #4366 `If support/tip unlock action fails, don't grey out` 

   >_I tried unlocking a tip and it failed because my wallet was locked (this can happen for other reasons), but then the unlock icon was still greyed out. Only grey out if successful._
## What is the new behavior?
Don't gray out the buttons on `ABANDON_STATES.ERROR` for:
- Support/Tip unlock
- Claim abandonment