### PR TITLE
Fix search suggestions 'View Channel' Bug

### DIFF
--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -52,10 +52,20 @@ export const selectSearchSuggestions: Array<SearchSuggestion> = createSelector(
     } else if (query.startsWith('lbry://')) {
       // If it starts with a prefix, don't show any autocomplete results
       // They are probably typing/pasting in a lbry uri
+      let type: string;
+      try {
+        const uri = normalizeURI(query);
+        let { isChannel } = parseURI(uri);
+        type = isChannel ? SEARCH_TYPES.CHANNEL : SEARCH_TYPES.FILE;
+      } catch (e) {
+        console.log('Query not recognized: ' + query);
+        type = SEARCH_TYPES.SEARCH;
+      }
+
       return [
         {
           value: query,
-          type: query[7] === '@' ? SEARCH_TYPES.CHANNEL : SEARCH_TYPES.FILE,
+          type: type,
         },
       ];
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 4607

## What is the current behavior?

Search suggestion drop-down box has the 'View Channel' label when the query string is in fact a URI for a file.

## What is the new behavior?

Label shows 'View Channel' when URI is recognized as a channel URI, and 'View File' when it is recognized as a file URI.

## Other information

Suggestion for future improvement - strip '#' from the end of query string, so that URIs will be correctly recognized (and navigated to) when they are being typed out but not fully completed.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
