### PR TITLE
Fix "Not Now"

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -418,6 +418,7 @@
   "Unclaimable": "Unclaimable",
   "Claimed": "Claimed",
   "Enter reward code": "Enter reward code",
+  "Redeem a custom reward code for": "Redeem a custom reward code for",
   "Redeem": "Redeem",
   "Code": "Code",
   "Nothing here": "Nothing here",
@@ -900,6 +901,7 @@
   "Community Choice?": "Community Choice?",
   "Download to your Library": "Download to your Library",
   "Leave a Comment": "Leave a Comment",
+  "That was pretty deep. What do you think?": "That was pretty deep. What do you think?",
   "%repost_total% Reposts": "%repost_total% Reposts",
   "File Description": "File Description",
   "View %count% reposts": "View %count% reposts",
@@ -1532,5 +1534,6 @@
   "Repost url": "Repost url",
   "Close sidebar - hide channels you are following": "Close sidebar - hide channels you are following",
   "Expand sidebar - view channels you are following.": "Expand sidebar - view channels you are following.",
+  "You have found the edge of the internet. %repost% or %publish% your stuff here to claim this spot.": "You have found the edge of the internet. %repost% or %publish% your stuff here to claim this spot.",
   "--end--": "--end--"
 }

--- a/ui/modal/modalAutoUpdateDownloaded/view.jsx
+++ b/ui/modal/modalAutoUpdateDownloaded/view.jsx
@@ -35,7 +35,7 @@ class ModalAutoUpdateDownloaded extends React.PureComponent<Props, State> {
         contentLabel={__('Upgrade Downloaded')}
         title={__('LBRY leveled up')}
         confirmButtonLabel={__('Upgrade Now')}
-        abortButtonLabel={__('Not now')}
+        abortButtonLabel={__('Not Now')}
         confirmButtonDisabled={this.state.disabled}
         onConfirmed={() => {
           this.setState({ disabled: true });


### PR DESCRIPTION
## Issue:
https://discord.com/channels/362322208485277697/646840786662719488/788694493532520458
![image](https://user-images.githubusercontent.com/64950861/102467773-a5ba1680-408b-11eb-99e7-e0c71058a2c0.png)

## Change:
It's either adding the non-capitalized "Not now" to the list, or change the usage to "Not Now".

Chose the latter since the rest of the modal (and other usages) is using the capitalized format.