### PR TITLE
Option to remove abandoned claims from Blocked Channels page

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1201,7 +1201,7 @@
   "%view_count% Views": "%view_count% Views",
   "Tap to unmute": "Tap to unmute",
   "Playing in %seconds_left% seconds...": "Playing in %seconds_left% seconds...",
-  "Autoplay timer paused.": "Autoplay timer paused.", 
+  "Autoplay timer paused.": "Autoplay timer paused.",
   "0 Bytes": "0 Bytes",
   "Bytes": "Bytes",
   "KB": "KB",
@@ -1257,5 +1257,7 @@
   "Get notified when a publish or channel is confirmed.": "Get notified when a publish or channel is confirmed.",
   "Email Preferences": "Email Preferences",
   "Opt out of any topics you don't want to receive email about.": "Opt out of any topics you don't want to receive email about.",
-  "Uncheck your email below if you want to stop receiving messages.": "Uncheck your email below if you want to stop receiving messages."
+  "Uncheck your email below if you want to stop receiving messages.": "Uncheck your email below if you want to stop receiving messages.",
+  "Remove from Blocked List": "Remove from Blocked List",
+  "Are you sure you want to remove this from the list?": "Are you sure you want to remove this from the list?"
 }

--- a/ui/component/abandonedChannelPreview/index.js
+++ b/ui/component/abandonedChannelPreview/index.js
@@ -1,10 +1,14 @@
 import { connect } from 'react-redux';
+import { selectBlockedChannels } from 'lbry-redux';
 import { doChannelUnsubscribe } from 'redux/actions/subscriptions';
+import { doOpenModal } from 'redux/actions/app';
 import AbandonedChannelPreview from './view';
 
-export default connect(
-  null,
-  {
-    doChannelUnsubscribe,
-  }
-)(AbandonedChannelPreview);
+const select = (state, props) => ({
+  blockedChannelUris: selectBlockedChannels(state),
+});
+
+export default connect(select, {
+  doChannelUnsubscribe,
+  doOpenModal,
+})(AbandonedChannelPreview);

--- a/ui/component/abandonedChannelPreview/view.jsx
+++ b/ui/component/abandonedChannelPreview/view.jsx
@@ -5,6 +5,7 @@ import ChannelThumbnail from 'component/channelThumbnail';
 import Button from 'component/button';
 import { parseURI } from 'lbry-redux';
 import * as ICONS from '../../constants/icons';
+import * as MODALS from 'constants/modal_types';
 
 type SubscriptionArgs = {
   channelName: string,
@@ -15,11 +16,14 @@ type Props = {
   uri: string,
   doChannelUnsubscribe: SubscriptionArgs => void,
   type: string,
+  blockedChannelUris: Array<string>,
+  doOpenModal: (string, {}) => void,
 };
 
 function AbandonedChannelPreview(props: Props) {
-  const { uri, doChannelUnsubscribe, type } = props;
+  const { uri, doChannelUnsubscribe, type, blockedChannelUris, doOpenModal } = props;
   const { channelName } = parseURI(uri);
+  const isBlockedChannel = blockedChannelUris.includes(uri);
 
   return (
     <li className={classnames('claim-preview__wrapper', 'claim-preview__wrapper--notice')}>
@@ -33,20 +37,31 @@ function AbandonedChannelPreview(props: Props) {
             <div className="media__subtitle">{__(`This channel may have been unpublished.`)}</div>
           </div>
           <div className="claim-preview__actions">
+            {isBlockedChannel && (
+              <Button
+                iconColor="red"
+                icon={ICONS.UNBLOCK}
+                button={'alt'}
+                label={__('Unblock')}
+                onClick={() => doOpenModal(MODALS.REMOVE_BLOCKED, { blockedUri: uri })}
+              />
+            )}
             {/* SubscribeButton uses resolved permanentUri; modifying it didn't seem worth it. */}
-            <Button
-              iconColor="red"
-              icon={ICONS.UNSUBSCRIBE}
-              button={'alt'}
-              label={__('Unfollow')}
-              onClick={e => {
-                e.stopPropagation();
-                doChannelUnsubscribe({
-                  channelName: `@${channelName}`,
-                  uri,
-                });
-              }}
-            />
+            {!isBlockedChannel && (
+              <Button
+                iconColor="red"
+                icon={ICONS.UNSUBSCRIBE}
+                button={'alt'}
+                label={__('Unfollow')}
+                onClick={e => {
+                  e.stopPropagation();
+                  doChannelUnsubscribe({
+                    channelName: `@${channelName}`,
+                    uri,
+                  });
+                }}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/ui/constants/modal_types.js
+++ b/ui/constants/modal_types.js
@@ -41,3 +41,4 @@ export const REPOST = 'repost';
 export const SIGN_OUT = 'sign_out';
 export const LIQUIDATE_SUPPORTS = 'liquidate_supports';
 export const CONFIRM_AGE = 'confirm_age';
+export const REMOVE_BLOCKED = 'remove_blocked';

--- a/ui/modal/modalRemoveBlocked/index.js
+++ b/ui/modal/modalRemoveBlocked/index.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import { doHideModal } from 'redux/actions/app';
+import ModalRemoveBlocked from './view';
+import { doToggleBlockChannel, selectBlockedChannels } from 'lbry-redux';
+
+const select = (state, props) => ({
+  blockedChannels: selectBlockedChannels(state),
+});
+
+const perform = dispatch => ({
+  closeModal: () => dispatch(doHideModal()),
+  toggleBlockChannel: uri => dispatch(doToggleBlockChannel(uri)),
+});
+
+export default connect(select, perform)(ModalRemoveBlocked);

--- a/ui/modal/modalRemoveBlocked/view.jsx
+++ b/ui/modal/modalRemoveBlocked/view.jsx
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react';
+import { Modal } from 'modal/modal';
+import I18nMessage from 'component/i18nMessage';
+
+type Props = {
+  blockedUri: string,
+  closeModal: () => void,
+  blockedChannels: Array<string>,
+  toggleBlockChannel: (uri: string) => void,
+};
+
+function ModalRemoveBlocked(props: Props) {
+  const { blockedUri, closeModal, blockedChannels, toggleBlockChannel } = props;
+
+  function handleConfirm() {
+    if (blockedUri && blockedChannels.includes(blockedUri)) {
+      // DANGER: Always ensure the uri is actually in the list since we are using a
+      // toggle function. If 'null' is accidentally toggled INTO the list, the app
+      // won't start. Ideally, we should add a "removeBlockedChannel()", but with
+      // the gating above, it should be safe/good enough.
+      toggleBlockChannel(blockedUri);
+    }
+
+    closeModal();
+  }
+
+  return (
+    <Modal
+      isOpen
+      type="confirm"
+      title={__('Remove from Blocked List')}
+      confirmButtonLabel={__('Remove')}
+      onConfirmed={handleConfirm}
+      onAborted={() => closeModal()}
+    >
+      <em>{blockedUri}</em>
+      <p />
+      <p>
+        <I18nMessage>Are you sure you want to remove this from the list?</I18nMessage>
+      </p>
+    </Modal>
+  );
+}
+
+export default ModalRemoveBlocked;

--- a/ui/modal/modalRouter/view.jsx
+++ b/ui/modal/modalRouter/view.jsx
@@ -17,6 +17,7 @@ import ModalRevokeClaim from 'modal/modalRevokeClaim';
 import ModalPhoneCollection from 'modal/modalPhoneCollection';
 import ModalFirstSubscription from 'modal/modalFirstSubscription';
 import ModalConfirmTransaction from 'modal/modalConfirmTransaction';
+import ModalRemoveBlocked from 'modal/modalRemoveBlocked';
 import ModalSocialShare from 'modal/modalSocialShare';
 import ModalSendTip from 'modal/modalSendTip';
 import ModalPublish from 'modal/modalPublish';
@@ -140,6 +141,8 @@ function ModalRouter(props: Props) {
       return <ModalFileSelection {...modalProps} />;
     case MODALS.LIQUIDATE_SUPPORTS:
       return <ModalSupportsLiquidate {...modalProps} />;
+    case MODALS.REMOVE_BLOCKED:
+      return <ModalRemoveBlocked {...modalProps} />;
     default:
       return null;
   }

--- a/ui/page/listBlocked/view.jsx
+++ b/ui/page/listBlocked/view.jsx
@@ -18,6 +18,7 @@ function ListBlocked(props: Props) {
           persistedStorageKey="block-list-published"
           uris={uris}
           defaultSort
+          showUnresolvedClaims
           showHiddenByUser
         />
       ) : (


### PR DESCRIPTION
## Fixes:
Fixes #3800 `allow unfollow / unblock of abandoned or blocked content`

## Changes:
If the `ClaimPreview` is in the Blocked Page, and if the claim itself is invalid, show a button to remove it from the blocked list.

![image](https://user-images.githubusercontent.com/64950861/85609195-6ab0ca80-b688-11ea-9601-e693563f8db4.png)

## Notes:
- I do not know if this change covers the DMCA part of #3800 or not since I don't see any special handling for DMCA'd claims in the code to emulate it.  I assume `!claim` does cover that scenario; if not, I'll might need LBRY to DMCA one of my claims for testing.
- This change involves altering the wallet, so extra testing would be good.
- Making `ClaimPreview` specifically check if it's in the `PAGES.BLOCKED` does feels a bit dirty, but I opted for this as it's cleaner compared to passing the info down 2 layers through `props`.
```
List Blocked
    ClaimList
        ClaimPreview
```