### PR TITLE
Fix "Notification" page button being incorrectly disabled by 0 blocked channels

### DIFF
--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -492,7 +492,6 @@ class SettingsPage extends React.PureComponent<Props, State> {
                         button="secondary"
                         label={__('Manage')}
                         icon={ICONS.SETTINGS}
-                        disabled={userBlockedChannelsCount === 0}
                         navigate={`/$/${PAGES.SETTINGS_NOTIFICATIONS}`}
                       />
                     </div>


### PR DESCRIPTION
- Fixes #4447 `Notifications and Blocked "Manage" button doesn't work with 0 blocked channels`
- I skipped the second bullet point -- no strong arguments for either way.
