### PR TITLE
Persist trending selectors between tags

### DIFF
--- a/ui/component/publishForm/view.jsx
+++ b/ui/component/publishForm/view.jsx
@@ -66,6 +66,7 @@ type Props = {
   // Add back type
   updatePublishForm: any => void,
   checkAvailability: string => void,
+  onChannelChange: string => void,
 };
 
 function PublishForm(props: Props) {
@@ -89,6 +90,7 @@ function PublishForm(props: Props) {
     publish,
     disabled = false,
     checkAvailability,
+    onChannelChange,
   } = props;
   const TAGS_LIMIT = 5;
   const formDisabled = (!filePath && !editingURI) || publishing;
@@ -144,6 +146,11 @@ function PublishForm(props: Props) {
     }
   }, [name, channel, resolveUri, updatePublishForm, checkAvailability]);
 
+  function handleChannelNameChange(channel) {
+    onChannelChange(channel);
+    updatePublishForm({ channel });
+  }
+
   return (
     <div className="card-stack">
       <PublishFile disabled={disabled || publishing} inProgress={isInProgress} />
@@ -182,7 +189,7 @@ function PublishForm(props: Props) {
           <Card
             actions={
               <React.Fragment>
-                <SelectChannel channel={channel} onChannelChange={channel => updatePublishForm({ channel })} />
+                <SelectChannel channel={channel} onChannelChange={handleChannelNameChange} />
                 <p className="help">
                   {__('This is a username or handle that your content can be found under.')}{' '}
                   {__('Ex. @Marvel, @TheBeatles, @BooksByJoe')}

--- a/ui/page/publish/view.jsx
+++ b/ui/page/publish/view.jsx
@@ -5,6 +5,7 @@ import Page from 'component/page';
 import Yrbl from 'component/yrbl';
 import LbcSymbol from 'component/common/lbc-symbol';
 import RewardAuthIntro from 'component/rewardAuthIntro';
+import usePersistedState from 'effects/use-persisted-state';
 
 type Props = {
   balance: number,
@@ -14,11 +15,17 @@ type Props = {
 function PublishPage(props: Props) {
   const { balance } = props;
 
+  const [channel, setChannel] = usePersistedState('publish-channel', '');
+
   function scrollToTop() {
     const mainContent = document.querySelector('main');
     if (mainContent) {
       mainContent.scrollTop = 0; // It would be nice to animate this
     }
+  }
+
+  function handleChannelChange(channel) {
+    setChannel(channel);
   }
 
   return (
@@ -55,7 +62,12 @@ function PublishPage(props: Props) {
           </div>
         </Fragment>
       ) : (
-        <PublishForm scrollToTop={scrollToTop} disabled={balance === 0} />
+        <PublishForm
+          scrollToTop={scrollToTop}
+          disabled={balance === 0}
+          channel={channel}
+          onChannelChange={handleChannelChange}
+        />
       )}
     </Page>
   );


### PR DESCRIPTION
## PR Type
- [x] Bugfix • Fixes #2679 `Persist trending selectors between tags`
> _When switching between tags, the selector defaults back to Trending even though you had another option already selected. I think it makes more sense to persist them._

Also, added persistence to `Channel` selection in `Publish` Page per discussion with Tom.

Skip the suggested change in the wallet for now until this method is reviewed.  There might be better ways to handle the history.

## Code changes
- `orderParamUser` will store the last user state persistently. The persistent state is also made unique for each page (i.e. "Your Tags" and "All Content" will have unique states).
- If the parent component passes in a specific order, that will be respected and will also become the new persisted value. One example is "Your Following", where it always starts at 'New'.
- Handling navigation history was a bit troublesome:
The test case:
   - Enter "Your Tags" (assume start at 'Trending')
   - Click 'New'
   - Click 'Top'
   - Back
   - Back (it should return to 'Trending')
As the top page history does not have any `?order=` value, we ended up with a no-op for the last Back. `orderParamEntry` is added to handle this, giving it a value to fall back to.