### PR TITLE
support sdk feature for fast comments

### DIFF
--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -16,6 +16,8 @@ export function doCommentList(uri: string, page: number = 1, pageSize: number = 
       claim_id: claimId,
       page,
       page_size: pageSize,
+      include_replies: true,
+      skip_validation: true,
     })
       .then((result: CommentListResponse) => {
         const { items: comments } = result;


### PR DESCRIPTION
merge when SDK > 79.1 ships.
--include_replies now defaults to false, included if you want full tree response
new flag to speed up comment loading