### PR TITLE
Add a LBRY Services status card to the help page (Tested Working)

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1310,6 +1310,5 @@
   "LBRY Status": "LBRY Status",
   "Check the status of various LBRY services.": "Check the status of various LBRY services.",
   "Check Status": "Check Status",
-  "Monitor Explanation FAQ": "Monitor Explanation FAQ",
   "--end--": "--end--"
 }

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1307,5 +1307,9 @@
   "Your publish on LBRY was successful, but uploading to YouTube Failed.": "Your publish on LBRY was successful, but uploading to YouTube Failed.",
   "Your publish on LBRY was successful, but the YouTube upload failed.": "Your publish on LBRY was successful, but the YouTube upload failed.",
   "Your file was published to LBRY, but the YouTube upload failed.": "Your file was published to LBRY, but the YouTube upload failed.",
+  "LBRY Status": "LBRY Status",
+  "Check the status of various LBRY services.": "Check the status of various LBRY services.",
+  "Check Status": "Check Status",
+  "Monitor Explanation FAQ": "Monitor Explanation FAQ",
   "--end--": "--end--"
 }

--- a/ui/component/common/icon-custom.jsx
+++ b/ui/component/common/icon-custom.jsx
@@ -694,4 +694,11 @@ export const icons = {
       <circle cx="12" cy="13" r="4" />
     </g>
   ),
+  [ICONS.LBRY_STATUS]: buildIcon(
+    <g>
+      <line x1="18" y1="20" x2="18" y2="10" />
+      <line x1="12" y1="20" x2="12" y2="4" />
+      <line x1="6" y1="20" x2="6" y2="14" />
+    </g>
+  ),
 };

--- a/ui/constants/icons.js
+++ b/ui/constants/icons.js
@@ -109,3 +109,4 @@ export const RECEIVE = 'Receive';
 export const CAMERA = 'Camera';
 export const OPEN_LOG = 'FilePlus';
 export const OPEN_LOG_FOLDER = 'Folder';
+export const LBRY_STATUS = 'BarChart';

--- a/ui/page/help/view.jsx
+++ b/ui/page/help/view.jsx
@@ -159,12 +159,6 @@ class HelpPage extends React.PureComponent<Props, State> {
                 icon={ICONS.LBRY_STATUS}
                 button="secondary"
               />
-              <Button
-                href="https://lbry.com/faq/services-monitor"
-                label={__('Monitor Explanation FAQ')}
-                icon={ICONS.HELP}
-                button="secondary"
-              />       
             </div>
           }
         />

--- a/ui/page/help/view.jsx
+++ b/ui/page/help/view.jsx
@@ -149,6 +149,26 @@ class HelpPage extends React.PureComponent<Props, State> {
         />
 
         <Card
+          title={__('LBRY Status')}
+          subtitle={__('Check the status of various LBRY services.')}
+          actions={
+            <div className="section__actions">
+              <Button
+                href="https://status.lbry.com/"
+                label={__('Check Status')}
+                icon={ICONS.LBRY_STATUS}
+                button="secondary"
+              />
+              <Button
+                href="https://lbry.com/faq/services-monitor"
+                label={__('Monitor Explanation FAQ')}
+                icon={ICONS.HELP}
+                button="secondary"
+            </div>
+          }
+        />
+
+        <Card
           title={__('Find Assistance')}
           subtitle={
             <I18nMessage tokens={{ channel: <strong>#help</strong> }}>

--- a/ui/page/help/view.jsx
+++ b/ui/page/help/view.jsx
@@ -164,6 +164,7 @@ class HelpPage extends React.PureComponent<Props, State> {
                 label={__('Monitor Explanation FAQ')}
                 icon={ICONS.HELP}
                 button="secondary"
+              />       
             </div>
           }
         />


### PR DESCRIPTION

![Annotation 2020-07-11 005032](https://user-images.githubusercontent.com/64234158/87219496-8f57a400-c310-11ea-8c22-0a9256560f67.png)
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: Fixes: #1170

## What is the current behavior?

## What is the new behavior?
A new card on the help page links to the status.lbry.com page and also links to my recently created FAQ page on what the services are. This commit is for the FAQ getting added to lbry.com: https://github.com/lbryio/lbry.com/pull/1324
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
