### PR TITLE
initial page view sets referring channel

### DIFF
--- a/ui/component/router/index.js
+++ b/ui/component/router/index.js
@@ -4,6 +4,9 @@ import { selectHasNavigated, selectScrollStartingPosition, selectWelcomeVersion 
 import Router from './view';
 import { normalizeURI, makeSelectTitleForUri } from 'lbry-redux';
 import { doSetHasNavigated } from 'redux/actions/app';
+import { doUserSetReferrer } from 'redux/actions/user';
+import { selectHasUnclaimedRefereeReward } from 'redux/selectors/rewards';
+
 const select = state => {
   const { pathname, hash } = state.router.location;
   const urlPath = pathname + hash;
@@ -28,11 +31,13 @@ const select = state => {
     isAuthenticated: selectUserVerifiedEmail(state),
     welcomeVersion: selectWelcomeVersion(state),
     hasNavigated: selectHasNavigated(state),
+    hasUnclaimedRefereeReward: selectHasUnclaimedRefereeReward(state),
   };
 };
 
 const perform = dispatch => ({
   setHasNavigated: () => dispatch(doSetHasNavigated()),
+  setReferrer: referrer => dispatch(doUserSetReferrer(referrer)),
 });
 
 export default connect(select, perform)(Router);

--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -50,7 +50,7 @@ import NotificationsPage from 'page/notifications';
 import SignInWalletPasswordPage from 'page/signInWalletPassword';
 import YoutubeSyncPage from 'page/youtubeSync';
 import { LINKED_COMMENT_QUERY_PARAM } from 'constants/comment';
-import { parseURI } from 'lbry-redux';
+import { parseURI, isURIValid } from 'lbry-redux';
 import { SITE_TITLE, WELCOME_VERSION } from 'config';
 
 const dynamicRoutes = Object.values(SIDEBAR_ROUTES).filter(
@@ -105,6 +105,8 @@ type Props = {
   welcomeVersion: number,
   hasNavigated: boolean,
   setHasNavigated: () => void,
+  setReferrer: string => void,
+  hasUnclaimedRefereeReward: boolean,
 };
 
 function AppRouter(props: Props) {
@@ -118,6 +120,8 @@ function AppRouter(props: Props) {
     welcomeVersion,
     hasNavigated,
     setHasNavigated,
+    hasUnclaimedRefereeReward,
+    setReferrer,
   } = props;
   const { entries } = history;
   const entryIndex = history.index;
@@ -134,6 +138,16 @@ function AppRouter(props: Props) {
     });
     return unlisten;
   }, [hasNavigated, setHasNavigated]);
+
+  useEffect(() => {
+    if (!hasNavigated && hasUnclaimedRefereeReward) {
+      const valid = isURIValid(uri);
+      if (valid) {
+        const { path } = parseURI(uri);
+        setReferrer(path);
+      }
+    }
+  }, [hasNavigated, uri, hasUnclaimedRefereeReward, setReferrer]);
 
   useEffect(() => {
     if (uri) {

--- a/ui/redux/selectors/rewards.js
+++ b/ui/redux/selectors/rewards.js
@@ -57,3 +57,7 @@ export const selectReferralReward = createSelector(
   selectUnclaimedRewards,
   unclaimedRewards => unclaimedRewards.filter(reward => reward.reward_type === REWARDS.TYPE_REFERRAL)[0]
 );
+
+export const selectHasUnclaimedRefereeReward = createSelector(selectUnclaimedRewards, unclaimedRewards =>
+  unclaimedRewards.some(reward => reward.reward_type === REWARDS.TYPE_REFEREE)
+);


### PR DESCRIPTION
When page is loaded directly onto a claim, if referee reward not claimed, resolve claim and set referer to channel uri.
It seems to make sense that if some content brings you in (again) and you end up getting through reward verification after it, that content's channel may as well be your referrer.