### PR TITLE
Improve auto string addition to produce better diffs and ease merging.

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1273,5 +1273,6 @@
   "Unlink YouTube Channel": "Unlink YouTube Channel",
   "Sign In With YouTube": "Sign In With YouTube",
   "There was an error with LBRY first publishing.": "There was an error with LBRY first publishing.",
-  "Automagically upload to your youtube channel.": "Automagically upload to your youtube channel."
+  "Automagically upload to your youtube channel.": "Automagically upload to your youtube channel.",
+  "--end--": "--end--"
 }

--- a/ui/i18n.js
+++ b/ui/i18n.js
@@ -26,8 +26,12 @@ function saveMessage(message) {
   }
 
   if (!knownMessages[message]) {
+    const END = '--end--';
+    delete knownMessages[END];
     knownMessages[message] = message;
-    fs.writeFile(messagesFilePath, JSON.stringify(knownMessages, null, 2), 'utf-8', err => {
+    knownMessages[END] = END;
+
+    fs.writeFile(messagesFilePath, JSON.stringify(knownMessages, null, 2) + '\n', 'utf-8', err => {
       if (err) {
         throw err;
       }


### PR DESCRIPTION
## Issue
- The diff for new strings are polluted by the need to add a comma to the previous entry.
- Having to re-add the newline at the end of file before commiting is a repetitive pain.

Before:
![image](https://user-images.githubusercontent.com/64950861/86880537-6c19d280-c11f-11ea-9009-cb09600c0a07.png)

After:
![image](https://user-images.githubusercontent.com/64950861/86880259-1513fd80-c11f-11ea-955d-7508e5582857.png)

## Caveats to this approach
- When manually adding strings, developers need to put it above the `--end--` entry. Hopefully it is obvious without having to put verbose comments like `^--- add new string before this line ---^`
- Translators will surely ask how to translate `--end--`.

