### PR TITLE
Fix: Controls do not show on iOS

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
@@ -151,8 +151,7 @@ const onPlayerReady = (player, options) => {
  *           Never shows if the endscreen plugin is present
  */
 const mobileUi = function(options) {
-  // if (videojs.browser.IS_ANDROID || videojs.browser.IS_IOS) {
-  if (videojs.browser.IS_ANDROID) {
+  if (videojs.browser.IS_ANDROID || videojs.browser.IS_IOS) {
     this.ready(() => {
       onPlayerReady(this, videojs.mergeOptions(defaults, options));
     });

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -58,18 +58,12 @@ type VideoJSOptions = {
 
 const videoPlaybackRates = [0.25, 0.5, 0.75, 1, 1.1, 1.25, 1.5, 1.75, 2];
 
-const IS_IOS =
-  (/iPad|iPhone|iPod/.test(navigator.platform) ||
-    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
-  !window.MSStream;
-
 const VIDEO_JS_OPTIONS: VideoJSOptions = {
   preload: 'auto',
   playbackRates: videoPlaybackRates,
   responsive: true,
   controls: true,
   html5: {
-    nativeControlsForTouch: IS_IOS,
     hls: {
       overrideNative: !videojs.browser.IS_ANY_SAFARI,
     },
@@ -168,14 +162,13 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       },
     ],
     autoplay: false,
+    muted: startMuted,
     poster: poster, // thumb looks bad in app, and if autoplay, flashing poster is annoying
     plugins: {
       eventTracking: true,
       overlay: OVERLAY.OVERLAY_DATA,
     },
   };
-
-  videoJsOptions.muted = startMuted;
 
   const tapToUnmuteRef = useRef();
   const tapToRetryRef = useRef();
@@ -375,7 +368,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   return (
     reload && (
       // $FlowFixMe
-      <div className={classnames('video-js-parent', { 'video-js-parent--ios': IS_IOS })} ref={containerRef}>
+      <div className={classnames('video-js-parent')} ref={containerRef}>
         <Button
           label={__('Tap to unmute')}
           button="link"

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -364,12 +364,6 @@
   width: 100%;
 }
 
-.video-js-parent--ios {
-  .vjs-control-bar {
-    display: none;
-  }
-}
-
 // By default no video js play button
 .vjs-big-play-button {
   display: none;


### PR DESCRIPTION
This attempts to remove code that prevents any controls from appearing on iOS. This may not fully resolve the issue though, as there may be an issue with both native and custom controls appearing on iOS devices.
However, it's a lot easier to remove / disable when they appear, and very difficult to understand what is preventing the appearance when they do not show at all.

this pr does the following:
- remove `video-js-parent--ios` class which hid control bar via css.
- remove `nativeControlsForTouch` option in favor of allowing for default behavior.
- remove `IS_IOS` const as the video.js library already defines a value that could be used instead, and there are no longer any references to it.
- Add `videojs.browser.IS_IOS` back to videojs-mobile-ui plugin as we should aim to have a unified experience across all devices. (also it might fix the controls not appearing issue)
- remove styling for `.video-js-parent--ios` class as we no longer use this class
- move `videoJsOptions.muted = startMuted;` to where `videoJsOptions` is initially defined.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #5263 (maybe)

## What is the current behavior?

no controls on iOS

## What is the new behavior?

hopefully more controls on iOS. Possible too many controls.

## Other information

This may introduce a new bug. But that bug would be less troublesome than current behavior.
It is unclear why certain modifications were made to some settings and code by other devs, so this first pass attempts to simplify the problem first. 

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

It's possible that both native controls and custom video.js controls appear on iOS devices after this PR. 
If that occurs, debugging because much simpler in which dev tools can be used to trigger breakpoints for determining where in code the additional controls come from. 

This is easier to debug than trying to pinpoint which portion of these changes prevented or removed *all* the controls.

tldr: Testing on iOS hardware just needs to be done with these modifications to see if controls re-appear first, and I do not own an iPhone.