### PR TITLE
Hide mouse cursor when video is playing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Loss of subscriptions on startup ([#4882](https://github.com/lbryio/lbry-desktop/pull/4882))
 - Fix lost search results when a timeout occurs _community pr!_ ([#4996](https://github.com/lbryio/lbry-desktop/pull/4996))
 - Can't slide volume slider in pop-sout mode _community pr!_ ([#4913](https://github.com/lbryio/lbry-desktop/pull/4913))
+- Hide mouse cursor when video is playing _community pr!_ ([#5046](https://github.com/lbryio/lbry-desktop/pull/5046))
 
 ## [0.48.2] - [2020-10-16]
 

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1484,5 +1484,7 @@
   "Short (< 4 minutes)": "Short (< 4 minutes)",
   "Long (> 20 min)": "Long (> 20 min)",
   "POWERED BY %lbry_link%": "POWERED BY %lbry_link%",
+  "Learn more about LBRY Credits on %DOMAIN%": "Learn more about LBRY Credits on %DOMAIN%",
+  "Results boosted by %lbc%": "Results boosted by %lbc%",
   "--end--": "--end--"
 }

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -126,7 +126,7 @@
   video {
     cursor: pointer;
   }
-  .video-js.vjs-fullscreen.vjs-user-inactive.vjs-playing {
+  .video-js.vjs-user-inactive.vjs-playing {
     video {
       cursor: none;
     }


### PR DESCRIPTION
## Issue:
Fixes #5044: Auto hide cursor on video on static hover

## Approach
The existing code only hides the cursor when playing in fullscreen. Extend that to normal mode as well.
