### PR TITLE
Fix "Price=free" giving 0 results in Following query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix video transcode setting not reflected correctly (MP3 incorrectly transcoded to MP4) _community pr!_ ([#4458](https://github.com/lbryio/lbry-desktop/pull/4458))
 - Fix search results not appearing when scrolling due to long Tags or Following list in the navigation bar _community pr!_ ([#4465](https://github.com/lbryio/lbry-desktop/pull/4465))
 - Fix unmuted state lost or reverted when playing a new video _community pr!_ ([#4483](https://github.com/lbryio/lbry-desktop/pull/4483))
+- Fix "Price=free" giving 0 results in Following query _community pr!_ ([#4489](https://github.com/lbryio/lbry-desktop/pull/4489))
 
 ## [0.46.2] - [2020-06-10]
 

--- a/ui/constants/claim_search.js
+++ b/ui/constants/claim_search.js
@@ -13,7 +13,7 @@ export const TAGS_FOLLOWED = 'tags_followed';
 export const FEE_AMOUNT_KEY = 'fee_amount';
 export const FEE_AMOUNT_ANY = '>=0';
 export const FEE_AMOUNT_ONLY_PAID = '>0';
-export const FEE_AMOUNT_ONLY_FREE = '0';
+export const FEE_AMOUNT_ONLY_FREE = '<=0';
 
 export const FRESH_DAY = 'day';
 export const FRESH_WEEK = 'week';


### PR DESCRIPTION
## Issue
Fixes #4477

## Remarks
I didn't consult the documentation, but simply did a trial-and-error.
`"=0"` -- didn't work
`"<=0"` -- work

## Disclaimer
I have no idea what I'm doing, but it works.  I have a feeling this might be an SDK problem.

![image](https://user-images.githubusercontent.com/64950861/86797605-70ec7100-c0a2-11ea-8155-aab8381ce00a.png)