### PR TITLE
Patch for "7839bbf2: Fix language-change not applied to all components immediately"

### DIFF
--- a/ui/component/settingAccountPassword/index.js
+++ b/ui/component/settingAccountPassword/index.js
@@ -1,13 +1,16 @@
 import { connect } from 'react-redux';
 import { selectUser, selectPasswordSetSuccess, selectPasswordSetError } from 'redux/selectors/user';
+import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { doUserPasswordSet, doClearPasswordEntry } from 'redux/actions/user';
 import { doToast } from 'redux/actions/notifications';
 import UserSignIn from './view';
+import * as SETTINGS from 'constants/settings';
 
 const select = state => ({
   user: selectUser(state),
   passwordSetSuccess: selectPasswordSetSuccess(state),
   passwordSetError: selectPasswordSetError(state),
+  language: makeSelectClientSetting(SETTINGS.LANGUAGE)(state),
 });
 
 export default connect(select, {

--- a/ui/component/settingAutoLaunch/index.js
+++ b/ui/component/settingAutoLaunch/index.js
@@ -7,6 +7,7 @@ import SettingAutoLaunch from './view';
 
 const select = state => ({
   autoLaunch: makeSelectClientSetting(SETTINGS.AUTO_LAUNCH)(state),
+  language: makeSelectClientSetting(SETTINGS.LANGUAGE)(state),
 });
 
 const perform = dispatch => ({

--- a/ui/component/syncToggle/index.js
+++ b/ui/component/syncToggle/index.js
@@ -10,6 +10,7 @@ const select = state => ({
   syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
   verifiedEmail: selectUserVerifiedEmail(state),
   getSyncError: selectGetSyncErrorMessage(state),
+  language: makeSelectClientSetting(SETTINGS.LANGUAGE)(state),
 });
 
 const perform = dispatch => ({

--- a/ui/page/settings/view.jsx
+++ b/ui/page/settings/view.jsx
@@ -279,7 +279,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
                   ? __("To enable this feature, check 'Save Password' the next time you start the app.")
                   : null
               }
-              actions={<SyncToggle language={language} disabled={walletEncrypted && !storedPassword} />}
+              actions={<SyncToggle disabled={walletEncrypted && !storedPassword} />}
             />
             <Card
               title={__('Download Directory')}
@@ -792,7 +792,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
 
             {/* @if TARGET='app' */}
             {/* Auto launch in a hidden state doesn't work on mac https://github.com/Teamwork/node-auto-launch/issues/81 */}
-            {!IS_MAC && <Card title={__('Startup Preferences')} actions={<SettingAutoLaunch language={language} />} />}
+            {!IS_MAC && <Card title={__('Startup Preferences')} actions={<SettingAutoLaunch />} />}
             {/* @endif */}
 
             <Card


### PR DESCRIPTION
Patch for `7839bbf2: Fix language-change not applied to all components immediately`

- Missed the "Account Password" card that is used for authenticated case.
- For cards that are only used in Settings, listen to the language change in "select" instead of passing it in as a prop. I think this is cleaner.