### PR TITLE
rewards redirect fix for manually approved users

### DIFF
--- a/ui/page/rewards/view.jsx
+++ b/ui/page/rewards/view.jsx
@@ -32,8 +32,15 @@ type Props = {
 
 class RewardsPage extends PureComponent<Props> {
   componentDidMount() {
-    this.props.fetchRewards();
+    const { user, fetchUser, fetchRewards } = this.props;
+    const rewardsApproved = user && user.is_reward_approved;
+
+    fetchRewards();
+    if (!rewardsApproved) {
+      fetchUser();
+    }
   }
+
   renderPageHeader() {
     const { user, daemonSettings, fetchUser } = this.props;
     const rewardsEnabled = IS_WEB || (daemonSettings && daemonSettings.share_usage_data);

--- a/ui/page/rewardsVerify/index.js
+++ b/ui/page/rewardsVerify/index.js
@@ -1,4 +1,9 @@
 import { connect } from 'react-redux';
-import AuthPage from './view';
+import { selectUser } from 'redux/selectors/user';
+import RewardsVerifyPage from './view';
 
-export default connect(null, null)(AuthPage);
+const select = state => ({
+  user: selectUser(state),
+});
+
+export default connect(select, null)(RewardsVerifyPage);

--- a/ui/page/rewardsVerify/view.jsx
+++ b/ui/page/rewardsVerify/view.jsx
@@ -4,8 +4,20 @@ import UserVerify from 'component/userVerify';
 import Page from 'component/page';
 import { useHistory } from 'react-router-dom';
 
-function RewardsVerifyPage() {
+type Props = {
+  user: ?User,
+};
+
+function RewardsVerifyPage(props: Props) {
+  const { user } = props;
   const { goBack } = useHistory();
+  const rewardsApproved = user && user.is_reward_approved;
+
+  React.useEffect(() => {
+    if (rewardsApproved) {
+      goBack();
+    }
+  }, [rewardsApproved]);
 
   return (
     <Page>


### PR DESCRIPTION
Makes sure the "refresh" button works properly for users that are manually approved. Also calls `user/me` for non-reward approved users on the rewards page so it updates automatically if they have been manually approved while they were using the app.