### PR TITLE
Normalize email place holder value

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -550,7 +550,6 @@
   "Go Back": "Go Back",
   "Sign In To LBRY": "Sign In To LBRY",
   "Create a new account or sign in.": "Create a new account or sign in.",
-  "hotstuff_96@hotmail.com": "hotstuff_96@hotmail.com",
   "Terms of Service": "Terms of Service",
   "Learn More": "Learn More",
   "Confirm Your Email": "Confirm Your Email",

--- a/ui/component/userEmailNew/view.jsx
+++ b/ui/component/userEmailNew/view.jsx
@@ -97,7 +97,7 @@ function UserEmailNew(props: Props) {
             <Form onSubmit={handleSubmit} className="section">
               <FormField
                 autoFocus
-                placeholder={__('hotstuff_96@hotmail.com')}
+                placeholder={__('yourstruly@example.com')}
                 type="email"
                 name="sign_up_email"
                 label={__('Email')}

--- a/ui/component/userEmailReturning/view.jsx
+++ b/ui/component/userEmailReturning/view.jsx
@@ -77,7 +77,7 @@ function UserEmailReturning(props: Props) {
               <Form onSubmit={handleSubmit} className="section">
                 <FormField
                   autoFocus={!emailExistsFromUrl}
-                  placeholder={__('hotstuff_96@hotmail.com')}
+                  placeholder={__('yourstruly@example.com')}
                   type="email"
                   id="username"
                   autoComplete="on"

--- a/ui/component/userPasswordReset/view.jsx
+++ b/ui/component/userPasswordReset/view.jsx
@@ -68,7 +68,7 @@ function UserPasswordReset(props: Props) {
               <FormField
                 autoFocus
                 disabled={passwordResetSuccess}
-                placeholder={__('hotstuff_96@hotmail.com')}
+                placeholder={__('yourstruly@example.com')}
                 type="email"
                 name="sign_in_email"
                 id="username"


### PR DESCRIPTION
#3886 
 PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [X] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: None

## What is the current behavior?

Some email place-holders use `hotstuff_96@hotmail.com` and there is also one case where it was `yourstruly@example.com`.

The `yourstruly@example.com` is probably more neutral so I keep it.

## What is the new behavior?

All `hotstuff_96@hotmail.com` references are now `yourstruly@example.com`

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
