### PR TITLE
Put LBC amount with 4 precision on tip menu for all versions

### DIFF
--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -238,11 +238,9 @@ function WalletSendTip(props: Props) {
                       label={
                         <React.Fragment>
                           {__('Custom support amount')}{' '}
-                          {isMobile && (
-                            <I18nMessage tokens={{ lbc_balance: <CreditAmount badge={false} amount={balance} /> }}>
+                            <I18nMessage tokens={{ lbc_balance: <CreditAmount badge={false} precision={4} amount={balance} /> }}>
                               (%lbc_balance% available)
                             </I18nMessage>
-                          )}
                         </React.Fragment>
                       }
                       className="form-field--price-amount"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: Small change

## Fixes

Issue Number: closes #4081 

## What is the current behavior?
The only balance seen is in the top right corner which has only 2 levels of precision.
## What is the new behavior?
I added 4 levels of precision to all devices with the balance and not just 2 levels on precision with the balance on mobile.
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
