### PR TITLE
disable snapshot thumbnail on desktop to prevent desktop crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+- Disable snapshot thumbnail upload on desktop until Electron issue is fixed ([#4905](https://github.com/lbryio/lbry-desktop/pull/4905))
+
+### Fixed
+
+
+
+## [0.48.1] - [2020-10-14]
+
+### Added
+
 - Add Publish Preview dialog _community pr!_ ([#4620](https://github.com/lbryio/lbry-desktop/pull/4620))
 - "ctrl/cmd+enter" can now be used to directly submit a comment ([#4809](https://github.com/lbryio/lbry-desktop/pull/4809))
 - Deeper comment thread depth ([#4868](https://github.com/lbryio/lbry-desktop/pull/4868))

--- a/ui/component/selectThumbnail/view.jsx
+++ b/ui/component/selectThumbnail/view.jsx
@@ -156,7 +156,9 @@ class SelectThumbnail extends React.PureComponent<Props, State> {
               label={__('Enter a thumbnail URL')}
               onClick={() => updatePublishForm({ uploadThumbnailStatus: THUMBNAIL_STATUSES.MANUAL })}
             />
-            {isSupportedVideo && (
+            {isSupportedVideo && IS_WEB && (
+              // Disabled on desktop until this is resolved
+              // https://github.com/electron/electron/issues/20750#issuecomment-709505902
               <Button
                 button="link"
                 label={__('Take a snapshot from your video')}


### PR DESCRIPTION
https://github.com/electron/electron/issues/20750#issuecomment-709505902