### PR TITLE
Increase max text length of posts

### DIFF
--- a/ui/component/postEditor/view.jsx
+++ b/ui/component/postEditor/view.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React, { useEffect } from 'react';
-import { FF_MAX_CHARS_IN_DESCRIPTION } from 'constants/form-field';
+import { FF_MAX_CHARS_IN_POST } from 'constants/form-field';
 import { FormField } from 'component/common/form';
 
 type Props = {
@@ -108,7 +108,7 @@ function PostEditor(props: Props) {
       value={ready ? fileText : __('Loading...')}
       disabled={!ready || disabled}
       onChange={value => updatePublishForm({ fileText: value })}
-      textAreaMaxLength={FF_MAX_CHARS_IN_DESCRIPTION}
+      textAreaMaxLength={FF_MAX_CHARS_IN_POST}
     />
   );
 }

--- a/ui/constants/form-field.js
+++ b/ui/constants/form-field.js
@@ -1,3 +1,4 @@
 export const FF_MAX_CHARS_DEFAULT = 2000;
 export const FF_MAX_CHARS_IN_COMMENT = 2000;
 export const FF_MAX_CHARS_IN_DESCRIPTION = 5000;
+export const FF_MAX_CHARS_IN_POST = 10000;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:


## What is the current behavior?
From twitter:
> is there a character limit? I could only edit 70 % of my old Markdown file text.

Currently the post editor uses the same limit on description: 5000 chars.
Any previous post ( markdown file ) that is above this limit can't be edited.
I'm still unsure what should be the limit. I tried to find a limit on `medium.com` but looks like there is no actual limit or is just to big to reach unless you post an actual book. 😕 

Unfortunately a limit is necessary to have specially for the web version ( I guess the markdown preview / parser will eventually become too slow or crash in a very extreme case ? ), I just doubled up the current limit to 10,000 Idk if that's really enough or still small. Open for suggestions ✌️ 