### PR TITLE
FloatingPlayer: Fix close button not working when AutoplayCountdown is visible.

### DIFF
--- a/ui/scss/component/_content.scss
+++ b/ui/scss/component/_content.scss
@@ -15,11 +15,11 @@
   height: calc(var(--floating-viewer-height) + var(--floating-viewer-info-height));
   overflow: hidden;
   left: calc(var(--spacing-l) + var(--spacing-s));
-  z-index: 9999;
 
   &:hover {
     .content__floating-close {
       visibility: visible;
+      z-index: 9999;
     }
   }
 }


### PR DESCRIPTION
## Issue
Closes #5221: floating player won't close during autoplay countdown

## Change
Change the z-index when hover to ensure it is really on top of everything.