### PR TITLE
Desktop: Enable 'Alt+Left/Right' for history navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Desktop: Enable 'Alt+Left/Right' for history navigation _community pr!_ ([#5203](https://github.com/lbryio/lbry-desktop/pull/5203))
+
 ### Changed
 
 ### Fixed

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -22,6 +22,7 @@ import Spinner from 'component/spinner';
 import SyncFatalError from 'component/syncFatalError';
 // @if TARGET='app'
 import useZoom from 'effects/use-zoom';
+import useHistoryNav from 'effects/use-history-nav';
 // @endif
 // @if TARGET='web'
 import OpenInAppLink from 'web/component/openInAppLink';
@@ -190,6 +191,11 @@ function App(props: Props) {
   // Enable ctrl +/- zooming on Desktop.
   // @if TARGET='app'
   useZoom();
+  // @endif
+
+  // Enable 'Alt + Left/Right' for history navigation on Desktop.
+  // @if TARGET='app'
+  useHistoryNav(history);
   // @endif
 
   useEffect(() => {

--- a/ui/effects/use-history-nav.js
+++ b/ui/effects/use-history-nav.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+export default function useHistoryNav(history) {
+  useEffect(() => {
+    const handleKeyPress = e => {
+      if ((e.metaKey || e.altKey) && !e.ctrlKey && !e.shiftKey) {
+        switch (e.code) {
+          case 'ArrowLeft':
+            e.preventDefault();
+            history.goBack();
+            break;
+          case 'ArrowRight':
+            e.preventDefault();
+            history.goForward();
+            break;
+          default:
+            // Do nothing
+            break;
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyPress);
+    return () => window.removeEventListener('keydown', handleKeyPress);
+  }, []);
+}


### PR DESCRIPTION
## Why
- Consistent behavior across Web and Desktop.