### PR TITLE
Prevent users from losing subs (again)

### DIFF
--- a/ui/component/userSignUp/view.jsx
+++ b/ui/component/userSignUp/view.jsx
@@ -18,6 +18,7 @@ import Spinner from 'component/spinner';
 import YoutubeTransferStatus from 'component/youtubeTransferStatus';
 import useFetched from 'effects/use-fetched';
 import Confetti from 'react-confetti';
+import usePrevious from 'effects/use-previous';
 
 const REDIRECT_PARAM = 'redirect';
 const REDIRECT_IMMEDIATELY_PARAM = 'immediate';
@@ -87,6 +88,7 @@ function UserSignUp(props: Props) {
   const isIdentityVerified = user && user.is_identity_verified;
   const passwordSet = user && user.password_set;
   const hasFetchedReward = useFetched(claimingReward);
+  const previousHasVerifiedEmail = usePrevious(hasVerifiedEmail);
   const channelCount = channels ? channels.length : 0;
   const hasClaimedEmailAward = claimedRewards.some(reward => reward.reward_type === REWARDS.TYPE_CONFIRM_EMAIL);
   const hasYoutubeChannels = youtubeChannels && Boolean(youtubeChannels.length);
@@ -134,11 +136,11 @@ function UserSignUp(props: Props) {
   }, [fetchUser]);
 
   React.useEffect(() => {
-    if (hasVerifiedEmail) {
+    if (previousHasVerifiedEmail === false && hasVerifiedEmail) {
       setPrefsReady();
       setSettingAndSync(SETTINGS.FIRST_RUN_STARTED, true);
     }
-  }, [hasVerifiedEmail, setPrefsReady]);
+  }, [hasVerifiedEmail, previousHasVerifiedEmail, setPrefsReady]);
 
   React.useEffect(() => {
     // Don't claim the reward if sync is enabled until after a sync has been completed successfully


### PR DESCRIPTION
If users signed in on a different tab, then went back to the original tab and did something that caused a redirect to the sign up page, they would lose their subs.

This additional check ensures we only call `sync_set` for new users, not existing users that were redirected because of multiple tab weirdness.