### PR TITLE
Fix str-related issues with new Language setting

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1462,6 +1462,7 @@
   "None selected": "None selected",
   "Secondary Language": "Secondary Language",
   "Your other content language": "Your other content language",
+  "Search only in this language by default": "Search only in this language by default",
   "This link leads to an external website.": "This link leads to an external website.",
   "Hold on, we are setting up your account": "Hold on, we are setting up your account",
   "No Content Found": "No Content Found",

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1457,7 +1457,6 @@
   "Pin": "Pin",
   "Unpin": "Unpin",
   "LBRY leveled up": "LBRY leveled up",
-  "Post": "Post",
   "Primary Language": "Primary Language",
   "Your main content language": "Your main content language",
   "None selected": "None selected",

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1468,16 +1468,5 @@
   "Publish Something": "Publish Something",
   "Watch on lbry.tv": "Watch on lbry.tv",
   "Paid content cannot be embedded.": "Paid content cannot be embedded.",
-  "Hrvatski": "Hrvatski",
-  "Nederlands": "Nederlands",
-  "Français": "Français",
-  "Deutsch": "Deutsch",
-  "Italiano": "Italiano",
-  "Polski": "Polski",
-  "Português": "Português",
-  "Русский": "Русский",
-  "Español": "Español",
-  "Türkçe": "Türkçe",
-  "Česky": "Česky",
   "--end--": "--end--"
 }

--- a/ui/component/channelAbout/view.jsx
+++ b/ui/component/channelAbout/view.jsx
@@ -71,7 +71,7 @@ function ChannelAbout(props: Props) {
             {/* this could use some nice 'tags' styling */}
             {languages && languages.length
               ? languages.reduce((acc, lang, i) => {
-                  return acc + `${__(SUPPORTED_LANGUAGES[lang])}` + ' ';
+                  return acc + `${SUPPORTED_LANGUAGES[lang]}` + ' ';
                 }, '')
               : null}
           </div>

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -385,7 +385,7 @@ function ClaimListHeader(props: Props) {
                     {Object.entries(SEARCHABLE_LANGUAGES).map(([code, label]) => {
                       return (
                         <option key={code} value={code}>
-                          {__(String(label))}
+                          {String(label)}
                         </option>
                       );
                     })}


### PR DESCRIPTION
```
  "Hrvatski": "Hrvatski",
  "Nederlands": "Nederlands",
  "Français": "Français",
  "Deutsch": "Deutsch",
  "Italiano": "Italiano",
  "Polski": "Polski",
  "Português": "Português",
  "Русский": "Русский",
  "Español": "Español",
  "Türkçe": "Türkçe",
  "Česky": "Česky",
```
**Remove translation macro on native language names.**
I believe we don't translate these since this is already the translated form?
(Well, there's a possibility that the original intention was to translate those languages into everyone's local language.  If that was the intention, I think we'll need to change those strings to the English version instead?  e.g. I don't know what Русский is to make the translation without googling)

**Use the contextual version of 'Post' instead of creating a new one.**
I couldn't find where this new 'Post' is being used, so I assume it's the same as the old one for now. If it appears in the list again, I'll ask around to put the context-metadata.

**Add 'Search only in this language by default'**