### PR TITLE
Translation - Unhardcode selectAsset options & placeholder

### DIFF
--- a/ui/component/selectAsset/view.jsx
+++ b/ui/component/selectAsset/view.jsx
@@ -66,10 +66,10 @@ function SelectAsset(props: Props) {
           label={__(assetName + ' source')}
         >
           <option key={'lmmnop'} value={'url'}>
-            URL
+            {__('URL')}
           </option>
           <option key={'lmmnopq'} value={'upload'}>
-            UPLOAD
+          {__('UPLOAD')}
           </option>
         </FormField>
         {assetSource === SOURCE_UPLOAD && (


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [X] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: None yet

## What is the current behavior?

In the selectAsset control (aka: when you are editing your channel) the thumbnail source and cover source select box display URL and UPLOAD to the end user. Unfortunatly they don't use use i18 translation.

## What is the new behavior?

URL and UPLOAD option are now translated

## Other information

I'm waiting for an answer on a change https://github.com/lbryio/lbry-desktop/commit/9a6f2a19756d3be211856d2bb1e88327e2ff4b51#r40337221 that remove a translation on the URL placeholder. I think it should be translated as well and this PR will contains it if possible.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
