### PR TITLE
Fix "Price=free" giving 0 results in Following query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix markdown editor "preview" not working when `<iframe>`s are present _community pr!_([#4767](https://github.com/lbryio/lbry-desktop/pull/4767))
 - First comment on claim not showing up immeditately ([#4747](https://github.com/lbryio/lbry-desktop/pull/4747))
 - Fix "Password updated successfully" kept showing up _community pr!_([#4766](https://github.com/lbryio/lbry-desktop/pull/4766))
+- Fix "Price=free" giving 0 results in Following query _community pr!_ ([#4489](https://github.com/lbryio/lbry-desktop/pull/4489))
 
 ## [0.47.1] - [2020-07-23]
 

--- a/ui/constants/claim_search.js
+++ b/ui/constants/claim_search.js
@@ -13,7 +13,7 @@ export const TAGS_FOLLOWED = 'tags_followed';
 export const FEE_AMOUNT_KEY = 'fee_amount';
 export const FEE_AMOUNT_ANY = '>=0';
 export const FEE_AMOUNT_ONLY_PAID = '>0';
-export const FEE_AMOUNT_ONLY_FREE = '0';
+export const FEE_AMOUNT_ONLY_FREE = '<=0';
 
 export const FRESH_DAY = 'day';
 export const FRESH_WEEK = 'week';


### PR DESCRIPTION
- This re-opens #4489 [Fix "Price=free" giving 0 results in Following query](https://github.com/lbryio/lbry-desktop/pull/4489) after  conversation in [Discord](https://discord.com/channels/362322208485277697/377895389992321064/756180990887591978). (github didn't allow me to re-open that PR)
- Fixes #4477