### PR TITLE
handle comment time display correctly immediately after posting

### DIFF
--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -177,9 +177,9 @@ function Comment(props: Props) {
                 className="button--uri-indicator"
                 navigate={`${uri}?lc=${commentId}`}
                 label={
-                  <time className="comment__time" dateTime={timePosted}>
-                    {DateTime.getTimeAgoStr(timePosted)}
-                  </time>
+                  <span className="comment__time">
+                    <DateTime date={timePosted} timeAgo />
+                  </span>
                 }
               />
             </div>

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -35,7 +35,12 @@ class DateTime extends React.PureComponent<Props> {
     // Strip off the 's' for the singular suffix, construct the string ID,
     // then load the localized version.
     const suffix = duration === 1 ? suffixList[i].substr(0, suffixList[i].length - 1) : suffixList[i];
-    const strId = '%duration% ' + suffix + ' ago';
+    let strId = '%duration% ' + suffix + ' ago';
+
+    if (!suffix) {
+      strId = 'Just now';
+    }
+
     return __(strId, { duration });
   }
 

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -151,7 +151,7 @@ $thumbnailWidthSmall: 1.5rem;
 }
 
 .comment__time {
-  opacity: 0.3;
+  opacity: 0.5;
   white-space: nowrap;
   height: 100%;
 }


### PR DESCRIPTION
When we displayed comments less than 1 second old, it would say "500 ago" (500 ms ago).

If there is no suffix, assume it is less than one second ago and show "Just now" as the time