### PR TITLE
TipModal: Add final warning when making a permanent tip. 

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1269,6 +1269,8 @@
   "Delete Your Channel": "Delete Your Channel",
   "Remove from Blocked List": "Remove from Blocked List",
   "Are you sure you want to remove this from the list?": "Are you sure you want to remove this from the list?",
+  "Send A Tip": "Send A Tip",
+  "Send a chunk of change to this creator to let them know you appreciate their content.": "Send a chunk of change to this creator to let them know you appreciate their content.",
   "CableTube Escape Artists": "CableTube Escape Artists",
   "Unlink YouTube Channel": "Unlink YouTube Channel",
   "Sign In With YouTube": "Sign In With YouTube",

--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -228,6 +228,15 @@ function WalletSendTip(props: Props) {
                     label={__('Custom')}
                     onClick={() => setUseCustomTip(true)}
                   />
+                  {DEFAULT_TIP_AMOUNTS.some(val => val > balance) && (
+                    <Button
+                      button="secondary"
+                      className="button-toggle-group-action"
+                      icon={ICONS.BUY}
+                      title={__('Buy More LBC')}
+                      navigate={`/$/${PAGES.BUY}`}
+                    />
+                  )}
                 </div>
 
                 {useCustomTip && (
@@ -281,11 +290,6 @@ function WalletSendTip(props: Props) {
                     />
                   )}
                 </div>
-                {DEFAULT_TIP_AMOUNTS.some(val => val > balance) && (
-                  <div className="section">
-                    <Button button="link" label={__('Buy More LBC')} navigate={`/$/${PAGES.BUY}`} />
-                  </div>
-                )}
               </>
             )
           }

--- a/ui/scss/component/_button.scss
+++ b/ui/scss/component/_button.scss
@@ -176,3 +176,12 @@ svg + .button__label,
     border-bottom-left-radius: 0;
   }
 }
+
+.button-toggle-group-action {
+  position: absolute; // Centers the button along toggle buttons
+
+  @media (max-width: $breakpoint-small) {
+    position: relative;
+    top: var(--spacing-s);
+  }
+}


### PR DESCRIPTION
## Issue
Closes #4492 `Make support (tip case) dialog clearer`

## Changes:
- Move the "Buy More" button to the middle instead of isolated at the bottom
- Add warning sentence 

![image](https://user-images.githubusercontent.com/64950861/86894854-3cc29000-c136-11ea-89b0-925d791a0691.png)

![image](https://user-images.githubusercontent.com/64950861/86894848-392f0900-c136-11ea-9940-e4dc9caaf4eb.png)
