### PR TITLE
Patch 37a1fd88: Sync selectedChannel only if the channel doesn't exist

### DIFF
--- a/ui/component/selectChannel/view.jsx
+++ b/ui/component/selectChannel/view.jsx
@@ -47,13 +47,15 @@ class ChannelSelection extends React.PureComponent<Props, State> {
       fetchChannelListMine();
     }
 
-    const elem = document.getElementById(ID_FF_SELECT_CHANNEL);
-    // $FlowFixMe
-    if (elem && elem.value && elem.value !== channel) {
-      setTimeout(() => {
-        // $FlowFixMe
-        onChannelChange(elem.value);
-      }, 250);
+    if (channels && channels.length && !channels.find(chan => chan.name === channel)) {
+      const elem = document.getElementById(ID_FF_SELECT_CHANNEL);
+      // $FlowFixMe
+      if (elem && elem.value && elem.value !== channel) {
+        setTimeout(() => {
+          // $FlowFixMe
+          onChannelChange(elem.value);
+        }, 250);
+      }
     }
   }
 


### PR DESCRIPTION
## Issue
https://github.com/lbryio/lbry-desktop/commit/37a1fd88e3b5fe54be2e45e924a20a5567211902#commitcomment-41233752
The previous commit was over-doing the manual syncing, causing other usages like the Repost Modal to always reset to a different channel.

## Fix
Only do the manual syncing when the channel does not exist.
At this point, we could also just take `channel[0]` as the new value.