### PR TITLE
Claim List channel items' thumb fix

### DIFF
--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -47,7 +47,6 @@ import BuyPage from 'page/buy';
 import NotificationsPage from 'page/notifications';
 import SignInWalletPasswordPage from 'page/signInWalletPassword';
 import YoutubeSyncPage from 'page/youtubeSync';
-import SignInWalletPasswordPage from 'page/signInWalletPassword';
 import { LINKED_COMMENT_QUERY_PARAM } from 'constants/comment';
 import { parseURI } from 'lbry-redux';
 import { SITE_TITLE, WELCOME_VERSION } from 'config';

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -213,8 +213,12 @@ $thumbnailWidthSmall: 1.5rem;
 
 .comment__actions--nested {
   @extend .comment__actions;
-  margin-left: calc((#{$thumbnailWidthSmall} + var(--spacing-l)));
+  margin-left: calc((#{$thumbnailWidthSmall} + var(--spacing-xs)));
   margin-top: var(--spacing-m);
+
+  @media (min-width: $breakpoint-small) {
+    margin-left: calc((#{$thumbnailWidth} + var(--spacing-m)));
+  }
 }
 
 .comment__action {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe:

## Fixes
## What is the current behavior?
Channel thumbs are square dimensions in 99.9% cases. New claim listing UI (for example "Discover" screen) assumes all thumbs are for content in some aspect ratio. That is why channel items look strange.
## What is the new behavior?
Channel thumbs' backgrounds are set to contain size and transparent background, looks much better