### PR TITLE
Search percent sign bug

### DIFF
--- a/ui/component/wunderbar/index.js
+++ b/ui/component/wunderbar/index.js
@@ -7,7 +7,6 @@ import { doToast } from 'redux/actions/notifications';
 import analytics from 'analytics';
 import Wunderbar from './view';
 import { withRouter } from 'react-router-dom';
-import { formatLbryUrlForWeb } from 'util/url';
 
 const select = state => ({
   suggestions: selectSearchSuggestions(state),
@@ -17,15 +16,14 @@ const select = state => ({
 });
 
 const perform = (dispatch, ownProps) => ({
-  onSearch: query => {
-    ownProps.history.push({ pathname: `/$/search`, search: `?q=${encodeURIComponent(query)}` });
+  doSearch: query => {
+    let encodedQuery = encodeURIComponent(query);
+    ownProps.history.push({ pathname: `/$/search`, search: `?q=${encodedQuery}` });
     dispatch(doUpdateSearchQuery(query));
     analytics.apiLogSearch();
   },
-  onSubmit: uri => {
-    const path = formatLbryUrlForWeb(uri);
-    ownProps.history.push(path);
-    dispatch(doUpdateSearchQuery(''));
+  navigateToUri: uri => {
+    ownProps.history.push(uri);
   },
   updateSearchQuery: query => dispatch(doUpdateSearchQuery(query)),
   doShowSnackBar: message => dispatch(doToast({ isError: true, message })),

--- a/ui/component/wunderbar/view.jsx
+++ b/ui/component/wunderbar/view.jsx
@@ -5,25 +5,30 @@ import * as PAGES from 'constants/pages';
 import * as ICONS from 'constants/icons';
 import React from 'react';
 import classnames from 'classnames';
-import { normalizeURI, isURIValid } from 'lbry-redux';
 import { withRouter } from 'react-router';
 import Icon from 'component/common/icon';
 import Autocomplete from './internal/autocomplete';
 import Tag from 'component/tag';
-
-const L_KEY_CODE = 76;
-const ESC_KEY_CODE = 27;
+import { isURIValid, normalizeURI } from 'lbry-redux';
+import { formatLbryUrlForWeb } from '../../util/url';
 const WEB_DEV_PREFIX = `${URL_DEV}/`;
 const WEB_LOCAL_PREFIX = `${URL_LOCAL}/`;
 const WEB_PROD_PREFIX = `${URL}/`;
 const SEARCH_PREFIX = `$/${PAGES.SEARCH}q=`;
+const INVALID_URL_ERROR = "Invalid LBRY URL entered. Only A-Z, a-z, 0-9, and '-' allowed.";
+
+const L_KEY_CODE = 76;
+const ESC_KEY_CODE = 27;
 
 type Props = {
   searchQuery: ?string,
   updateSearchQuery: string => void,
   onSearch: string => void,
   onSubmit: string => void,
-  wunderbarValue: ?string,
+
+  navigateToUri: string => void,
+  doSearch: string => void,
+
   suggestions: Array<string>,
   doFocus: () => void,
   doBlur: () => void,
@@ -99,68 +104,70 @@ class WunderBar extends React.PureComponent<Props, State> {
     updateSearchQuery(value);
   }
 
-  handleSubmit(value: string, suggestion?: { value: string, type: string }) {
-    const { onSubmit, onSearch, doShowSnackBar, history } = this.props;
-    let query = value.trim();
-    this.input && this.input.blur();
-    const showSnackError = () => {
-      doShowSnackBar('Invalid LBRY URL entered. Only A-Z, a-z, 0-9, and "-" allowed.');
-    };
-
+  onSubmitWebUri(uri: string) {
     // Allow copying a lbry.tv url and pasting it into the search bar
-    const includesLbryTvProd = query.includes(WEB_PROD_PREFIX);
-    const includesLbryTvLocal = query.includes(WEB_LOCAL_PREFIX);
-    const includesLbryTvDev = query.includes(WEB_DEV_PREFIX);
-    const wasCopiedFromWeb = includesLbryTvDev || includesLbryTvLocal || includesLbryTvProd;
+    const { doSearch, navigateToUri, updateSearchQuery } = this.props;
 
-    if (wasCopiedFromWeb) {
-      if (includesLbryTvDev) {
-        query = query.slice(WEB_DEV_PREFIX.length);
-      } else if (includesLbryTvLocal) {
-        query = query.slice(WEB_LOCAL_PREFIX.length);
-      } else {
-        query = query.slice(WEB_PROD_PREFIX.length);
-      }
-
-      query = query.replace(/:/g, '#');
-
-      if (query.includes(SEARCH_PREFIX)) {
-        query = query.slice(SEARCH_PREFIX.length);
-        onSearch(query);
-        return;
-      } else {
-        query = `lbry://${query}`;
-        onSubmit(query);
-        return;
-      }
+    const slashPosition = uri.indexOf('/');
+    let query = uri.slice(slashPosition);
+    query = query.replace(/:/g, '#');
+    if (query.includes(SEARCH_PREFIX)) {
+      query = query.slice(SEARCH_PREFIX.length);
+      doSearch(query);
+    } else {
+      // TODO - double check this code path
+      let path = `lbry://${query}`;
+      const uri = formatLbryUrlForWeb(path);
+      navigateToUri(uri);
+      updateSearchQuery('');
     }
+  }
 
-    // User selected a suggestion
-    if (suggestion) {
-      if (suggestion.type === SEARCH_TYPES.SEARCH) {
-        onSearch(query);
-      } else if (suggestion.type === SEARCH_TYPES.TAG) {
-        history.push(`/$/${PAGES.DISCOVER}?t=${suggestion.value}`);
-      } else if (isURIValid(query)) {
-        const uri = normalizeURI(query);
-        onSubmit(uri);
-      } else {
-        showSnackError();
-      }
+  onClickSuggestion(query: string, suggestion: { value: string, type: string }): void {
+    const { navigateToUri, doSearch, doShowSnackBar } = this.props;
 
-      return;
+    if (suggestion.type === SEARCH_TYPES.SEARCH) {
+      doSearch(query);
+    } else if (suggestion.type === SEARCH_TYPES.TAG) {
+      const encodedSuggestion = encodeURIComponent(suggestion.value);
+      const uri = `/$/${PAGES.DISCOVER}?t=${encodedSuggestion}`;
+      navigateToUri(uri);
+    } else if (isURIValid(query)) {
+      let uri = normalizeURI(query);
+      uri = formatLbryUrlForWeb(uri);
+      navigateToUri(uri);
+    } else {
+      doShowSnackBar(INVALID_URL_ERROR);
     }
+  }
+
+  onSubmitRawString(st: string): void {
+    const { navigateToUri, doSearch, doShowSnackBar } = this.props;
     // Currently no suggestion is highlighted. The user may have started
     // typing, then lost focus and came back later on the same page
     try {
-      if (isURIValid(query)) {
-        const uri = normalizeURI(query);
-        onSubmit(uri);
+      if (isURIValid(st)) {
+        const uri = normalizeURI(st);
+        navigateToUri(uri);
       } else {
-        showSnackError();
+        doShowSnackBar(INVALID_URL_ERROR);
       }
     } catch (e) {
-      onSearch(query);
+      doSearch(st);
+    }
+  }
+
+  handleSubmit(value: string, suggestion?: { value: string, type: string }) {
+    let query = value.trim();
+    this.input && this.input.blur();
+
+    const wasCopiedFromWeb = [WEB_DEV_PREFIX, WEB_LOCAL_PREFIX, WEB_PROD_PREFIX].some(p => query.includes(p));
+    if (wasCopiedFromWeb) {
+      this.onSubmitWebUri(query);
+    } else if (suggestion) {
+      this.onClickSuggestion(query, suggestion);
+    } else {
+      this.onSubmitRawString(query);
     }
   }
 

--- a/ui/page/search/view.jsx
+++ b/ui/page/search/view.jsx
@@ -3,7 +3,7 @@ import { SIMPLE_SITE, SHOW_ADS } from 'config';
 import * as ICONS from 'constants/icons';
 import * as PAGES from 'constants/pages';
 import React, { useEffect, Fragment } from 'react';
-import { Lbry, regexInvalidURI, parseURI } from 'lbry-redux';
+import { Lbry, regexInvalidURI, parseURI, isNameValid } from 'lbry-redux';
 import ClaimPreview from 'component/claimPreview';
 import ClaimList from 'component/claimList';
 import Page from 'component/page';
@@ -50,11 +50,13 @@ export default function SearchPage(props: Props) {
   }
 
   const INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
-  let isValid = false;
   let path;
+  let isValid = true;
   try {
-    ({ path } = parseURI(urlQuery.replace(/ /g, '-').replace(/:/g, '#')));
-    isValid = true;
+    let { streamName } = parseURI(urlQuery.replace(/ /g, '-').replace(/:/g, '#'));
+    if (!isNameValid(streamName)) {
+      isValid = false;
+    }
   } catch (e) {
     isValid = false;
   }
@@ -94,7 +96,7 @@ export default function SearchPage(props: Props) {
       <section className="search">
         {urlQuery && (
           <Fragment>
-            {!SIMPLE_SITE && (
+            {!SIMPLE_SITE && isValid && (
               <header className="search__header">
                 <div className="claim-preview__actions--header">
                   <ClaimUri uri={uriFromQuery} noShortUrl />

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -45,7 +45,7 @@ export const getSearchSuggestions = (value: string) => (dispatch: Dispatch, getS
     return;
   }
 
-  fetch(`${CONNECTION_STRING}autocomplete?s=${searchValue}`)
+  fetch(`${CONNECTION_STRING}autocomplete?s=${encodeURIComponent(searchValue)}`)
     .then(handleFetchResponse)
     .then(apiSuggestions => {
       dispatch({
@@ -71,6 +71,8 @@ export const doUpdateSearchQuery = (query: string, shouldSkipSuggestions: ?boole
     type: ACTIONS.UPDATE_SEARCH_QUERY,
     data: { query },
   });
+
+  if (!query) return;
 
   // Don't fetch new suggestions if the user just added a space
   if (!query.endsWith(' ') || !shouldSkipSuggestions) {


### PR DESCRIPTION
This is another attempt at PR lbryio/lbry-desktop#4730

This includes the change suggested to fix the lingering bug from that commit.



## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 4516

## What is the current behavior?

Search query containing '%' causes app crash

## What is the new behavior?

Searches can now contain '%' character

## Other information

Api request was breaking for main search and autocomplete when query string included symbols such as '%' and whitespace.
The ClaimPreview component was also throwing an exception when the claim URI was invalid, causing the app to crash.

This PR fixes all of the above, and includes a minor refactor of the wunderbar component view/index.
I have hidden the URI header in the search page (which contains the ClaimPreview component, and a couple of URI-related links) for inavlid URIs.

The search functionality still logs an error to the console when the search string contains whitespace - this comes from directly calling ```console.error(...)``` in the ```parseURI``` method (lbry-redux project). This should probably be improved at some point.

Thanks!



<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
