### PR TITLE
Fix nsfw parameter in search page

### DIFF
--- a/ui/component/searchOptions/index.js
+++ b/ui/component/searchOptions/index.js
@@ -8,7 +8,7 @@ import SearchOptions from './view';
 const select = state => ({
   options: selectSearchOptions(state),
   expanded: selectSearchOptionsExpanded(state),
-  query: makeSelectQueryWithOptions()(state),
+  query: makeSelectQueryWithOptions(undefined, {})(state),
 });
 
 const perform = (dispatch, ownProps) => {

--- a/ui/page/search/view.jsx
+++ b/ui/page/search/view.jsx
@@ -46,9 +46,8 @@ export default function SearchPage(props: Props) {
   const urlParams = new URLSearchParams(location.search);
   const urlQuery = urlParams.get('q') || '';
   const additionalOptions: AdditionalOptions = { isBackgroundSearch: false };
-  if (!showNsfw) {
-    additionalOptions['nsfw'] = false;
-  }
+
+  additionalOptions['nsfw'] = showNsfw;
 
   const modifiedUrlQuery = urlQuery
     .trim()

--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -77,9 +77,7 @@ export const makeSelectRecommendedContentForUri = (uri: string) =>
           isBackgroundSearch?: boolean,
         } = { related_to: claim.claim_id, isBackgroundSearch: true };
 
-        if (!isMature) {
-          options['nsfw'] = false;
-        }
+        options['nsfw'] = isMature;
         const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
 
         let searchUris = searchUrisByQuery[searchQuery];

--- a/ui/util/query-params.js
+++ b/ui/util/query-params.js
@@ -66,7 +66,7 @@ export const getSearchQueryString = (query: string, options: any = {}) => {
   const { related_to } = options;
   const { nsfw } = options;
   if (related_to) additionalOptions['related_to'] = related_to;
-  if (nsfw !== true) additionalOptions['nsfw'] = false;
+  if (nsfw === false) additionalOptions['nsfw'] = false;
 
   if (additionalOptions) {
     Object.keys(additionalOptions).forEach(key => {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/pull/5277

## What is the current behavior?

NSFW parameter is not being sent correctly when searching.

## What is the new behavior?

NSFW parameter is being sent correctly.
When mature content is enable, nsfw isn't sent (which allows for mature content to show up)
When mature content is disabled, nsfw is sent as false

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
