### PR TITLE
Fix: Videos start muted on initial session

### DIFF
--- a/ui/redux/reducers/app.js
+++ b/ui/redux/reducers/app.js
@@ -85,7 +85,7 @@ const defaultState: AppState = {
 // @@router comes from react-router
 // This action is dispatched any time a user navigates forward or back
 try {
-  defaultState.volume = Number(sessionStorage.getItem('volume'));
+  defaultState.volume = Number(sessionStorage.getItem('volume') || 1);
 } catch (e) {}
 
 reducers['@@router/LOCATION_CHANGE'] = (state, action) => {


### PR DESCRIPTION
## Issue
Closes #4831: [Videos start muted on Desktop (fresh install) and web (sometimes resets)](https://github.com/lbryio/lbry-desktop/issues/4831)

This covers the Desktop fresh install and Web fresh session (incognito) part. 
It doesn't cover the "sometimes reset" part -- not sure how to reproduce that.

## Change
`sessionStorage` is always empty when that piece of code is called, even for non-fresh Desktop and even in Brave. 
`localStorage` doesn't have a `volume` entry either.

We now fallback to `1` when `volume` is `null`. Still not sure the purpose of that code, but leaving it there just in case something relies on it.

## Tests
[/] Desktop fresh-install is not muted.
[/] Desktop return session restores previous volume level.
[/] Web* fresh session (cleared data) is not muted.
[/] Web return session restores previous volume level.

*Web = Chrome, Firefox and Brave.