### PR TITLE
Add Chromecast support on cast-able browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@reach/utils": "^0.12.1",
     "@sentry/browser": "^5.12.1",
     "@sentry/webpack-plugin": "^1.10.0",
+    "@silvermine/videojs-chromecast": "^1.2.2",
     "@types/three": "^0.93.1",
     "adm-zip": "^0.4.13",
     "async-exit-hook": "^2.0.1",

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -44,6 +44,7 @@ export type Player = {
 
 type Props = {
   source: string,
+  claim: StreamClaim,
   sourceType: string,
   poster: ?string,
   onPlayerReady: Player => void,
@@ -145,13 +146,16 @@ class ChromecastWrapper {
   /**
    * Actions that need to happen before initializing 'videojs'.
    */
-  static preInit(videojs, options, title) {
+  static preInit(videojs, options, claim) {
     const additionalOptions = {
       // @if TARGET='web'
       techOrder: ['chromecast', 'html5'],
       chromecast: {
         requestTitleFn: function(src) {
-          return '';
+          return claim && claim.value && claim.value.title ? claim.value.title : '';
+        },
+        requestSubtitleFn: function(src) {
+          return claim && claim.signing_channel && claim.signing_channel.name ? claim.signing_channel.name : '';
         },
       },
       // @endif
@@ -188,7 +192,7 @@ class ChromecastWrapper {
 properties for this component should be kept to ONLY those that if changed should REQUIRE an entirely new videojs element
  */
 export default React.memo<Props>(function VideoJs(props: Props) {
-  const { startMuted, source, sourceType, poster, isAudio, onPlayerReady } = props;
+  const { startMuted, source, claim, sourceType, poster, isAudio, onPlayerReady } = props;
   const [reload, setReload] = useState('initial');
 
   let player: ?Player;
@@ -368,7 +372,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
           videoJsOptions.sources[0].type = 'application/x-mpegURL';
         }
 
-        videoJsOptions = ChromecastWrapper.preInit(videojs, videoJsOptions);
+        videoJsOptions = ChromecastWrapper.preInit(videojs, videoJsOptions, claim);
 
         player = videojs(el, videoJsOptions, () => {
           if (player) {

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -211,6 +211,7 @@ function VideoViewer(props: Props) {
       {isLoading && <LoadingScreen status={__('Loading')} />}
       <VideoJs
         source={source}
+        claim={claim}
         isAudio={isAudio}
         poster={isAudio || (embedded && !autoplayIfEmbedded) ? thumbnail : null}
         sourceType={forcePlayer ? 'video/mp4' : contentType}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,6 +2040,15 @@
   dependencies:
     "@sentry/cli" "^1.49.0"
 
+"@silvermine/videojs-chromecast@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@silvermine/videojs-chromecast/-/videojs-chromecast-1.2.2.tgz#da679e50b856be8d1586bc7df9cb85466a2f2f6b"
+  integrity sha512-4EpUm4Zf21yWbloJXEbvmWBM468onj8lk12cp+W1RsH3YNm3hIx7/y4w5QnA/TLCQ4gUpxMTwFYrgE/ejr9Gmw==
+  dependencies:
+    class.extend "0.9.1"
+    underscore "1.9.1"
+    webcomponents.js "git+https://git@github.com/webcomponents/webcomponentsjs.git#v0.7.24"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -3527,6 +3536,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+class.extend@0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/class.extend/-/class.extend-0.9.1.tgz#b4ee417c693740a44a92a6d64f1c9540641b097a"
+  integrity sha1-tO5BfGk3QKRKkqbWTxyVQGQbCXo=
 
 classnames@^2.2.5:
   version "2.2.6"
@@ -11559,6 +11573,11 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
+underscore@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
 underscore@>1.4.4:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.2.tgz#0c8d6f536d6f378a5af264a72f7bec50feb7cf2f"
@@ -12075,6 +12094,10 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
   dependencies:
     minimalistic-assert "^1.0.0"
+
+"webcomponents.js@git+https://git@github.com/webcomponents/webcomponentsjs.git#v0.7.24":
+  version "0.7.24"
+  resolved "git+https://git@github.com/webcomponents/webcomponentsjs.git#8a2e40557b177e2cca0def2553f84c8269c8f93e"
 
 webpack-bundle-analyzer@^3.1.0:
   version "3.6.1"


### PR DESCRIPTION
## Issue
Currently, we can only cast from Android Chrome (Mobile).  This PR extends it to browsers that support casting.  Goggle Chrome supports it by default, while other browsers will require some flag-tweaking or installing an extension.

## Notes
- The chromecast API ignores `http`, so `dev-server` alone won't work.  Needs `https`.  I used `ngrok` for testing.

## Screenshot
![image](https://user-images.githubusercontent.com/64950861/103925771-fbe21d00-5152-11eb-909f-e75fd8412787.png)
