### PR TITLE
Search percent sign bug

### DIFF
--- a/ui/component/wunderbar/index.js
+++ b/ui/component/wunderbar/index.js
@@ -7,7 +7,6 @@ import { doToast } from 'redux/actions/notifications';
 import analytics from 'analytics';
 import Wunderbar from './view';
 import { withRouter } from 'react-router-dom';
-import { formatLbryUrlForWeb } from 'util/url';
 
 const select = state => ({
   suggestions: selectSearchSuggestions(state),
@@ -17,15 +16,14 @@ const select = state => ({
 });
 
 const perform = (dispatch, ownProps) => ({
-  onSearch: query => {
-    ownProps.history.push({ pathname: `/$/search`, search: `?q=${encodeURIComponent(query)}` });
+  doSearch: query => {
+    let encodedQuery = encodeURIComponent(query);
+    ownProps.history.push({ pathname: `/$/search`, search: `?q=${encodedQuery}` });
     dispatch(doUpdateSearchQuery(query));
     analytics.apiLogSearch();
   },
-  onSubmit: uri => {
-    const path = formatLbryUrlForWeb(uri);
-    ownProps.history.push(path);
-    dispatch(doUpdateSearchQuery(''));
+  navigateToUri: uri => {
+    ownProps.history.push(uri);
   },
   updateSearchQuery: query => dispatch(doUpdateSearchQuery(query)),
   doShowSnackBar: message => dispatch(doToast({ isError: true, message })),

--- a/ui/page/search/view.jsx
+++ b/ui/page/search/view.jsx
@@ -3,7 +3,7 @@ import { SIMPLE_SITE, SHOW_ADS } from 'config';
 import * as ICONS from 'constants/icons';
 import * as PAGES from 'constants/pages';
 import React, { useEffect, Fragment } from 'react';
-import { Lbry, regexInvalidURI, parseURI } from 'lbry-redux';
+import { Lbry, regexInvalidURI, parseURI, isNameValid } from 'lbry-redux';
 import ClaimPreview from 'component/claimPreview';
 import ClaimList from 'component/claimList';
 import Page from 'component/page';
@@ -50,11 +50,13 @@ export default function SearchPage(props: Props) {
   }
 
   const INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
-  let isValid = false;
   let path;
+  let isValid = true;
   try {
-    ({ path } = parseURI(urlQuery.replace(/ /g, '-').replace(/:/g, '#')));
-    isValid = true;
+    let { streamName } = parseURI(urlQuery.replace(/ /g, '-').replace(/:/g, '#'));
+    if (!isNameValid(streamName)) {
+      isValid = false;
+    }
   } catch (e) {
     isValid = false;
   }
@@ -94,7 +96,7 @@ export default function SearchPage(props: Props) {
       <section className="search">
         {urlQuery && (
           <Fragment>
-            {!SIMPLE_SITE && (
+            {!SIMPLE_SITE && isValid && (
               <header className="search__header">
                 <div className="claim-preview__actions--header">
                   <ClaimUri uri={uriFromQuery} noShortUrl />

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -45,7 +45,7 @@ export const getSearchSuggestions = (value: string) => (dispatch: Dispatch, getS
     return;
   }
 
-  fetch(`${CONNECTION_STRING}autocomplete?s=${searchValue}`)
+  fetch(`${CONNECTION_STRING}autocomplete?s=${encodeURIComponent(searchValue)}`)
     .then(handleFetchResponse)
     .then(apiSuggestions => {
       dispatch({

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -72,6 +72,8 @@ export const doUpdateSearchQuery = (query: string, shouldSkipSuggestions: ?boole
     data: { query },
   });
 
+  if (!query) return;
+
   // Don't fetch new suggestions if the user just added a space
   if (!query.endsWith(' ') || !shouldSkipSuggestions) {
     throttledSearchSuggestions(dispatch, query);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 4516

## What is the current behavior?

Search query containing '%' causes app crash

## What is the new behavior?

Searches can now contain '%' character

## Other information

Api request was breaking for main search and autocomplete when query string included symbols such as '%' and whitespace.
The ClaimPreview component was also throwing an exception when the claim URI was invalid, causing the app to crash.

This PR fixes all of the above, and includes a minor refactor of the wunderbar component view/index.
I have hidden the URI header in the search page (which contains the ClaimPreview component, and a couple of URI-related links) for inavlid URIs.

The search functionality still logs an error to the console when the search string contains whitespace - this comes from directly calling ```console.error(...)``` in the ```parseURI``` method (lbry-redux project). This should probably be improved at some point.

Thanks!

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
