### PR TITLE
Allow entering Blocked Page even for 0 blocked channels.

### DIFF
--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -513,7 +513,6 @@ class SettingsPage extends React.PureComponent<Props, State> {
                         button="secondary"
                         label={__('Manage')}
                         icon={ICONS.SETTINGS}
-                        disabled={userBlockedChannelsCount === 0}
                         navigate={`/$/${PAGES.BLOCKED}`}
                       />
                     </div>


### PR DESCRIPTION
Issue #4447 (item 2)

>Notifications and Blocked Manage button doesn't work with 0 blocked channels.
>
>- The former should work regardless of blocked channel count?
> - **The latter is technically correct, but no harm to just enter the page since it will show a When you block a channel, all content from that channel will be hidden. message which seems useful for beginners?**

