### PR TITLE
Inf-scroll: fixes for 3071 and 4351

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -1,7 +1,7 @@
 // @flow
 import { MAIN_WRAPPER_CLASS } from 'component/app/view';
 import type { Node } from 'react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import classnames from 'classnames';
 import ClaimPreview from 'component/claimPreview';
 import Spinner from 'component/spinner';
@@ -50,7 +50,6 @@ export default function ClaimList(props: Props) {
     onScrollBottom,
     pageSize,
     page,
-    id,
     showHiddenByUser,
     showUnresolvedClaims,
     renderProperties,
@@ -60,7 +59,6 @@ export default function ClaimList(props: Props) {
     timedOutMessage,
     isCardBody = false,
   } = props;
-  const [scrollBottomCbMap, setScrollBottomCbMap] = useState({});
   const [currentSort, setCurrentSort] = usePersistedState(persistedStorageKey, SORT_NEW);
   const timedOut = uris === null;
   const urisLength = (uris && uris.length) || 0;
@@ -71,12 +69,8 @@ export default function ClaimList(props: Props) {
   }
 
   useEffect(() => {
-    setScrollBottomCbMap({});
-  }, [id, setScrollBottomCbMap]);
-
-  useEffect(() => {
     const handleScroll = debounce(e => {
-      if (page && pageSize && onScrollBottom && !scrollBottomCbMap[page]) {
+      if (page && pageSize && onScrollBottom) {
         const mainElWrapper = document.querySelector(`.${MAIN_WRAPPER_CLASS}`);
 
         if (mainElWrapper && !loading && urisLength >= pageSize) {
@@ -84,9 +78,6 @@ export default function ClaimList(props: Props) {
 
           if (contentWrapperAtBottomOfPage) {
             onScrollBottom();
-
-            // Save that we've fetched this page to avoid weird stuff happening with fast scrolling
-            setScrollBottomCbMap({ ...scrollBottomCbMap, [page]: true });
           }
         }
       }
@@ -96,7 +87,7 @@ export default function ClaimList(props: Props) {
       window.addEventListener('scroll', handleScroll);
       return () => window.removeEventListener('scroll', handleScroll);
     }
-  }, [loading, onScrollBottom, urisLength, pageSize, page, setScrollBottomCbMap]);
+  }, [loading, onScrollBottom, urisLength, pageSize, page]);
 
   return (
     <section

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -102,7 +102,7 @@ function ClaimListDiscover(props: Props) {
 
   const [page, setPage] = useState(1);
   const [forceRefresh, setForceRefresh] = useState();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = usePersistedState(`expanded-${location.pathname}`, false);
   const [orderParamEntry, setOrderParamEntry] = useState(CS.ORDER_BY_TRENDING);
   const [orderParamUser, setOrderParamUser] = usePersistedState(`orderUser-${location.pathname}`, CS.ORDER_BY_TRENDING);
   const followed = (followedTags && followedTags.map(t => t.name)) || [];
@@ -132,7 +132,9 @@ function ClaimListDiscover(props: Props) {
     );
 
   useEffect(() => {
-    if (isFiltered()) setExpanded(true);
+    if (history.action !== 'POP' && isFiltered()) {
+      setExpanded(true);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -296,9 +296,10 @@ function ClaimListDiscover(props: Props) {
   const claimSearchCacheQuery = createNormalizedClaimSearchKey(options);
   const claimSearchResult = claimSearchByQuery[claimSearchCacheQuery];
 
-  const [prevOptions, setPrevOptions] = useState(options);
+  const [prevOptions, setPrevOptions] = useState(null);
 
   if (!isJustScrollingToNewPage(prevOptions, options)) {
+    // --- New search, or search options changed.
     setPrevOptions(options);
 
     if (didNavigateForward) {
@@ -306,7 +307,7 @@ function ClaimListDiscover(props: Props) {
       window.scrollTo(0, 0); // Prevents onScrollBottom() from re-hitting while waiting for doClaimQuery():
       options.page = 1;
       setPage(options.page);
-    } else {
+    } else if (claimSearchResult) {
       // --- Update 'page' based on retrieved 'claimSearchResult'.
       options.page = Math.ceil(claimSearchResult.length / CS.PAGE_SIZE);
       if (options.page !== page) {
@@ -359,6 +360,11 @@ function ClaimListDiscover(props: Props) {
   // Returns true if the change in 'options' indicate that we are simply scrolling
   // down to a new page; false otherwise.
   function isJustScrollingToNewPage(prevOptions, options) {
+    if (!prevOptions) {
+      // It's a new search, or we just popped back from a different view.
+      return false;
+    }
+
     // Compare every field except for 'page' and 'release_time'.
     // There might be better ways to achieve this.
     let tmpPrevOptions = { ...prevOptions };


### PR DESCRIPTION
## (1) PR Type
- [x] Bugfix » Fixes #3071 `Infinite scroll stops working when navigating to file page / back`

<details>
<summary>Test case (<em>click to expand</em>)</summary>
<ol>
  <li>Search for a tag</li>
  <li>Scroll down to at least load one extra page</li>
  <li>Click on any claim in the list</li>
  <li>Click Back</li>
  <li>Scroll all the way down.  New pages aren't loaded</li>
</ol>
</details>  

## The Issue:
In the POP operation, the `page` value is back to 1 due to the initializer `useState(1)`. If the results cache already contained more than 1 page's worth, then the rest of the logic thinks there's nothing to do.

## The Fix:
Previous fixes to Inf-Scroll added a "page correction" code to handle the mismatch. This fix simply adds this scenario to the list of scenarios to perform the correction.

## Bonus:
Fixed improper debouncing code.

----
## (2) PR Type
- [x] Bugfix » Fixes #4351 `Infinite load won't work if the same sort option clicked`

<details>
<summary>Test case (<em>click to expand</em>)</summary>
1. Click Following<br>
2. Click New<br>
3. Scroll down to load at least 1 extra page.<br>
4. Go up and click New again.<br>
</details>  

## The Issue:
`scrollBottomCbMap[page]` in this case did not reset since the `id` remained the same.

## The Fix:
I don't know how else to notify the effect to run. Perhaps "when `page=1`" is one criteria, but I found that removing `scrollBottomCbMap` can also fix it.

I don't know what scenario that `scrollBottomCbMap` was originally meant to handle, so will need to depend of reviewer to confirm I did not break something else. This fix assumes that recent inf-scroll fixes and debouncing would have addressed the "weird stuff happening with fast scrolling" problem mentioned in the comments.