### PR TITLE
Inf-scroll: Handle case of "pop from claim"

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -103,7 +103,7 @@ function ClaimListDiscover(props: Props) {
   const [page, setPage] = useState(1);
   const [forceRefresh, setForceRefresh] = useState();
   const [expanded, setExpanded] = usePersistedState(`expanded-${location.pathname}`, false);
-  const [orderParamEntry, setOrderParamEntry] = useState(CS.ORDER_BY_TRENDING);
+  const [orderParamEntry, setOrderParamEntry] = usePersistedState(`entry-${location.pathname}`, CS.ORDER_BY_TRENDING);
   const [orderParamUser, setOrderParamUser] = usePersistedState(`orderUser-${location.pathname}`, CS.ORDER_BY_TRENDING);
   const followed = (followedTags && followedTags.map(t => t.name)) || [];
   const urlParams = new URLSearchParams(search);
@@ -155,7 +155,9 @@ function ClaimListDiscover(props: Props) {
 
   useEffect(() => {
     // One-time update to stash the finalized 'orderParam' at entry.
-    setOrderParamEntry(orderParam);
+    if (history.action !== 'POP') {
+      setOrderParamEntry(orderParam);
+    }
   }, []);
 
   let options: {


### PR DESCRIPTION
This is a follow-up on PR-4392.

## Issue:
The previous PR covered "pop from within the same page but with different query/order", but missed "pop after entering a claim".

1. Click `Your Tags`.
2. Set order to `New`.
3. Restart app or reload (crucial step)
4. Click `Your Tags`.
5. Click any claim.
6. `Back`. The order incorrectly resets to `Trending` -- it should stay at `New`.

