### PR TITLE
Remove background color from img.channel-thumbnail__custom

### DIFF
--- a/ui/scss/component/_channel.scss
+++ b/ui/scss/component/_channel.scss
@@ -87,7 +87,6 @@ $metadata-z-index: 1;
 .channel-thumbnail__custom {
   width: 100%;
   object-fit: cover;
-  background-color: var(--color-thumbnail-background);
 }
 
 .channel-thumbnail__default {


### PR DESCRIPTION
#4019  PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe:

Many of the creators including myself use transparency to achieve some effect. We all love PNGs and GIFs, so please dont shoot in your leg by limiting creative potential :)

For example: you can see the effect here, you can inspect element and remove background color from channel "profile image": https://lbry.tv/@LBRYlytics:4, before recent changes it was without background color, and is what many of us expect.