### PR TITLE
Clear 'passwordSet*' flags too in USER_PASSWORD_SET_CLEAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Floating player: Stay within screen when window is resized _community pr!_([#4750](https://github.com/lbryio/lbry-desktop/pull/4750))
 - App crash when including % sign in search _community pr!_([#4753](https://github.com/lbryio/lbry-desktop/pull/4753))
 - First comment on claim not showing up immeditately ([#4747](https://github.com/lbryio/lbry-desktop/pull/4747))
+- Fix "Password updated successfully" kept showing up _community pr!_([#4766](https://github.com/lbryio/lbry-desktop/pull/4766))
 
 ## [0.47.1] - [2020-07-23]
 

--- a/ui/redux/reducers/user.js
+++ b/ui/redux/reducers/user.js
@@ -171,6 +171,8 @@ reducers[ACTIONS.USER_PASSWORD_SET_CLEAR] = state =>
     passwordResetSuccess: false,
     passwordResetPending: false,
     passwordResetError: null,
+    passwordSetPending: false,
+    passwordSetSuccess: false,
   });
 
 reducers[ACTIONS.USER_EMAIL_VERIFY_STARTED] = state =>


### PR DESCRIPTION
## Issue
Fixes #4749: ["Password updated successfully" kept showing up](https://github.com/lbryio/lbry-desktop/issues/4749)

## Change
In addition to the `passwordReset*` variables, reset the `passwordSet*` variables as well in `USER_PASSWORD_SET_CLEAR`.

_Based on current usage, I think it's ok to re-use USER_PASSWORD_SET_CLEAR instead of creating another one to differentiate between Reset and Set?_