### PR TITLE
Fix video transcode setting not reflected correctly (MP3 incorrectly transcoded to MP4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow upgrade bar to be dismissed per session _community pr!_ ([#4413](https://github.com/lbryio/lbry-desktop/pull/4413))
 - Pause the "autoplay next" timer when performing long operations such as Tipping, Supporting or commenting _community pr!_ ([4419](https://github.com/lbryio/lbry-desktop/pull/4419))  
 - Email notification management page ([#4409](https://github.com/lbryio/lbry-desktop/pull/4409))
-- Publish Page improvements to prevent accidental overwrites of existing claims _community pr!_ ([#4461](https://github.com/lbryio/lbry-desktop/pull/4416))
+- Publish Page improvements to prevent accidental overwrites of existing claims _community pr!_ ([#4416](https://github.com/lbryio/lbry-desktop/pull/4416))
+- Option to remove abandoned claims from Blocked Channels page _community pr!_ ([#4433](https://github.com/lbryio/lbry-desktop/pull/4433))
 
 ### Changed
 
@@ -22,7 +23,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix report page layout ([#4384](https://github.com/lbryio/lbry-desktop/pull/4384))
 - Fix language-change not applied to components immediately _community pr!_ ([#4437](https://github.com/lbryio/lbry-desktop/pull/4437))
+- Fix scenarios where new search results are not appearing when scrolled to the bottom _community pr!_ ([4424](https://github.com/lbryio/lbry-desktop/pull/4424))
 - Fix incorrect creator status shown when navigating between channels _community pr!_ ([#4438](https://github.com/lbryio/lbry-desktop/pull/4438))
+- Fix unresolved translations in the Splash Screen _community pr!_ ([#4440](https://github.com/lbryio/lbry-desktop/pull/4440))
+- Fix Notification page button being incorrectly disabled by 0 blocked channels _community pr!_ ([#4449](https://github.com/lbryio/lbry-desktop/pull/4449))
+- Fix "Refresh" on Publish page not showing the loading indicator when pressed _community pr!_ ([#4451](https://github.com/lbryio/lbry-desktop/pull/4451))
+- Fix video duration not appearing on Mobile with enough width _community pr!_ ([#4452](https://github.com/lbryio/lbry-desktop/pull/4452))
+- Fix video transcode setting not reflected correctly (MP3 incorrectly transcoded to MP4) _community pr!_ ([#4458](https://github.com/lbryio/lbry-desktop/pull/4458))
+- Fix search results not appearing when scrolling due to long Tags or Following list in the navigation bar _community pr!_  ([#4465](https://github.com/lbryio/lbry-desktop/pull/4465))
 
 ## [0.46.2] - [2020-06-10]
 

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -7,7 +7,8 @@ import Button from 'component/button';
 import Card from 'component/common/card';
 import { FormField } from 'component/common/form';
 import Spinner from 'component/spinner';
-import I18nMessage from '../i18nMessage';
+import I18nMessage from 'component/i18nMessage';
+import usePersistedState from 'effects/use-persisted-state';
 
 type Props = {
   name: ?string,
@@ -48,6 +49,8 @@ function PublishFile(props: Props) {
   const ffmpegAvail = ffmpegStatus.available;
   const [oversized, setOversized] = useState(false);
   const [currentFile, setCurrentFile] = useState(null);
+  const [optimizeAvail, setOptimizeAvail] = useState(false);
+  const [userOptimize, setUserOptimize] = usePersistedState('publish-file-user-optimize', false);
 
   const RECOMMENDED_BITRATE = 6000000;
   const TV_PUBLISH_SIZE_LIMIT: number = 1073741824;
@@ -72,6 +75,14 @@ function PublishFile(props: Props) {
       }
     }
   }, [filePath, currentFile, handleFileChange, updateFileInfo]);
+
+  useEffect(() => {
+    const isOptimizeAvail = currentFile && currentFile !== '' && isVid && ffmpegAvail;
+    const finalOptimizeState = isOptimizeAvail && userOptimize;
+
+    setOptimizeAvail(isOptimizeAvail);
+    updatePublishForm({ optimize: finalOptimizeState });
+  }, [filePath, isVid, ffmpegAvail, userOptimize]);
 
   function updateFileInfo(duration, size, isvid) {
     updatePublishForm({ fileDur: duration, fileSize: size, fileVid: isvid });
@@ -266,9 +277,9 @@ function PublishFile(props: Props) {
           {/* @if TARGET='app' */}
           <FormField
             type="checkbox"
-            checked={isVid && ffmpegAvail && optimize}
-            disabled={!isVid || !ffmpegAvail}
-            onChange={e => updatePublishForm({ optimize: e.target.checked })}
+            checked={userOptimize}
+            disabled={!optimizeAvail}
+            onChange={() => setUserOptimize(!userOptimize)}
             label={__('Optimize and transcode video')}
             name="optimize"
           />

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -45,7 +45,7 @@ function PublishFile(props: Props) {
     isVid,
   } = props;
 
-  const { available } = ffmpegStatus;
+  const ffmpegAvail = ffmpegStatus.available;
   const [oversized, setOversized] = useState(false);
   const [currentFile, setCurrentFile] = useState(null);
 
@@ -64,16 +64,16 @@ function PublishFile(props: Props) {
     if (!filePath || filePath === '') {
       setCurrentFile('');
       setOversized(false);
-      updateOptimizeState(0, 0, false);
+      updateFileInfo(0, 0, false);
     } else if (typeof filePath !== 'string') {
       // Update currentFile file
       if (filePath.name !== currentFile && filePath.path !== currentFile) {
         handleFileChange(filePath);
       }
     }
-  }, [filePath, currentFile, handleFileChange, updateOptimizeState]);
+  }, [filePath, currentFile, handleFileChange, updateFileInfo]);
 
-  function updateOptimizeState(duration, size, isvid) {
+  function updateFileInfo(duration, size, isvid) {
     updatePublishForm({ fileDur: duration, fileSize: size, fileVid: isvid });
   }
 
@@ -100,7 +100,7 @@ function PublishFile(props: Props) {
   function getUnitsForMB(s) {
     if (s < MINUTES_THRESHOLD) {
       if (secondsToProcess > 1) return __('seconds');
-	return __('second');
+      return __('second');
     } else if (s >= MINUTES_THRESHOLD && s < HOURS_THRESHOLD) {
       if (Math.floor(secondsToProcess / 60) > 1) return __('minutes');
       return __('minute');
@@ -195,15 +195,15 @@ function PublishFile(props: Props) {
         const video = document.createElement('video');
         video.preload = 'metadata';
         video.onloadedmetadata = function() {
-          updateOptimizeState(video.duration, file.size, isVideo);
+          updateFileInfo(video.duration, file.size, isVideo);
           window.URL.revokeObjectURL(video.src);
         };
         video.onerror = function() {
-          updateOptimizeState(0, file.size, isVideo);
+          updateFileInfo(0, file.size, isVideo);
         };
         video.src = window.URL.createObjectURL(file);
       } else {
-        updateOptimizeState(0, file.size, isVideo);
+        updateFileInfo(0, file.size, isVideo);
       }
     }
 
@@ -266,13 +266,13 @@ function PublishFile(props: Props) {
           {/* @if TARGET='app' */}
           <FormField
             type="checkbox"
-            checked={isVid && available && optimize}
-            disabled={!isVid || !available}
+            checked={isVid && ffmpegAvail && optimize}
+            disabled={!isVid || !ffmpegAvail}
             onChange={e => updatePublishForm({ optimize: e.target.checked })}
             label={__('Optimize and transcode video')}
             name="optimize"
           />
-          {!available && (
+          {!ffmpegAvail && (
             <p className="help">
               <I18nMessage
                 tokens={{
@@ -283,7 +283,7 @@ function PublishFile(props: Props) {
               </I18nMessage>
             </p>
           )}
-          {Boolean(size) && available && optimize && isVid && (
+          {Boolean(size) && ffmpegAvail && optimize && isVid && (
             <p className="help">
               <I18nMessage
                 tokens={{


### PR DESCRIPTION
## Issue
Fixes #4332 `Video transcode setting not reflected correctly (MP3 incorrectly transcoded to MP4)`

2 issues here:
(1) The checkbox is mixing between user state and logic state.
(2) The variables (e.g. `optimize`, `isVid`, `filePath`, etc) will have values from the previous operation when you enter Publish Page, so GUI issues beyond Transcode can be also produced (e.g. transcode appearing for a image file)

## Changes
The "Transcode" checkbox state (checked vs. unchecked) will now reflect the user's desire and will be a persisted state. Whether or not this setting is used will be reflected by the checkbox's grayed-out state (i.e. it can be checked for non videos, but it will be grayed out).