### PR TITLE
Inf-scroll: Change region to 'main' to ignore long tag/following list.

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { MAIN_WRAPPER_CLASS } from 'component/app/view';
+import { MAIN_CLASS } from 'component/page/view';
 import type { Node } from 'react';
 import React, { useEffect } from 'react';
 import classnames from 'classnames';
@@ -71,10 +71,10 @@ export default function ClaimList(props: Props) {
   useEffect(() => {
     const handleScroll = debounce(e => {
       if (page && pageSize && onScrollBottom) {
-        const mainElWrapper = document.querySelector(`.${MAIN_WRAPPER_CLASS}`);
+        const mainEl = document.querySelector(`.${MAIN_CLASS}`);
 
-        if (mainElWrapper && !loading && urisLength >= pageSize) {
-          const contentWrapperAtBottomOfPage = mainElWrapper.getBoundingClientRect().bottom - 0.5 <= window.innerHeight;
+        if (mainEl && !loading && urisLength >= pageSize) {
+          const contentWrapperAtBottomOfPage = mainEl.getBoundingClientRect().bottom - 0.5 <= window.innerHeight;
 
           if (contentWrapperAtBottomOfPage) {
             onScrollBottom();


### PR DESCRIPTION
## Issue:
Fixes #2789 `Infinite scrolling should activate at end of listed claims, not subscription list`

I believe it also closes #2957 `scroll restoration issues when tags/sub list longer than page`.  Looks to be working, and any quirks with `Back` will be a common (existing) one that is unrelated to extended Tag/Following size.

## Remarks:
If you press `End` on the keyboard, you'll go to the bottom but only 1 extra page will be loaded.  If you scroll back up slowly, inf-scroll will continue to load one page at a time.  I think this is arguably a better behavior than trying to load all the way to the bottom in one-shot;  it's laggy enough as it is.