### PR TITLE
[mobile] show "time left/progress" on video player bar

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -339,6 +339,24 @@
   }
 }
 
+.video-js:not(.vjs-fullscreen).vjs-layout-small {
+  .vjs-current-time {
+    display: flex;
+    padding-left: 0.5em;
+    padding-right: 0;
+  }
+
+  .vjs-time-divider {
+    display: flex;
+  }
+
+  .vjs-duration {
+    display: flex;
+    padding-left: 0;
+    padding-right: 0.5em;
+  }
+}
+
 .video-js:hover {
   .vjs-big-play-button {
     background-color: var(--color-primary);


### PR DESCRIPTION
## Fixes:
Fixes #4220 `[moble] show time left / progress on video player bar`

## Changes:
For `vjs-layout-small`, there is still space to display the said controls. This layout covers devices like Galaxy S5 up to Nexus 6P.

For layouts smaller that that (e.g. 'vjs-layout-xsmall'), they will remain hidden.

![image](https://user-images.githubusercontent.com/64950861/86162104-df7c7c80-bb40-11ea-9a30-7ad201bc23e5.png)
