### PR TITLE
Use fallback image for broken thumbnails

### DIFF
--- a/config.js
+++ b/config.js
@@ -30,6 +30,7 @@ const config = {
   PINNED_LABEL_1: process.env.PINNED_LABEL_1,
   PINNED_URI_2: process.env.PINNED_URI_2,
   PINNED_LABEL_2: process.env.PINNED_LABEL_2,
+  THUMBNAIL_FALLBACK: process.env.THUMBNAIL_FALLBACK,
 };
 
 config.URL_LOCAL = `http://localhost:${config.WEB_SERVER_PORT}`;

--- a/ui/component/fileThumbnail/view.jsx
+++ b/ui/component/fileThumbnail/view.jsx
@@ -1,6 +1,7 @@
 // @flow
 import type { Node } from 'react';
 import React from 'react';
+import { THUMBNAIL_FALLBACK } from 'config';
 import FreezeframeWrapper from './FreezeframeWrapper';
 import Placeholder from './placeholder.png';
 
@@ -8,13 +9,14 @@ type Props = {
   thumbnail: ?string, // externally sourced image
   children?: Node,
   allowGifs: boolean,
+  fallbackThumbnail?: string,
 };
 
 const className = 'media__thumb';
 
 class FileThumbnail extends React.PureComponent<Props> {
   render() {
-    const { thumbnail: rawThumbnail, children, allowGifs = false } = this.props;
+    const { thumbnail: rawThumbnail, children, allowGifs = false, fallbackThumbnail = THUMBNAIL_FALLBACK } = this.props;
     const thumbnail = rawThumbnail && rawThumbnail.trim().replace(/^http:\/\//i, 'https://');
 
     if (!allowGifs && thumbnail && thumbnail.endsWith('gif')) {
@@ -39,8 +41,10 @@ class FileThumbnail extends React.PureComponent<Props> {
     url = thumbnail || Placeholder;
     // @endif
 
+    const cleanUrl = url.replace(/'/g, "\\'");
+
     return (
-      <div style={{ backgroundImage: `url('${url.replace(/'/g, "\\'")}')` }} className={className}>
+      <div style={{ backgroundImage: `url('${cleanUrl}'), url('${fallbackThumbnail}')` }} className={className}>
         {children}
       </div>
     );


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 3290

## What is the current behavior?

When a broken or invalid image is used for a thumbnail, no default/fallback is being used.

## What is the new behavior?

When a broken or invalid image is used for a thumbnail, a default/fallback image will be used instead.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
