### PR TITLE
Don't parse a 'mailto:' into a lbry link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.49.0] - [2020-12-10]
+
+### Added
+
 - Better search suggestions ([#5124](https://github.com/lbryio/lbry-desktop/pull/5124))
 - Inline video player in comments/markdown posts ([#4894](https://github.com/lbryio/lbry-desktop/pull/4894))
 - Better handling of winning claim + top page improvements ([#4944](https://github.com/lbryio/lbry-desktop/pull/4944))

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1504,8 +1504,5 @@
   "Now following %channel%!": "Now following %channel%!",
   "Turn Back On": "Turn Back On",
   "Turn Off": "Turn Off",
-  "Search Results": "Search Results",
-  "View All Results": "View All Results",
-  "Most Supported": "Most Supported",
   "--end--": "--end--"
 }

--- a/ui/component/markdownLink/view.jsx
+++ b/ui/component/markdownLink/view.jsx
@@ -40,7 +40,7 @@ function MarkdownLink(props: Props) {
   } catch (e) {}
 
   let lbryUrlFromLink;
-  if (linkUrlObject) {
+  if (linkUrlObject && !href.startsWith('mailto:')) {
     const linkDomain = linkUrlObject.host;
     const isKnownAppDomainLink = KNOWN_APP_DOMAINS.includes(linkDomain);
     if (isKnownAppDomainLink) {


### PR DESCRIPTION
## Issue
Closes #5130: [Support mailto hyperlinks / urls in markdown](https://github.com/lbryio/lbry-desktop/issues/5130)

## Change
The markdown components already support mailto, just that the logic here ended up making it a 'ClaimLink'