### PR TITLE
Fix incorrect creator status shown when navigating between channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix report page layout ([#4384](https://github.com/lbryio/lbry-desktop/pull/4384))
 - Fix language-change not applied to components immediately _community pr!_ ([#4437](https://github.com/lbryio/lbry-desktop/pull/4437))
+- Fix incorrect creator status shown when navigating between channels _community pr!_ ([#4438](https://github.com/lbryio/lbry-desktop/pull/4438))
 
 ## [0.46.2] - [2020-06-10]
 

--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -110,6 +110,8 @@ function ChannelPage(props: Props) {
     Lbryio.call('yt', 'get_youtuber', { channel_claim_id: claimId }).then(response => {
       if (response.is_verified_youtuber) {
         setLastYtSyncDate(response.last_synced);
+      } else {
+        setLastYtSyncDate(undefined);
       }
     });
   }, [claimId]);


### PR DESCRIPTION
Fixes #3750 `refresh youtube creator status when switching between channels`
