### PR TITLE
String fix for 'Support Repost'

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -737,6 +737,8 @@
   "refreshing the app": "refreshing the app",
   "Follower": "Follower",
   "%repost_channel_link% reposted": "%repost_channel_link% reposted",
+  "%anonymous% Reposted": "%anonymous% Reposted",
+  "Anonymous --[used in <%anonymous% Reposted>]--": "Anonymous",
   "This channel may have been unpublished.": "This channel may have been unpublished.",
   "Custom": "Custom",
   "Playing in %seconds_left% seconds": "Playing in %seconds_left% seconds",

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -257,6 +257,7 @@
   "Support --[button to support a claim]--": "Support",
   "Support --[noun; transaction type]--": "Support",
   "Support --[used in footer; general help/support]--": "Support",
+  "Support Repost": "Support Repost",
   "Update": "Update",
   "Abandon": "Abandon",
   "Unlock tip": "Unlock tip",

--- a/ui/component/claimRepostAuthor/view.jsx
+++ b/ui/component/claimRepostAuthor/view.jsx
@@ -30,7 +30,13 @@ function ClaimRepostAuthor(props: Props) {
       <div className="claim-preview__repost-author">
         <Icon icon={ICONS.REPOST} size={10} />
         <span>
-          <strong>Anonymous</strong> {__('Reposted')}
+          <I18nMessage
+            tokens={{
+              anonymous: <strong>{__('Anonymous --[used in <%anonymous% Reposted>]--')}</strong>,
+            }}
+          >
+            %anonymous% Reposted
+          </I18nMessage>
         </span>
       </div>
     );

--- a/ui/component/claimSupportButton/view.jsx
+++ b/ui/component/claimSupportButton/view.jsx
@@ -27,9 +27,7 @@ export default function ClaimSupportButton(props: Props) {
       className={classnames({ 'button--file-action': fileAction })}
       icon={ICONS.LBC}
       iconSize={fileAction ? 22 : undefined}
-      label={
-        isRepost ? __('Support Repost --[button to support a claim]--') : __('Support --[button to support a claim]--')
-      }
+      label={isRepost ? __('Support Repost') : __('Support --[button to support a claim]--')}
       requiresAuth={IS_WEB}
       title={__('Support this claim')}
       onClick={() => doOpenModal(MODALS.SEND_TIP, { uri, isSupport: true })}


### PR DESCRIPTION
String fix for 'Support Repost'
- Added to json
- Don't need the context note for this case.

Fix split string