### PR TITLE
Fix long tag query-URL when changing between [Trending|New|Top]

### DIFF
--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -140,8 +140,8 @@ function ClaimListHeader(props: Props) {
   function buildUrl(delta) {
     const newUrlParams = new URLSearchParams(location.search);
     CS.KEYS.forEach(k => {
-      // $FlowFixMe append() can't take null as second arg, but get() can return null
-      if (urlParams.get(k) !== null) newUrlParams.append(k, urlParams.get(k));
+      // $FlowFixMe get() can return null
+      if (urlParams.get(k) !== null) newUrlParams.set(k, urlParams.get(k));
     });
 
     switch (delta.key) {


### PR DESCRIPTION
## Issue
Fixes #4393: [Tag query URL goes on indefinitely as you change between [Trending|New|Top]](https://github.com/lbryio/lbry-desktop/issues/4393)

## Change
Change from `append` to `set` when building the query to remove duplicates.

Flow hates null being not a string, so the FixMe was retained.