### PR TITLE
Publish: Make 'Channel' setting persistent.

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#7df96d47671308c09db0a28892dbbfd6486d81f4",
+    "lbry-redux": "lbryio/lbry-redux#05b949d470dd1f3436b45ab1e252c0dcc0ae9a3f",
     "lbryinc": "lbryio/lbryinc#cff5dd60934c4c6080e135f47ebbece1548c658c",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/ui/component/publishForm/view.jsx
+++ b/ui/component/publishForm/view.jsx
@@ -77,7 +77,6 @@ type Props = {
   // Add back type
   updatePublishForm: any => void,
   checkAvailability: string => void,
-  onChannelChange: string => void,
   ytSignupPending: boolean,
 };
 
@@ -114,7 +113,6 @@ function PublishForm(props: Props) {
     publish,
     disabled = false,
     checkAvailability,
-    onChannelChange,
     ytSignupPending,
   } = props;
 
@@ -209,7 +207,6 @@ function PublishForm(props: Props) {
   }, [name, channel, resolveUri, updatePublishForm, checkAvailability]);
 
   function handleChannelNameChange(channel) {
-    onChannelChange(channel);
     updatePublishForm({ channel });
   }
 

--- a/ui/page/publish/view.jsx
+++ b/ui/page/publish/view.jsx
@@ -5,7 +5,6 @@ import Page from 'component/page';
 import Yrbl from 'component/yrbl';
 import LbcSymbol from 'component/common/lbc-symbol';
 import RewardAuthIntro from 'component/rewardAuthIntro';
-import usePersistedState from 'effects/use-persisted-state';
 
 type Props = {
   balance: number,
@@ -15,17 +14,11 @@ type Props = {
 function PublishPage(props: Props) {
   const { balance } = props;
 
-  const [channel, setChannel] = usePersistedState('publish-channel', '');
-
   function scrollToTop() {
     const mainContent = document.querySelector('main');
     if (mainContent) {
       mainContent.scrollTop = 0; // It would be nice to animate this
     }
-  }
-
-  function handleChannelChange(channel) {
-    setChannel(channel);
   }
 
   return (
@@ -62,12 +55,7 @@ function PublishPage(props: Props) {
           </div>
         </Fragment>
       ) : (
-        <PublishForm
-          scrollToTop={scrollToTop}
-          disabled={balance === 0}
-          channel={channel}
-          onChannelChange={handleChannelChange}
-        />
+        <PublishForm scrollToTop={scrollToTop} disabled={balance === 0} />
       )}
     </Page>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6413,9 +6413,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#7df96d47671308c09db0a28892dbbfd6486d81f4:
+lbry-redux@lbryio/lbry-redux#05b949d470dd1f3436b45ab1e252c0dcc0ae9a3f:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/7df96d47671308c09db0a28892dbbfd6486d81f4"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/05b949d470dd1f3436b45ab1e252c0dcc0ae9a3f"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
## Issue
Users are annoyed with the constant reset of the 'channel' setting in the Publish page.

## Changes
1. Revert the previous attempt in ff7b4092. The `usePersistedState` method is bad, as it will clash with the Redux value.  It only worked on initial entry, which was ok back then with the old version of Publish, but not with the new dynamic version of Publish (and it's probably partially broken too back then).
2. Implemented the persistence in Redux -- requires "https://github.com/lbryio/lbry-redux/pull/347".