### PR TITLE
Fix 'transcoding' checkbox state when switching file types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix 'transcoding' checkbox state when switching file types _community pr!_ ([#4529](https://github.com/lbryio/lbry-desktop/pull/4529))
+
 ## [0.47.0] - [2020-07-13]
 
 ### Added

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -82,7 +82,7 @@ function PublishFile(props: Props) {
 
     setOptimizeAvail(isOptimizeAvail);
     updatePublishForm({ optimize: finalOptimizeState });
-  }, [filePath, isVid, ffmpegAvail, userOptimize]);
+  }, [currentFile, filePath, isVid, ffmpegAvail, userOptimize]);
 
   function updateFileInfo(duration, size, isvid) {
     updatePublishForm({ fileDur: duration, fileSize: size, fileVid: isvid });
@@ -216,6 +216,8 @@ function PublishFile(props: Props) {
       } else {
         updateFileInfo(0, file.size, isVideo);
       }
+    } else {
+      updateFileInfo(0, file.size, isVideo);
     }
 
     // @if TARGET='web'


### PR DESCRIPTION
## Issue:
Currently, the checkbox grayed-out state is only correctly updated when changing from "no-file" to "file selected". If you have selected a video file and later changed to a text file, the checkbox doesn't gray out.

## Code Changes:
`fileVid` wasn't being updated for the case of non-videos; now it does.

