### PR TITLE
Fix 'Related' section lazy-load not working in some scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix sluggish Back button when navigation back to channels with lots of comments _community pr!_ ([#4576](https://github.com/lbryio/lbry-desktop/pull/4576))
+- Fix 'Related' and 'Comments' section lazy-load not working in some scenarios _community pr!_ ([#4586](https://github.com/lbryio/lbry-desktop/pull/4586))
 
 ## [0.47.1] - [2020-07-23]
 

--- a/ui/component/common/wait-until-on-page.jsx
+++ b/ui/component/common/wait-until-on-page.jsx
@@ -1,5 +1,8 @@
 // @flow
 import React from 'react';
+import debounce from 'util/debounce';
+
+const DEBOUNCE_SCROLL_HANDLER_MS = 300;
 
 type Props = {
   children: any,
@@ -10,7 +13,7 @@ export default function WaitUntilOnPage(props: Props) {
   const [shouldRender, setShouldRender] = React.useState(false);
 
   React.useEffect(() => {
-    function handleDisplayingRef() {
+    const handleDisplayingRef = debounce(e => {
       const element = ref && ref.current;
       if (element) {
         const bounding = element.getBoundingClientRect();
@@ -28,12 +31,9 @@ export default function WaitUntilOnPage(props: Props) {
 
       if (element && !shouldRender) {
         window.addEventListener('scroll', handleDisplayingRef);
-
-        return () => {
-          window.removeEventListener('scroll', handleDisplayingRef);
-        };
+        return () => window.removeEventListener('scroll', handleDisplayingRef);
       }
-    }
+    }, DEBOUNCE_SCROLL_HANDLER_MS);
 
     if (ref) {
       handleDisplayingRef();

--- a/ui/component/common/wait-until-on-page.jsx
+++ b/ui/component/common/wait-until-on-page.jsx
@@ -6,11 +6,16 @@ const DEBOUNCE_SCROLL_HANDLER_MS = 300;
 
 type Props = {
   children: any,
+  lastUpdateDate?: any,
 };
 
 export default function WaitUntilOnPage(props: Props) {
   const ref = React.useRef();
   const [shouldRender, setShouldRender] = React.useState(false);
+
+  React.useEffect(() => {
+    setShouldRender(false);
+  }, [props.lastUpdateDate]);
 
   React.useEffect(() => {
     const handleDisplayingRef = debounce(e => {

--- a/ui/component/recommendedContent/view.jsx
+++ b/ui/component/recommendedContent/view.jsx
@@ -25,6 +25,7 @@ export default class RecommendedContent extends React.PureComponent<Props> {
     super();
 
     this.didSearch = undefined;
+    this.lastReset = undefined;
   }
 
   componentDidMount() {
@@ -36,6 +37,7 @@ export default class RecommendedContent extends React.PureComponent<Props> {
 
     if (uri !== prevProps.uri) {
       this.didSearch = false;
+      this.lastReset = Date.now();
     }
 
     if (claim && !this.didSearch) {
@@ -60,6 +62,7 @@ export default class RecommendedContent extends React.PureComponent<Props> {
   }
 
   didSearch: ?boolean;
+  lastReset: ?any;
 
   render() {
     const { recommendedContent, isSearching, isAuthenticated } = this.props;
@@ -69,7 +72,7 @@ export default class RecommendedContent extends React.PureComponent<Props> {
         isBodyList
         title={__('Related')}
         body={
-          <WaitUntilOnPage>
+          <WaitUntilOnPage lastUpdateDate={this.lastReset}>
             <ClaimList
               isCardBody
               type="small"

--- a/ui/component/recommendedContent/view.jsx
+++ b/ui/component/recommendedContent/view.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ClaimList from 'component/claimList';
 import Ads from 'web/component/ads';
 import Card from 'component/common/card';
+import WaitUntilOnPage from 'component/common/wait-until-on-page';
 
 type Options = {
   related_to: string,
@@ -68,14 +69,16 @@ export default class RecommendedContent extends React.PureComponent<Props> {
         isBodyList
         title={__('Related')}
         body={
-          <ClaimList
-            isCardBody
-            type="small"
-            loading={isSearching}
-            uris={recommendedContent}
-            injectedItem={!isAuthenticated && IS_WEB && <Ads type="video" small />}
-            empty={__('No related content found')}
-          />
+          <WaitUntilOnPage>
+            <ClaimList
+              isCardBody
+              type="small"
+              loading={isSearching}
+              uris={recommendedContent}
+              injectedItem={!isAuthenticated && IS_WEB && <Ads type="video" small />}
+              empty={__('No related content found')}
+            />
+          </WaitUntilOnPage>
         }
       />
     );

--- a/ui/page/file/view.jsx
+++ b/ui/page/file/view.jsx
@@ -37,6 +37,11 @@ type Props = {
 };
 
 class FilePage extends React.Component<Props> {
+  constructor() {
+    super();
+    this.lastReset = undefined;
+  }
+
   componentDidMount() {
     const { uri, fetchFileInfo, fetchCostInfo, setViewed, isSubscribed } = this.props;
 
@@ -64,6 +69,7 @@ class FilePage extends React.Component<Props> {
 
     if (prevProps.uri !== uri) {
       setViewed(uri);
+      this.lastReset = Date.now();
     }
 
     // @if TARGET='app'
@@ -142,6 +148,8 @@ class FilePage extends React.Component<Props> {
     );
   }
 
+  lastReset: ?any;
+
   render() {
     const { uri, renderMode, costInfo, obscureNsfw, isMature } = this.props;
 
@@ -164,7 +172,7 @@ class FilePage extends React.Component<Props> {
               actions={
                 <div>
                   <CommentCreate uri={uri} />
-                  <WaitUntilOnPage>
+                  <WaitUntilOnPage lastUpdateDate={this.lastReset}>
                     <CommentsList uri={uri} />
                   </WaitUntilOnPage>
                 </div>

--- a/ui/page/file/view.jsx
+++ b/ui/page/file/view.jsx
@@ -171,9 +171,7 @@ class FilePage extends React.Component<Props> {
               }
             />
           </div>
-          <WaitUntilOnPage>
-            <RecommendedContent uri={uri} />
-          </WaitUntilOnPage>
+          <RecommendedContent uri={uri} />
         </div>
       </Page>
     );


### PR DESCRIPTION
## Issue
1. Sometimes, the Related Section will load unnecessarily when a File Page is entered.  This happens more to Image claims, although I see it happening on Videos.  I think it's due to my slow connection causing the upper components to not fully inflate, so the Related Section will briefly appear on screen.
2. In the Autoplay case, if the `WaitUntilOnPage` has already opened the gates previously, the next video's Related Section will be loaded regardless of scroll position.

## Changes
See the commit messages for the walkthrough.

## Comments
Using the debounce method doesn't fix the first issue 100%, but it covers most cases with a decent connection speed.  In the future, I'm thinking of using a dummy placeholder component with typical Video height while waiting for Images to load.