### PR TITLE
pass max-age header on js bundle so cloudflare can cache it

### DIFF
--- a/web/middleware/cache-control.js
+++ b/web/middleware/cache-control.js
@@ -23,7 +23,7 @@ async function redirectMiddleware(ctx, next) {
     request: { url },
   } = ctx;
 
-  if (STATIC_ASSET_PATHS.includes(url)) {
+  if (STATIC_ASSET_PATHS.includes(url) || (url.startsWith('/public/ui-') && url.endsWith('.js'))) {
     ctx.set('Cache-Control', `public, max-age=${SIX_MONTHS_IN_SECONDS}`);
   }
 


### PR DESCRIPTION
Not the best solution. I think I need to revisit the bundleId creation. It's really hard to work with.