### PR TITLE
eliminate scrollbar jumping in the sidebar

### DIFF
--- a/ui/scss/component/_navigation.scss
+++ b/ui/scss/component/_navigation.scss
@@ -168,6 +168,7 @@
     padding: var(--spacing-s);
     justify-content: flex-start;
     flex-direction: column;
+    width: var(--side-nav-width--micro);
   }
 
   .button__label {


### PR DESCRIPTION
Fixes #5115 [eliminate scrollbar jumping in the sidebar](https://github.com/lbryio/lbry-desktop/issues/5115)

Make the content's width the same as the area, so that the "column flex" won't cause a shift.