### PR TITLE
Support for auto-detection of direction for component with varying content

### DIFF
--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -94,11 +94,11 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
     <span className="button__content">
       {icon && <Icon icon={icon} iconColor={iconColor} size={iconSize} />}
 
-      {!largestLabel && label && <span className="button__label">{label}</span>}
+      {!largestLabel && label && <span dir="auto" className="button__label">{label}</span>}
 
       {/* largestLabel is used when a single button has two different labels based on hover state */}
       {largestLabel && (
-        <div className="button__label" style={{ position: 'relative' }}>
+        <div dir="auto" className="button__label" style={{ position: 'relative' }}>
           <div
             style={{
               position: 'relative',

--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -128,7 +128,7 @@ const MarkdownPreview = (props: MarkdownProps) => {
     // Remove new lines and extra space
     remarkOptions.remarkReactComponents.p = SimpleText;
     return (
-      <span className="markdown-preview">
+      <span dir="auto" className="markdown-preview">
         {
           remark()
             .use(remarkStrip)
@@ -140,7 +140,7 @@ const MarkdownPreview = (props: MarkdownProps) => {
   }
 
   return (
-    <div className="markdown-preview">
+    <div dir="auto" className="markdown-preview">
       {
         remark()
           .use(remarkAttr, remarkAttrOpts)

--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -57,7 +57,7 @@ class UriIndicator extends React.PureComponent<Props> {
         return null;
       }
 
-      return <span className={classnames('channel-name', { 'channel-name--inline': inline })}>Anonymous</span>;
+      return <span dir="auto" className={classnames('channel-name', { 'channel-name--inline': inline })}>Anonymous</span>;
     }
 
     const channelClaim = isChannelClaim ? claim : claim.signing_channel;
@@ -66,7 +66,7 @@ class UriIndicator extends React.PureComponent<Props> {
       const { name } = channelClaim;
       const channelLink = link ? channelClaim.canonical_url || channelClaim.permanent_url : false;
 
-      const inner = <span className={classnames('channel-name', { 'channel-name--inline': inline })}>{name}</span>;
+      const inner = <span dir="auto" className={classnames('channel-name', { 'channel-name--inline': inline })}>{name}</span>;
 
       if (!channelLink) {
         return inner;

--- a/ui/page/report/view.jsx
+++ b/ui/page/report/view.jsx
@@ -87,7 +87,7 @@ class ReportPage extends React.Component {
             title={__('Developer?')}
             actions={
               <Fragment>
-                <div className="markdown-preview">
+                <div dir="auto" className="markdown-preview">
                   <p>{__('You can also:')}</p>
                   <ul>
                     <li>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #4430

## What is the current behavior?
There are some components that can contain both rtl and ltr direction (direction is unknown).
e.g: channel name, content description.
## What is the new behavior?
Auto-detection of direction for components with varying content by letting the browser figure out the text direction, based on the content.
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
