### PR TITLE
Add link to "Buy More LBC" button (Tested Working)

### DIFF
--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -275,7 +275,7 @@ function WalletSendTip(props: Props) {
                 </div>
                 {DEFAULT_TIP_AMOUNTS.some(val => val > balance) && (
                   <div className="section">
-                    <Button button="link" label={__('Buy More LBC')} />
+                    <Button button="link" label={__('Buy More LBC')} navigate={`/$/${PAGES.BUY}`} />
                   </div>
                 )}
               </>


### PR DESCRIPTION
Previously, the link was missing and the button didn't do anything.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
The button doesn't actually lead anywhere when you click it.
## What is the new behavior?
As I have tested, it works and leads to the purchase LBC page.
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
