### PR TITLE
Revert "use dynamic js bundle urls"

### DIFF
--- a/static/index-web.html
+++ b/static/index-web.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="/public/ui.js" async></script>
     <link rel="icon" type="image/png" href="/public/favicon.png" />
 
     <link rel="preload" href="/public/font/v1/300.woff" as="font" type="font/woff" />

--- a/web/bundle-id.js
+++ b/web/bundle-id.js
@@ -1,8 +1,0 @@
-const uuid = require('uuid/v4');
-const jsBundleId = uuid();
-
-function getJsBundleId() {
-  return jsBundleId;
-}
-
-module.exports = { getJsBundleId };

--- a/web/package.json
+++ b/web/package.json
@@ -34,8 +34,7 @@
     "lbry-redux": "lbryio/lbry-redux#c107d9cc4c4b2cc31f182f196ab6a033aefe976e",
     "lbryinc": "lbryio/lbryinc#6a52f8026cdc7cd56d200fb5c46f852e0139bbeb",
     "mysql": "^2.17.1",
-    "node-fetch": "^2.6.0",
-    "uuid": "^8.3.0"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/web/src/html.js
+++ b/web/src/html.js
@@ -14,16 +14,11 @@ const { getClaim } = require('./chainquery');
 const { parseURI } = require('lbry-redux');
 const fs = require('fs');
 const path = require('path');
-const { getJsBundleId } = require('../bundle-id.js');
-const jsBundleId = getJsBundleId();
 
 function insertToHead(fullHtml, htmlToInsert) {
   return fullHtml.replace(
     /<!-- VARIABLE_HEAD_BEGIN -->.*<!-- VARIABLE_HEAD_END -->/s,
-    `
-      ${htmlToInsert || buildOgMetadata()}
-      <script src="/public/ui-${jsBundleId}.js" async></script>
-    `
+    htmlToInsert || buildOgMetadata()
   );
 }
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -6,7 +6,6 @@ const baseConfig = require('../webpack.base.config.js');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { DefinePlugin, ProvidePlugin } = require('webpack');
 const SentryWebpackPlugin = require('@sentry/webpack-plugin');
-const { getJsBundleId } = require('./bundle-id.js');
 const { insertToHead, buildBasicOgMetadata } = require('./src/html');
 const { insertVariableXml, getOpenSearchXml } = require('./src/xml');
 
@@ -17,7 +16,6 @@ const DIST_ROOT = path.resolve(__dirname, 'dist/');
 const WEB_PLATFORM_ROOT = __dirname;
 const isProduction = process.env.NODE_ENV === 'production';
 const hasSentryToken = process.env.SENTRY_AUTH_TOKEN !== undefined;
-const jsBundleId = getJsBundleId();
 
 const copyWebpackCommands = [
   {
@@ -82,7 +80,7 @@ if (isProduction && hasSentryToken) {
 const webConfig = {
   target: 'web',
   entry: {
-    [`ui-${jsBundleId}`]: '../ui/index.jsx',
+    ui: '../ui/index.jsx',
   },
   output: {
     filename: '[name].js',

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5413,11 +5413,6 @@ uuid@^3.0.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
-uuid@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
-
 vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
Reverts lbryio/lbry-desktop#4672

Reverting this because I still need to fix handling the HTML file for `yarn dev:web`, which is currently broken since the bundle URL is only updated in the HTML file when you run `yarn compile:web`