### PR TITLE
Fix double translation in homepage

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1481,7 +1481,6 @@
   "Homepage": "Homepage",
   "Currently winning": "Currently winning",
   "URL can not include a space": "URL can not include a space",
-  "Creator analytics are down for maintenance. Please check back later.": "Creator analytics are down for maintenance. Please check back later.",
   "Sign up to earn %lbc% for you and your favorite creators.": "Sign up to earn %lbc% for you and your favorite creators.",
   "Short (< 4 minutes)": "Short (< 4 minutes)",
   "Long (> 20 min)": "Long (> 20 min)",

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -55,7 +55,7 @@ function HomePage(props: Props) {
             <h1 className="claim-grid__header">
               <Button navigate={route || link} button="link">
                 {icon && <Icon className="claim-grid__header-icon" sectionIcon icon={icon} size={20} />}
-                <span className="claim-grid__title">{__(title)}</span>
+                <span className="claim-grid__title">{title}</span>
                 {help}
               </Button>
             </h1>


### PR DESCRIPTION
## Issue
The "Trending for xxx" string was being resolved and translated twice, so it often re-appears in the string list during development.

## Change
It seems like `getHomepage` is repopulated every time, so I think it is safe to just resolve and translate `title` at that level.

## Extra
Remove unused "Creator analytics are down" message per recent changes.