### PR TITLE
Fix initial pause state for the Autoplay Countdown

### DIFF
--- a/ui/component/autoplayCountdown/view.jsx
+++ b/ui/component/autoplayCountdown/view.jsx
@@ -61,18 +61,25 @@ function AutoplayCountdown(props: Props) {
     }
   }, [navigateUrl, nextRecommendedUri, isFloating, doSetPlayingUri, doPlayUri, push]);
 
+  function shouldPauseAutoplay() {
+    const elm = document.querySelector(`.${CLASSNAME_AUTOPLAY_COUNTDOWN}`);
+    return elm && elm.getBoundingClientRect().top < 0;
+  }
+
+  // Update 'setTimerPaused'.
   React.useEffect(() => {
+    // Ensure correct 'setTimerPaused' on initial render.
+    setTimerPaused(shouldPauseAutoplay());
+
     const handleScroll = debounce(e => {
-      const elm = document.querySelector(`.${CLASSNAME_AUTOPLAY_COUNTDOWN}`);
-      if (elm) {
-        setTimerPaused(elm.getBoundingClientRect().top < 0);
-      }
+      setTimerPaused(shouldPauseAutoplay());
     }, DEBOUNCE_SCROLL_HANDLER_MS);
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Update countdown timer.
   React.useEffect(() => {
     let interval;
     if (!timerCanceled && nextRecommendedUri) {


### PR DESCRIPTION
## Issue
Closes #5204: [Don't autoplay when commenting/video off screen](https://github.com/lbryio/lbry-desktop/issues/5204)

## Change
Previously, the checking was only done during a scroll event. We also need to check if the user has already scroll down before the component was invoked.