### PR TITLE
manually encode "'" because encodeURIComponent doesn't encode it

### DIFF
--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -2,6 +2,12 @@
 const PAGES = require('../constants/pages');
 const { parseURI, buildURI } = require('lbry-redux');
 
+function encodeWithApostropheEncode(string) {
+  // encodeURIComponent doesn't encode `'`
+  // in most cases this is fine, but wordpress doesn't like it
+  return encodeURIComponent(string).replace(/'/g, '%27');
+}
+
 exports.formatLbryUrlForWeb = uri => {
   let newUrl = uri.replace('lbry://', '/').replace(/#/g, ':');
   if (newUrl.startsWith('/?')) {
@@ -88,7 +94,7 @@ exports.generateLbryWebUrl = lbryUrl => {
 
 exports.generateEncodedLbryURL = (domain, lbryWebUrl, includeStartTime, startTime) => {
   const queryParam = includeStartTime ? `?t=${startTime}` : '';
-  const encodedPart = encodeURIComponent(`${lbryWebUrl}${queryParam}`);
+  const encodedPart = encodeWithApostropheEncode(`${lbryWebUrl}${queryParam}`);
   return `${domain}/${encodedPart}`;
 };
 
@@ -107,9 +113,9 @@ exports.generateShareUrl = (domain, lbryUrl, referralCode, rewardsApproved, incl
   const { streamName, streamClaimId, channelName, channelClaimId } = parseURI(lbryUrl);
 
   let uriParts = {
-    ...(streamName ? { streamName: encodeURIComponent(streamName) } : {}),
+    ...(streamName ? { streamName: encodeWithApostropheEncode(streamName) } : {}),
     ...(streamClaimId ? { streamClaimId } : {}),
-    ...(channelName ? { channelName: encodeURIComponent(channelName) } : {}),
+    ...(channelName ? { channelName: encodeWithApostropheEncode(channelName) } : {}),
     ...(channelClaimId ? { channelClaimId } : {}),
   };
 

--- a/ui/util/web.js
+++ b/ui/util/web.js
@@ -16,7 +16,7 @@ function generateEmbedUrl(claimName, claimId, includeStartTime, startTime, refer
     urlParams.append('r', referralLink);
   }
 
-  return `${URL}/$/embed/${encodeURIComponent(claimName)}/${claimId}?${urlParams.toString()}`;
+  return `${URL}/$/embed/${encodeURIComponent(claimName).replace(/'/g, '%27')}/${claimId}?${urlParams.toString()}`;
 }
 
 function generateDownloadUrl(claimName, claimId) {


### PR DESCRIPTION
This PR has made me realize we should probably combine `util/web.js` and `util/url.js` (or at least combine parts of them)