### PR TITLE
Precursor fixes to support #2669 ("Page does not restore to top when navigating new tags")

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -73,27 +73,34 @@ export default function ClaimList(props: Props) {
   }, [id, setScrollBottomCbMap]);
 
   useEffect(() => {
+    let timeout;
+
     function handleScroll(e) {
-      if (page && pageSize && onScrollBottom && !scrollBottomCbMap[page]) {
-        const mainElWrapper = document.querySelector(`.${MAIN_WRAPPER_CLASS}`);
+      timeout = setTimeout(() => {
+        if (page && pageSize && onScrollBottom && !scrollBottomCbMap[page]) {
+          const mainElWrapper = document.querySelector(`.${MAIN_WRAPPER_CLASS}`);
 
-        if (mainElWrapper && !loading && urisLength >= pageSize) {
-          const contentWrapperAtBottomOfPage = window.scrollY + window.innerHeight >= mainElWrapper.offsetHeight;
+          if (mainElWrapper && !loading && urisLength >= pageSize) {
+            const contentWrapperAtBottomOfPage = window.scrollY + window.innerHeight >= mainElWrapper.offsetHeight;
 
-          if (contentWrapperAtBottomOfPage) {
-            onScrollBottom();
+            if (contentWrapperAtBottomOfPage) {
+              onScrollBottom();
 
-            // Save that we've fetched this page to avoid weird stuff happening with fast scrolling
-            setScrollBottomCbMap({ ...scrollBottomCbMap, [page]: true });
+              // Save that we've fetched this page to avoid weird stuff happening with fast scrolling
+              setScrollBottomCbMap({ ...scrollBottomCbMap, [page]: true });
+            }
           }
         }
-      }
+      }, 150);
     }
 
     if (onScrollBottom) {
       window.addEventListener('scroll', handleScroll);
 
       return () => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
         window.removeEventListener('scroll', handleScroll);
       };
     }

--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -81,7 +81,8 @@ export default function ClaimList(props: Props) {
           const mainElWrapper = document.querySelector(`.${MAIN_WRAPPER_CLASS}`);
 
           if (mainElWrapper && !loading && urisLength >= pageSize) {
-            const contentWrapperAtBottomOfPage = window.scrollY + window.innerHeight >= mainElWrapper.offsetHeight;
+            const contentWrapperAtBottomOfPage =
+              mainElWrapper.getBoundingClientRect().bottom - 0.5 <= window.innerHeight;
 
             if (contentWrapperAtBottomOfPage) {
               onScrollBottom();

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -402,7 +402,12 @@ function ClaimListDiscover(props: Props) {
 
   function handleScrollBottom() {
     if (!loading && infiniteScroll) {
-      setPage(page + 1);
+      if (claimSearchResult && claimSearchResult.length % CS.PAGE_SIZE === 0) {
+        // Only increment the page if the current page is full. A partially-filled page probably
+        // indicates "no more search results" (at least based on my testing). Gating this prevents
+        // incrementing the page when scrolling upwards.
+        setPage(page + 1);
+      }
     }
   }
 


### PR DESCRIPTION
## PR Type
- [x] Bugfix
This serves as precursor fixes to support #2669 `Page does not restore to top when navigating new tags`.
Even if we don't end up fixing 2669, this PR fixes a few glitches with inf-scroll and improves the performance a bit.

For 2669, I have a general fix, but more corner-cases came up during test, so I did not include it in this PR.  Back to drawing board for that.

## Code changes
See the commit messages for the walk-through.