### PR TITLE
claim_search: Don't clear past page results if subsequent pages timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Loss of subscriptions on startup ([#4882](https://github.com/lbryio/lbry-desktop/pull/4882))
+- Fix lost search results when a timeout occurs _community pr!_ ([#4996](https://github.com/lbryio/lbry-desktop/pull/4996))
 
 ## [0.48.2] - [2020-10-16]
 

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#c86810038c966f5d88e1df7b787fbe1d31a96802",
+    "lbry-redux": "lbryio/lbry-redux#8093d69807d890f4110be0b2aa629e3df5945661",
     "lbryinc": "lbryio/lbryinc#2a9d04b2efcae0a68b7315bf04632db4a757461c",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -356,6 +356,7 @@ function ClaimListDiscover(props: Props) {
     claimSearchResult === undefined ||
     didNavigateForward ||
     (!loading &&
+      !claimSearchResultLastPageReached &&
       claimSearchResult &&
       claimSearchResult.length &&
       claimSearchResult.length < dynamicPageSize * options.page &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -7411,9 +7411,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#c86810038c966f5d88e1df7b787fbe1d31a96802:
+lbry-redux@lbryio/lbry-redux#8093d69807d890f4110be0b2aa629e3df5945661:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/c86810038c966f5d88e1df7b787fbe1d31a96802"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/8093d69807d890f4110be0b2aa629e3df5945661"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
## Issue
Fixes #4609: [If claim search on latter page fails, don't clear out all previous data](https://github.com/lbryio/lbry-desktop/issues/4609)

## Change
This requires an accompanying change in `lbry-redux` (https://github.com/lbryio/lbry-redux/pull/365) that sets `claimSearchResultsLastPageReached` to `true` when the timeout occurs, and also not purging the previous pages.

## Test Case:
1. https://lbry.tv/$/discover?t=imherelbry&content=video&order=top&fresh=year
2. Scroll down 5 pages until 100 results are shown.
3. When querying the 6th page, a timeout occurs and the past results are gone.