### PR TITLE
Fix sidebar tooltip showing string with context metadata.

### DIFF
--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -336,6 +336,7 @@ function SideNavigation(props: Props) {
                     <Button
                       {...passedProps}
                       label={__(linkProps.title)}
+                      title={__(linkProps.title)}
                       //   $FlowFixMe
                       navigate={linkProps.route || linkProps.link}
                       icon={pulseLibrary && linkProps.icon === ICONS.LIBRARY ? ICONS.PURCHASED : linkProps.icon}
@@ -415,6 +416,7 @@ function SideNavigation(props: Props) {
                         {...passedProps}
                         navigate={route || link}
                         label={__(linkProps.title)}
+                        title={__(linkProps.title)}
                         icon={pulseLibrary && linkProps.icon === ICONS.LIBRARY ? ICONS.PURCHASED : linkProps.icon}
                         className={classnames('navigation-link', {
                           'navigation-link--pulse': linkProps.icon === ICONS.LIBRARY && pulseLibrary,
@@ -437,6 +439,7 @@ function SideNavigation(props: Props) {
                         {...passedProps}
                         navigate={linkProps.link}
                         label={__(linkProps.title)}
+                        title={__(linkProps.title)}
                         className="navigation-link"
                         activeClass="navigation-link--active"
                       />


### PR DESCRIPTION
## Issue
In the odysee branch, the tooltip for `Following` in the Sidebar was shown as `Following --[sidebar]--`.
In lbry.tv, the tooltip doesn't appear.

I believe the tooltip appeared due to the name change from 'label' to 'title' and then being passed to Button through '...passedProps'.

Fix by explicitly setting the Button's 'title' to the localized text.