### PR TITLE
Add option to retry video stream on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Allow zooming on Desktop _community pr!_ ([#4513](https://github.com/lbryio/lbry-desktop/pull/4513))
-- Show "YT Creator" label in File Page as well _community pr!_ ([#4523](https://github.com/lbryio/lbry-desktop/pull/4523)) 
+- Show "YT Creator" label in File Page as well _community pr!_ ([#4523](https://github.com/lbryio/lbry-desktop/pull/4523))
+- Add option to retry video stream on failure _community pr!_ ([#4541](https://github.com/lbryio/lbry-desktop/pull/4541))
 
 ### Changed
 

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1162,6 +1162,7 @@
   "No information will be sent directly to LBRY, Inc. or third-parties about your usage. Note that as\n                peer-to-peer software, your IP address and potentially other system information can be sent to other\n                users, though this information is not stored permanently.": "No information will be sent directly to LBRY, Inc. or third-parties about your usage. Note that as\n                peer-to-peer software, your IP address and potentially other system information can be sent to other\n                users, though this information is not stored permanently.",
   "%view_count% Views": "%view_count% Views",
   "Tap to unmute": "Tap to unmute",
+  "Retry": "Retry",
   "Playing in %seconds_left% seconds...": "Playing in %seconds_left% seconds...",
   "Autoplay timer paused.": "Autoplay timer paused.",
   "0 Bytes": "0 Bytes",

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -21,6 +21,7 @@ export type Player = {
   currentTime: (?number) => number,
   ended: () => boolean,
   error: () => any,
+  loadingSpinner: any,
 };
 
 type Props = {
@@ -136,6 +137,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
   function onError() {
     showTapToUnmute(false);
+    if (player && player.loadingSpinner) {
+      player.loadingSpinner.hide();
+    }
   }
 
   function onEnded() {

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -39,7 +39,6 @@ type VideoJSOptions = {
   responsive: boolean,
   poster?: string,
   muted?: boolean,
-  poster?: string,
 };
 
 const IS_IOS =


### PR DESCRIPTION
## (1) Video: Stop loading circle when there's an error.
When there is an error in loading the video, the loading circle spins perpetually, giving false hope.  This commit removes the loading circle in that scenario.

## (2) Closes #4475 `Option to retry video stream on failure`
Added a `Retry` button to reload the video without re-rendering the app or even the page.  
See example of how it looks like: https://www.youtube.com/watch?v=C3_GRWWFDC8

Note that this doesn't cover #4540 `lbry.tv: video cut-off without errors`.  There's no error message for this case, plus refreshing will produce the same cut-off anyway (server issue?) 