### PR TITLE
Fix unmuted state lost or reverted when playing a new video.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix video duration not appearing on Mobile with enough width _community pr!_ ([#4452](https://github.com/lbryio/lbry-desktop/pull/4452))
 - Fix video transcode setting not reflected correctly (MP3 incorrectly transcoded to MP4) _community pr!_ ([#4458](https://github.com/lbryio/lbry-desktop/pull/4458))
 - Fix search results not appearing when scrolling due to long Tags or Following list in the navigation bar _community pr!_ ([#4465](https://github.com/lbryio/lbry-desktop/pull/4465))
+- Fix unmuted state lost or reverted when playing a new video _community pr!_ ([#4483](https://github.com/lbryio/lbry-desktop/pull/4483))
 
 ## [0.46.2] - [2020-06-10]
 

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -171,10 +171,8 @@ function VideoViewer(props: Props) {
         }
       });
       player.on('volumechange', () => {
-        if (player && player.volume() !== volume) {
+        if (player) {
           changeVolume(player.volume());
-        }
-        if (player && player.muted() !== muted) {
           changeMute(player.muted());
         }
       });


### PR DESCRIPTION
## Issue
Fixes #4460 `unmuted state lost / reverted`

1. Play a video.
2. Press mute.
3. Drag the volume bar to unmute.
4. Play a new video --> the video starts muted.

## Fix
The `volumechange` handler was comparing against stale variables, so there are times where the state was not saved. Just save both `muted` and `volume` without additional gating (the gating is probably unnecessary in the first place, since we are in a onChange function).