### PR TITLE
encode share url parts

### DIFF
--- a/ui/component/socialShare/view.jsx
+++ b/ui/component/socialShare/view.jsx
@@ -49,9 +49,7 @@ function SocialShare(props: Props) {
   const encodedLbryURL: string = generateEncodedLbryURL(SHARE_DOMAIN, lbryWebUrl, includeStartTime, startTimeSeconds);
   const shareUrl: string = generateShareUrl(
     SHARE_DOMAIN,
-    lbryWebUrl,
-    canonicalUrl,
-    permanentUrl,
+    lbryUrl,
     referralCode,
     rewardsApproved,
     includeStartTime,

--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -1,5 +1,6 @@
 // Can't use aliases here because we're doing exports/require
 const PAGES = require('../constants/pages');
+const { parseURI, buildURI } = require('lbry-redux');
 
 exports.formatLbryUrlForWeb = uri => {
   let newUrl = uri.replace('lbry://', '/').replace(/#/g, ':');
@@ -91,16 +92,7 @@ exports.generateEncodedLbryURL = (domain, lbryWebUrl, includeStartTime, startTim
   return `${domain}/${encodedPart}`;
 };
 
-exports.generateShareUrl = (
-  domain,
-  lbryWebUrl,
-  canonicalUrl,
-  permanentUrl,
-  referralCode,
-  rewardsApproved,
-  includeStartTime,
-  startTime
-) => {
+exports.generateShareUrl = (domain, lbryUrl, referralCode, rewardsApproved, includeStartTime, startTime) => {
   let urlParams = new URLSearchParams();
   if (referralCode && rewardsApproved) {
     urlParams.append('r', referralCode);
@@ -111,6 +103,18 @@ exports.generateShareUrl = (
   }
 
   const urlParamsString = urlParams.toString();
+
+  const { streamName, streamClaimId, channelName, channelClaimId } = parseURI(lbryUrl);
+
+  let uriParts = {
+    ...(streamName ? { streamName: encodeURIComponent(streamName) } : {}),
+    ...(streamClaimId ? { streamClaimId } : {}),
+    ...(channelName ? { channelName: encodeURIComponent(channelName) } : {}),
+    ...(channelClaimId ? { channelClaimId } : {}),
+  };
+
+  const encodedUrl = buildURI(uriParts, false);
+  const lbryWebUrl = encodedUrl.replace(/#/g, ':');
 
   const url = `${domain}/${lbryWebUrl}` + (urlParamsString === '' ? '' : `?${urlParamsString}`);
   return url;

--- a/ui/util/web.js
+++ b/ui/util/web.js
@@ -16,7 +16,7 @@ function generateEmbedUrl(claimName, claimId, includeStartTime, startTime, refer
     urlParams.append('r', referralLink);
   }
 
-  return `${URL}/$/embed/${claimName}/${claimId}?${urlParams.toString()}`;
+  return `${URL}/$/embed/${encodeURIComponent(claimName)}/${claimId}?${urlParams.toString()}`;
 }
 
 function generateDownloadUrl(claimName, claimId) {


### PR DESCRIPTION
Only encodes the claim/stream name this time, not the whole url