### PR TITLE
Translation - Un hardcoded price filter label options

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1289,5 +1289,7 @@
   "Cover Image": "Cover Image",
   "You Followed Your First Channel!": "You Followed Your First Channel!",
   "Awesome! You just followed your first first channel.": "Awesome! You just followed your first first channel.",
-  "After submitting, it will take a few minutes for your changes to be live for everyone.": "After submitting, it will take a few minutes for your changes to be live for everyone."
+  "After submitting, it will take a few minutes for your changes to be live for everyone.": "After submitting, it will take a few minutes for your changes to be live for everyone.",
+  "Anything": "Anything",
+  "Paid": "Paid"
 }

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -703,9 +703,9 @@ function ClaimListDiscover(props: Props) {
                     })
                   }
                 >
-                  <option value={CS.FEE_AMOUNT_ANY}>Anything</option>
-                  <option value={CS.FEE_AMOUNT_ONLY_FREE}>Free</option>
-                  <option value={CS.FEE_AMOUNT_ONLY_PAID}>Paid</option>
+                  <option value={CS.FEE_AMOUNT_ANY}>{__('Anything')}</option>
+                  <option value={CS.FEE_AMOUNT_ONLY_FREE}>{__('Free')}</option>
+                  <option value={CS.FEE_AMOUNT_ONLY_PAID}>{__('Paid')}</option>
                   ))}
                 </FormField>
               </div>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [X] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: No issue exists yet (introduced by #4218 thought)

## What is the current behavior?

The claimListDiscover contains an option to filter out on prices. The text visible to the end user for options are currently hard-coded and don't use the i18 translation method. (Untranslated: Anything, Paid and Free)

## What is the new behavior?

Will be translated

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
