### PR TITLE
Pause 'Autoplay' when scrolled off screen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add "tap to unmute" button for videos that start with audio muted _community pr!_ ([#4365](https://github.com/lbryio/lbry-desktop/pull/4365))
 - Allow upgrade bar to be dismissed per session _community pr!_ ([#4413](https://github.com/lbryio/lbry-desktop/pull/4413))
+- Pause the "autoplay next" timer when performing long operations such as Tipping, Supporting or commenting _community pr!_ ([4419](https://github.com/lbryio/lbry-desktop/pull/4419))  
 - Email notification management page ([#4409](https://github.com/lbryio/lbry-desktop/pull/4409))
 
 ### Changed

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1198,6 +1198,8 @@
   "No information will be sent directly to LBRY, Inc. or third-parties about your usage. Note that as\n                peer-to-peer software, your IP address and potentially other system information can be sent to other\n                users, though this information is not stored permanently.": "No information will be sent directly to LBRY, Inc. or third-parties about your usage. Note that as\n                peer-to-peer software, your IP address and potentially other system information can be sent to other\n                users, though this information is not stored permanently.",
   "%view_count% Views": "%view_count% Views",
   "Tap to unmute": "Tap to unmute",
+  "Playing in %seconds_left% seconds...": "Playing in %seconds_left% seconds...",
+  "Autoplay timer paused.": "Autoplay timer paused.", 
   "0 Bytes": "0 Bytes",
   "Bytes": "Bytes",
   "KB": "KB",

--- a/ui/component/autoplayCountdown/index.js
+++ b/ui/component/autoplayCountdown/index.js
@@ -6,6 +6,7 @@ import { makeSelectIsPlayerFloating, makeSelectNextUnplayedRecommended } from 'r
 import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { doSetPlayingUri, doPlayUri } from 'redux/actions/content';
 import AutoplayCountdown from './view';
+import { selectModal } from 'redux/selectors/app';
 
 /*
 AutoplayCountdown does not fetch it's own next content to play, it relies on <RecommendedContent> being rendered. This is dumb but I'm just the guy who noticed
@@ -17,6 +18,7 @@ const select = (state, props) => {
     nextRecommendedClaim: makeSelectClaimForUri(nextRecommendedUri)(state),
     isFloating: makeSelectIsPlayerFloating(props.location)(state),
     autoplay: makeSelectClientSetting(SETTINGS.AUTOPLAY)(state),
+    modal: selectModal(state),
   };
 };
 

--- a/ui/component/autoplayCountdown/view.jsx
+++ b/ui/component/autoplayCountdown/view.jsx
@@ -13,6 +13,7 @@ type Props = {
   isFloating: boolean,
   doSetPlayingUri: (string | null) => void,
   doPlayUri: string => void,
+  modal: { id: string, modalProps: {} },
 };
 
 function AutoplayCountdown(props: Props) {
@@ -23,6 +24,7 @@ function AutoplayCountdown(props: Props) {
     doPlayUri,
     isFloating,
     history: { push },
+    modal,
   } = props;
   const nextTitle = nextRecommendedClaim && nextRecommendedClaim.value && nextRecommendedClaim.value.title;
 
@@ -32,6 +34,8 @@ function AutoplayCountdown(props: Props) {
   const [timer, setTimer] = React.useState(countdownTime);
   const [timerCanceled, setTimerCanceled] = React.useState(false);
   const [timerPaused, setTimerPaused] = React.useState(false);
+  const anyModalPresent = modal !== undefined && modal !== null;
+  const isTimerPaused = timerPaused || anyModalPresent;
 
   let navigateUrl;
   if (nextTitle) {
@@ -82,7 +86,7 @@ function AutoplayCountdown(props: Props) {
   React.useEffect(() => {
     let interval;
     if (!timerCanceled && nextRecommendedUri) {
-      if (timerPaused) {
+      if (isTimerPaused) {
         clearInterval(interval);
         setTimer(countdownTime);
       } else {
@@ -99,7 +103,7 @@ function AutoplayCountdown(props: Props) {
     return () => {
       clearInterval(interval);
     };
-  }, [timer, doNavigate, navigateUrl, push, timerCanceled, timerPaused, nextRecommendedUri]);
+  }, [timer, doNavigate, navigateUrl, push, timerCanceled, isTimerPaused, nextRecommendedUri]);
 
   if (timerCanceled || !nextRecommendedUri) {
     return null;
@@ -119,12 +123,12 @@ function AutoplayCountdown(props: Props) {
           <div className={'autoplay-countdown__button autoplay-countdown__button--' + (timer % 5)}>
             <Button onClick={doNavigate} iconSize={30} title={__('Play')} className="button--icon button--play" />
           </div>
-          {timerPaused && (
+          {isTimerPaused && (
             <div className="file-viewer__overlay-secondary autoplay-countdown__counter">
               {__('Autoplay timer paused.')}{' '}
             </div>
           )}
-          {!timerPaused && (
+          {!isTimerPaused && (
             <div className="file-viewer__overlay-secondary autoplay-countdown__counter">
               {__('Playing in %seconds_left% seconds...', { seconds_left: timer })}{' '}
               <Button label={__('Cancel')} button="link" onClick={() => setTimerCanceled(true)} />

--- a/ui/component/autoplayCountdown/view.jsx
+++ b/ui/component/autoplayCountdown/view.jsx
@@ -5,6 +5,10 @@ import UriIndicator from 'component/uriIndicator';
 import I18nMessage from 'component/i18nMessage';
 import { formatLbryUrlForWeb } from 'util/url';
 import { withRouter } from 'react-router';
+import debounce from 'util/debounce';
+
+const DEBOUNCE_SCROLL_HANDLER_MS = 150;
+const CLASSNAME_AUTOPLAY_COUNTDOWN = 'autoplay-countdown';
 
 type Props = {
   history: { push: string => void },
@@ -57,27 +61,13 @@ function AutoplayCountdown(props: Props) {
     }
   }, [navigateUrl, nextRecommendedUri, isFloating, doSetPlayingUri, doPlayUri]);
 
-  function debounce(fn, time) {
-    let timeoutId;
-    return wrapper;
-    function wrapper(...args) {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      timeoutId = setTimeout(() => {
-        timeoutId = null;
-        fn(...args);
-      }, time);
-    }
-  }
-
   React.useEffect(() => {
     const handleScroll = debounce(e => {
-      const elm = document.querySelector('.autoplay-countdown');
+      const elm = document.querySelector(`.${CLASSNAME_AUTOPLAY_COUNTDOWN}`);
       if (elm) {
         setTimerPaused(elm.getBoundingClientRect().top < 0);
       }
-    }, 150);
+    }, DEBOUNCE_SCROLL_HANDLER_MS);
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
@@ -111,7 +101,7 @@ function AutoplayCountdown(props: Props) {
 
   return (
     <div className="file-viewer__overlay">
-      <div className="autoplay-countdown">
+      <div className={CLASSNAME_AUTOPLAY_COUNTDOWN}>
         <div className="file-viewer__overlay-secondary">
           <I18nMessage tokens={{ channel: <UriIndicator link uri={nextRecommendedUri} /> }}>
             Up Next by %channel%


### PR DESCRIPTION
## PR Type
- [x] Bug   »   Fixes #4021 `Don't Allow Autoplay when commenting / taking other actions`

## Changes
- When the autoplay overlay gets partially off-screen, the timer will be stopped. We can tweak how much down it needs to be scrolled.
- When timer is paused, the countdown resets.
- The pausing mechanism has no effect on the floating player (since the 'top' can never go negative). This behavior is the same as another big video platform.
- Pause when any `Modal` is present.

## Aside
- Also present in `0.46.2`: I noticed that with the first video viewed from a fresh session, the timer takes a while to appear. (Update: seems like just need to scroll down for "Related"to load at least once).