### PR TITLE
Fix language-change not applied to all components immediately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix report page layout ([#4384](https://github.com/lbryio/lbry-desktop/pull/4384))
+- Fix language-change not applied to components immediately _community pr!_ ([#4437](https://github.com/lbryio/lbry-desktop/pull/4437))
 
 ## [0.46.2] - [2020-06-10]
 

--- a/ui/component/wunderbar/index.js
+++ b/ui/component/wunderbar/index.js
@@ -6,7 +6,9 @@ import {
   selectSearchValue,
   selectSearchSuggestions,
   selectSearchBarFocused,
+  SETTINGS,
 } from 'lbry-redux';
+import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { doToast } from 'redux/actions/notifications';
 import analytics from 'analytics';
 import Wunderbar from './view';
@@ -17,6 +19,7 @@ const select = state => ({
   suggestions: selectSearchSuggestions(state),
   searchQuery: selectSearchValue(state),
   isFocused: selectSearchBarFocused(state),
+  language: makeSelectClientSetting(SETTINGS.LANGUAGE)(state),
 });
 
 const perform = (dispatch, ownProps) => ({

--- a/ui/page/settings/index.js
+++ b/ui/page/settings/index.js
@@ -46,6 +46,7 @@ const select = state => ({
   darkModeTimes: makeSelectClientSetting(SETTINGS.DARK_MODE_TIMES)(state),
   ffmpegStatus: selectFfmpegStatus(state),
   findingFFmpeg: selectFindingFFmpeg(state),
+  language: makeSelectClientSetting(SETTINGS.LANGUAGE)(state),
 });
 
 const perform = dispatch => ({

--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -87,6 +87,7 @@ type Props = {
   findingFFmpeg: boolean,
   findFFmpeg: () => void,
   openModal: string => void,
+  language?: string,
 };
 
 type State = {
@@ -246,6 +247,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
       clearCache,
       findingFFmpeg,
       openModal,
+      language,
     } = this.props;
     const { storedPassword } = this.state;
     const noDaemonSettings = !daemonSettings || Object.keys(daemonSettings).length === 0;
@@ -277,7 +279,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
                   ? __("To enable this feature, check 'Save Password' the next time you start the app.")
                   : null
               }
-              actions={<SyncToggle disabled={walletEncrypted && !storedPassword} />}
+              actions={<SyncToggle language={language} disabled={walletEncrypted && !storedPassword} />}
             />
             <Card
               title={__('Download Directory')}
@@ -353,6 +355,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
 
                   {!disableMaxKeyFee && (
                     <FormFieldPrice
+                      language={language}
                       name="max_key_fee"
                       min={0}
                       onChange={this.onKeyFeeChange}
@@ -791,7 +794,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
 
             {/* @if TARGET='app' */}
             {/* Auto launch in a hidden state doesn't work on mac https://github.com/Teamwork/node-auto-launch/issues/81 */}
-            {!IS_MAC && <Card title={__('Startup Preferences')} actions={<SettingAutoLaunch />} />}
+            {!IS_MAC && <Card title={__('Startup Preferences')} actions={<SettingAutoLaunch language={language} />} />}
             {/* @endif */}
 
             <Card


### PR DESCRIPTION
## Fixes:
Fixes #3641 `Language switch does not take effect right away`

## Assessment:
Although `Card`s in the Settings Page are actually being re-rendered, the `actions` within them might not be getting the signal or have anything to update, depending on their props.

## Changes:
(1) Pass the language variable to the `actions`'s props for items that are affected.
(2) Make the Wunderbar listen to language-changes as well (the only component outside of Settings that would need an immediate update).

## Comments:
- The fix does feel a bit like a whack-a-mole instead of a systematic global update, but it's only a handful of components that need an update anyway; plus it's no worse than existing version, performance-wise.

## Aside:
- Before this PR, I noticed the `SettingsPage` seems to be re-rendered every 5 seconds, whether a change happened or not.