### PR TITLE
Tip Modal: Don't do final submit when the intention is to create New Channel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased on desktop]
 
 ### Added
+
 - Block mature content when accessed directly from URL _community pr!_ ([#4560](https://github.com/lbryio/lbry-desktop/pull/4560))
 
 ### Changed
 
 ### Fixed
+
 - Fix sluggish Back button when navigation back to channels with lots of comments _community pr!_ ([#4576](https://github.com/lbryio/lbry-desktop/pull/4576))
 - Fix 'Related' and 'Comments' section lazy-load not working in some scenarios _community pr!_ ([#4586](https://github.com/lbryio/lbry-desktop/pull/4586))
 - Fix comment-creation failure if you have recently deleted a channel _community pr!_ ([#4630](https://github.com/lbryio/lbry-desktop/pull/4630))
+- Tip Modal: Don't do final submit when the intention is to create New Channel _community pr!_ ([#4629](https://github.com/lbryio/lbry-desktop/pull/4629))
 
 ## [0.47.1] - [2020-07-23]
 

--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -4,7 +4,7 @@ import * as PAGES from 'constants/pages';
 import React from 'react';
 import Button from 'component/button';
 import { FormField, Form } from 'component/common/form';
-import { MINIMUM_PUBLISH_BID, CHANNEL_ANONYMOUS } from 'constants/claim';
+import { MINIMUM_PUBLISH_BID, CHANNEL_ANONYMOUS, CHANNEL_NEW } from 'constants/claim';
 import CreditAmount from 'component/common/credit-amount';
 import I18nMessage from 'component/i18nMessage';
 import { Lbryio } from 'lbryinc';
@@ -120,6 +120,12 @@ function WalletSendTip(props: Props) {
   }
 
   function handleSubmit() {
+    if (selectedChannel === CHANNEL_NEW) {
+      // This is the submission to create a new channel, and would
+      // be handled by <ChannelSelection>, so do nothing here.
+      return;
+    }
+
     if (tipAmount && claimId) {
       if (instantTipEnabled) {
         if (instantTipMax.currency === 'LBC') {


### PR DESCRIPTION
## Issue
Fixes [#4544 Channel-creation in "Tip|Support" Modal shouldn't submit LBC immediately](https://github.com/lbryio/lbry-desktop/issues/4544)

## Changes
`Form` seems to have already tried to stop the propagation of `onSubmit`, so I'm not sure why it was still propagated.

Fix by using the same method used in the `CommentCreate`, which is simply to check for `CHANNEL_NEW` as the current selection.