### PR TITLE
Check search string for web URL prefixes and remove

### DIFF
--- a/ui/component/wunderbar/view.jsx
+++ b/ui/component/wunderbar/view.jsx
@@ -104,12 +104,11 @@ class WunderBar extends React.PureComponent<Props, State> {
     updateSearchQuery(value);
   }
 
-  onSubmitWebUri(uri: string) {
+  onSubmitWebUri(uri: string, prefix: string) {
     // Allow copying a lbry.tv url and pasting it into the search bar
     const { doSearch, navigateToUri, updateSearchQuery } = this.props;
 
-    const slashPosition = uri.indexOf('/');
-    let query = uri.slice(slashPosition);
+    let query = uri.slice(prefix.length);
     query = query.replace(/:/g, '#');
     if (query.includes(SEARCH_PREFIX)) {
       query = query.slice(SEARCH_PREFIX.length);
@@ -161,9 +160,16 @@ class WunderBar extends React.PureComponent<Props, State> {
     let query = value.trim();
     this.input && this.input.blur();
 
-    const wasCopiedFromWeb = [WEB_DEV_PREFIX, WEB_LOCAL_PREFIX, WEB_PROD_PREFIX].some(p => query.includes(p));
+    const includesLbryTvProd = query.includes(WEB_PROD_PREFIX);
+    const includesLbryTvLocal = query.includes(WEB_LOCAL_PREFIX);
+    const includesLbryTvDev = query.includes(WEB_DEV_PREFIX);
+    const wasCopiedFromWeb = includesLbryTvDev || includesLbryTvLocal || includesLbryTvProd;
+
     if (wasCopiedFromWeb) {
-      this.onSubmitWebUri(query);
+      let prefix = WEB_PROD_PREFIX;
+      if (includesLbryTvLocal) prefix = WEB_LOCAL_PREFIX;
+      if (includesLbryTvDev) prefix = WEB_DEV_PREFIX;
+      this.onSubmitWebUri(query, prefix);
     } else if (suggestion) {
       this.onClickSuggestion(query, suggestion);
     } else {

--- a/ui/page/search/view.jsx
+++ b/ui/page/search/view.jsx
@@ -50,10 +50,10 @@ export default function SearchPage(props: Props) {
   }
 
   const INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
-  let path;
+  let path, streamName;
   let isValid = true;
   try {
-    let { streamName } = parseURI(urlQuery.replace(/ /g, '-').replace(/:/g, '#'));
+    ({ path, streamName } = parseURI(urlQuery.replace(/ /g, '-').replace(/:/g, '#')));
     if (!isNameValid(streamName)) {
       isValid = false;
     }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: 4758

## What is the current behavior?

404 when pasting URL from web browser into search bar, and some channel/stream URLs being reformatted before submitting, causing a search to be executed as opposed to directly navigating to the correct page.

## What is the new behavior?

App navigates to correct page

## Other information

This bug was introduced by a refactor to the wunderbar component by me a few days ago. It's annoying to have to check for all 3 of prod, dev and local environment url prefixes in the production code, so I attempted to re-write. This introduced the bug and the 3-way check has been re-introduced by this PR. It seems like we are stuck with this check for now.

Another problem was the logic deciding whether to hide the search page URI header... (see changes below) It has now been fixed.

*** Please test this branch before accepting the PR. As far as I can tell, the wunderbar is working correctly now. However I am new to this project and I imagine there are still some behaviours/test cases that I am not aware of (... this led to the bug originally being introducted in the initial PR earlier this week).

Thanks!

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
