### PR TITLE
Fix floating player being paused after dragging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix comment-creation failure if you have recently deleted a channel _community pr!_ ([#4630](https://github.com/lbryio/lbry-desktop/pull/4630))
 - Tip Modal: Don't do final submit when the intention is to create New Channel _community pr!_ ([#4629](https://github.com/lbryio/lbry-desktop/pull/4629))
 - Fix related + search results loading slowly ([#4657](https://github.com/lbryio/lbry-desktop/pull/4657))
+- Fix floating player being paused after dragging _community pr!_ ([#4710](https://github.com/lbryio/lbry-desktop/pull/4710))
 
 ## [0.47.1] - [2020-07-23]
 

--- a/ui/component/fileRenderFloating/view.jsx
+++ b/ui/component/fileRenderFloating/view.jsx
@@ -40,6 +40,7 @@ export default function FileRenderFloating(props: Props) {
   const isMobile = useIsMobile();
   const [fileViewerRect, setFileViewerRect] = useState();
   const [desktopPlayStartTime, setDesktopPlayStartTime] = useState();
+  const [wasDragging, setWasDragging] = useState(false);
   const [position, setPosition] = usePersistedState('floating-file-viewer:position', {
     x: -25,
     y: window.innerHeight - 400,
@@ -89,7 +90,14 @@ export default function FileRenderFloating(props: Props) {
     return null;
   }
 
+  function handleStart(e, ui) {
+    // Not really necessary, but reset just in case 'handleStop' didn't fire.
+    setWasDragging(false);
+  }
+
   function handleDrag(e, ui) {
+    setWasDragging(true);
+
     const { x, y } = position;
     const newX = x + ui.deltaX;
     const newY = y + ui.deltaY;
@@ -99,9 +107,18 @@ export default function FileRenderFloating(props: Props) {
     });
   }
 
+  function handleStop(e, ui) {
+    if (wasDragging) {
+      e.stopPropagation();
+      setWasDragging(false);
+    }
+  }
+
   return (
     <Draggable
       onDrag={handleDrag}
+      onStart={handleStart}
+      onStop={handleStop}
       defaultPosition={position}
       position={isFloating ? position : { x: 0, y: 0 }}
       bounds="parent"


### PR DESCRIPTION
## Issue

Fixes #4709 [Dragging floating player via video section pauses video](https://github.com/lbryio/lbry-desktop/issues/4709)

## Changes
Don't propagate the key-up action if the window was dragged. Hopefully there isn't another sub-component that relies on the action being propagated.

## Note
If you drag at exactly the "Play" icon the control bar, the issue still happens, though.