### PR TITLE
When a new reward is acquired, only close modals if the reward comes from reward_code

### DIFF
--- a/ui/index.jsx
+++ b/ui/index.jsx
@@ -135,8 +135,10 @@ rewards.setCallback('claimFirstRewardSuccess', () => {
   app.store.dispatch(doOpenModal(MODALS.FIRST_REWARD));
 });
 
-rewards.setCallback('claimRewardSuccess', () => {
-  app.store.dispatch(doHideModal());
+rewards.setCallback('claimRewardSuccess', reward => {
+  if (reward && reward.type === rewards.TYPE_REWARD_CODE) {
+    app.store.dispatch(doHideModal());
+  }
 });
 
 // @if TARGET='app'

--- a/ui/rewards.js
+++ b/ui/rewards.js
@@ -38,7 +38,7 @@ rewards.claimReward = (type, rewardParams) => {
       window.store.dispatch(action);
 
       if (rewards.callbacks.claimRewardSuccess) {
-        rewards.callbacks.claimRewardSuccess();
+        rewards.callbacks.claimRewardSuccess(reward);
       }
 
       resolve(reward);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/2177

## What is the current behavior?

When a reward comes in, the open modal will be closed.

## What is the new behavior?

When a reward comes in, the open modal will only be closed if the reward being acquired is of type reward_code.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

**NOTE**

I wasn't able to test the entire flow with real data because I don't own a reward code. I was only able to test the flow with mocked data.
