### PR TITLE
New Channel: Fix incorrect GUI configuration at entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix 'transcoding' checkbox state when switching file types _community pr!_ ([#4529](https://github.com/lbryio/lbry-desktop/pull/4529))
 - Fix channel file-search not available in mobile _community pr!_ ([#4527](https://github.com/lbryio/lbry-desktop/pull/4527))
+- New Channel: Fix incorrect GUI configuration at entry _community pr!_ ([#4545](https://github.com/lbryio/lbry-desktop/pull/4545))
 
 ## [0.47.0] - [2020-07-13]
 

--- a/ui/component/selectChannel/view.jsx
+++ b/ui/component/selectChannel/view.jsx
@@ -28,7 +28,7 @@ class ChannelSelection extends React.PureComponent<Props, State> {
     super(props);
 
     this.state = {
-      addingChannel: false,
+      addingChannel: props.channel === CHANNEL_NEW,
     };
 
     (this: any).handleChannelChange = this.handleChannelChange.bind(this);
@@ -77,7 +77,7 @@ class ChannelSelection extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const channel = this.state.addingChannel ? 'new' : this.props.channel;
+    const channel = this.state.addingChannel ? CHANNEL_NEW : this.props.channel;
     const { fetchingChannels, channels = [], hideAnon, hideNew, label, injected = [] } = this.props;
     const { addingChannel } = this.state;
 


### PR DESCRIPTION
## Issue:
Fixes #4411 `"SelectChannel=New" doesn't show all fields on re-entry`

## Code Changes:
Correct the value of `addingChannel` in the constructor based on the given props.
