### PR TITLE
Fix sidebar tooltip showing string with context metadata. 

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -484,7 +484,7 @@
   "In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this channel from our applications.": "In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this channel from our applications.",
   "Read More": "Read More",
   "Read more": "Read more",
-  "Multi-language support is brand new and incomplete. Switching your language may have unintended consequences, like glossolalia.": "Multi-language support is brand new and incomplete. Switching your language may have unintended consequences, like glossolalia.",
+  "Tailor your experience.": "Tailor your experience.",
   "Save Password": "Save Password",
   "Automatically unlock your wallet on startup": "Automatically unlock your wallet on startup",
   "Dark": "Dark",

--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -336,6 +336,7 @@ function SideNavigation(props: Props) {
                     <Button
                       {...passedProps}
                       label={__(linkProps.title)}
+                      title={__(linkProps.title)}
                       //   $FlowFixMe
                       navigate={linkProps.route || linkProps.link}
                       icon={pulseLibrary && linkProps.icon === ICONS.LIBRARY ? ICONS.PURCHASED : linkProps.icon}
@@ -415,6 +416,7 @@ function SideNavigation(props: Props) {
                         {...passedProps}
                         navigate={route || link}
                         label={__(linkProps.title)}
+                        title={__(linkProps.title)}
                         icon={pulseLibrary && linkProps.icon === ICONS.LIBRARY ? ICONS.PURCHASED : linkProps.icon}
                         className={classnames('navigation-link', {
                           'navigation-link--pulse': linkProps.icon === ICONS.LIBRARY && pulseLibrary,
@@ -437,6 +439,7 @@ function SideNavigation(props: Props) {
                         {...passedProps}
                         navigate={linkProps.link}
                         label={__(linkProps.title)}
+                        title={__(linkProps.title)}
                         className="navigation-link"
                         activeClass="navigation-link--active"
                       />


### PR DESCRIPTION
This is actually identical to #5007, but now done on `master`.

I just noticed that a few odysee changes were promoted to master yesterday, and the issue got moved to `master`, so I'm moving this commit to `master` as well.  I believe when odysee rebases later, there should be not conflict (auto removed).

Also snuck in 1 string update.