### PR TITLE
Refresh on publish page does not have loading indicator

### DIFF
--- a/ui/page/fileListPublished/view.jsx
+++ b/ui/page/fileListPublished/view.jsx
@@ -63,12 +63,15 @@ function FileListPublished(props: Props) {
             title={__('Publishes')}
             titleActions={
               <div className="card__actions--inline">
-                <Button
-                  button="alt"
-                  label={__('Refresh')}
-                  icon={ICONS.REFRESH}
-                  onClick={() => fetchClaimListMine(params.page, params.page_size)}
-                />
+                {fetching && <Spinner type="small" />}
+                {!fetching && (
+                  <Button
+                    button="alt"
+                    label={__('Refresh')}
+                    icon={ICONS.REFRESH}
+                    onClick={() => fetchClaimListMine(params.page, params.page_size)}
+                  />
+                )}
                 <Button
                   icon={ICONS.PUBLISH}
                   button="secondary"


### PR DESCRIPTION
## Fixes:
Fixes #4214 `Refresh on publish page does not have loading indicator`

## Approach:
`ClaimList` currently only shows the loading indicator if there is a header. We could make the indicator always appear at the top of the list when `loading=true`, but that would be the list jump up and down as the indicator appears/dissapears. I assume that is too distracting and is the reason why it was not made that way in the first place.

Show the indicator in place of the Refresh button while fetching instead.

## Issues:
- [ ] I couldn't figure out why the indicator doesn't appear in mobile.  Something in  `card__actions--inline` or inherited is making it not appear. 
