### PR TITLE
Notification fixes

### DIFF
--- a/ui/component/notification/view.jsx
+++ b/ui/component/notification/view.jsx
@@ -66,6 +66,10 @@ export default function Notification(props: Props) {
     case NOTIFICATIONS.NOTIFICATION_REPLY:
       icon = <ChannelThumbnail small uri={notification_parameters.dynamic.reply_author} />;
       break;
+    case NOTIFICATIONS.DAILY_WATCH_AVAILABLE:
+    case NOTIFICATIONS.DAILY_WATCH_REMIND:
+      icon = <Icon icon={ICONS.LBC} sectionIcon className="notification__icon" />;
+      break;
     default:
       icon = <Icon icon={ICONS.NOTIFICATION} sectionIcon className="notification__icon" />;
   }

--- a/ui/redux/actions/notifications.js
+++ b/ui/redux/actions/notifications.js
@@ -44,7 +44,7 @@ export function doDismissError() {
 export function doNotificationList() {
   return (dispatch: Dispatch) => {
     dispatch({ type: ACTIONS.NOTIFICATION_LIST_STARTED });
-    return Lbryio.call('notification', 'list')
+    return Lbryio.call('notification', 'list', { is_app_readable: true })
       .then(response => {
         const notifications = response || [];
         const channelsToResolve = notifications


### PR DESCRIPTION
Now passes `is_app_readable` to `notification/list` so the app doesn't receive email only notifications
Uses LBC icon for reward notifications