### PR TITLE
Fix edge case issue where 2 videos players existed on page causing double audio

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -320,7 +320,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   // Create the video DOM element and wrapper
   function createVideoPlayerDOM(container) {
     if (!container) {
-      console.error(`VideoPlayer Error: missing ref to container!`);
       return;
     }
 
@@ -339,14 +338,12 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   // Initialize video.js
   function initializeVideoPlayer(el) {
     if (!el) {
-      console.error(`Failed to initialize video player: Missing element to attach to`);
       return;
     }
 
     player = videojs(el, videoJsOptions, () => {
       // this seems like a weird thing to have to check for here
       if (!player) {
-        console.error(`Failed to create videojs player!`);
         return;
       }
       
@@ -396,8 +393,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       if (player) {
         player.dispose();
         window.player = undefined;
-
-        console.log(`Disposed of video.js instance (unmounted)`);
       }
     }
   }, []);
@@ -409,7 +404,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       const player = window.player;
 
       if (!player) {
-        console.log(`Our player was disposed, we should disregard the fetch result.`);
         return;
       }
 
@@ -434,13 +428,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         src: source,
         type: type,
       });
-
-      console.log(`Updated Player: ${source} (${type}) Poster: ${poster}`);
     });
-
-    return () => {
-      console.log('Cleanup after source update.');
-    }
   }, [source]);
 
   return (

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -317,59 +317,126 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     }
   }
 
-  // Create the video element. Note that a new videojs instantiation will happen on *every* render, so do not add props to this component!
+  // Create the video DOM element and wrapper
+  function createVideoPlayerDOM(container) {
+    if (!container) {
+      console.error(`VideoPlayer Error: missing ref to container!`);
+      return;
+    }
+
+    // This seems like a poor way to generate the DOM for video.js
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-vjs-player', 'true');
+    const el = document.createElement(isAudio ? 'audio' : 'video');
+    el.className = 'video-js';
+    wrapper.appendChild(el);
+
+    container.appendChild(wrapper);
+
+    return el;
+  }
+
+  // Initialize video.js
+  function initializeVideoPlayer(el) {
+    if (!el) {
+      console.error(`Failed to initialize video player: Missing element to attach to`);
+      return;
+    }
+
+    player = videojs(el, videoJsOptions, () => {
+      // this seems like a weird thing to have to check for here
+      if (!player) {
+        console.error(`Failed to create videojs player!`);
+        return;
+      }
+      
+      // Add various event listeners to player
+      player.one('play', onInitialPlay);
+      player.on('volumechange', onVolumeChange);
+      player.on('error', onError);
+      player.on('ended', onEnded);
+
+      // Replace volume bar with custom LBRY volume bar
+      LbryVolumeBarClass.replaceExisting(player);
+      
+      // initialize mobile UI
+      player.mobileUi(); // Inits mobile version. No-op if Desktop.
+
+      // I think this is a callback function
+      onPlayerReady(player);
+    });
+
+    // Add quality selector to player
+    player.hlsQualitySelector({
+      displayCurrentQuality: true,
+    });
+
+    // Add reference to player to global scope
+    window.player = player;
+
+    // fixes #3498 (https://github.com/lbryio/lbry-desktop/issues/3498)
+    // summary: on firefox the focus would stick to the fullscreen button which caused buggy behavior with spacebar
+    player.on('fullscreenchange', () => document.activeElement && document.activeElement.blur());
+
+    return player;
+  }
+
+  // This lifecycle hook is only called once (on mount)
   useEffect(() => {
-    if (containerRef.current) {
-      const wrapper = document.createElement('div');
-      wrapper.setAttribute('data-vjs-player', 'true');
-      const el = document.createElement(isAudio ? 'audio' : 'video');
-      el.className = 'video-js';
-      wrapper.appendChild(el);
+    const vjsElement = createVideoPlayerDOM(containerRef.current);
+    const vjsPlayer = initializeVideoPlayer(vjsElement);
 
-      // $FlowFixMe
-      containerRef.current.appendChild(wrapper);
+    // Add event listener for keyboard shortcuts
+    window.addEventListener('keydown', handleKeyDown);
 
-      fetch(source, { method: 'HEAD' }).then(response => {
-        if (response && response.redirected && response.url && response.url.endsWith('m3u8')) {
-          videoJsOptions.sources[0].type = 'application/x-mpegURL';
-        }
+    // Cleanup
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
 
-        player = videojs(el, videoJsOptions, () => {
-          if (player) {
-            player.one('play', onInitialPlay);
-            player.on('volumechange', onVolumeChange);
-            player.on('error', onError);
-            player.on('ended', onEnded);
-            LbryVolumeBarClass.replaceExisting(player);
-            player.mobileUi(); // Inits mobile version. No-op if Desktop.
+      if (player) {
+        player.dispose();
+        window.player = undefined;
+      }
+    }
+  }, []);
 
-            onPlayerReady(player);
-          }
-        });
+  // Update video player settings and reload it when props change
+  useEffect(() => {
+    // For some reason the video player is responsible for detecting content type this way
+    fetch(source, { method: 'HEAD' }).then(response => {
+      if (!player) {
+        console.log(`Our player was disposed, we should disregard the fetch result.`);
+        return;
+      }
 
-        player.hlsQualitySelector({
-          displayCurrentQuality: true,
-        });
+      let type = sourceType;
 
-        window.player = player;
+      // override type if we receive an .m3u8 (transcoded mp4)
+      if (
+        response && 
+        response.redirected && 
+        response.url && 
+        response.url.endsWith('m3u8')
+      ) {
+        type = 'application/x-mpegURL';
+      }
 
-        // fixes #3498 (https://github.com/lbryio/lbry-desktop/issues/3498)
-        // summary: on firefox the focus would stick to the fullscreen button which caused buggy behavior with spacebar
-        // $FlowFixMe
-        player.on('fullscreenchange', () => document.activeElement && document.activeElement.blur());
+      // Update player poster
+      // note: the poster prop seems to return null usually.
+      if ( poster ) player.poster(poster);
 
-        window.addEventListener('keydown', handleKeyDown);
+      // Update player source
+      player.src({
+        src: source,
+        type: type,
       });
 
-      return () => {
-        window.removeEventListener('keydown', handleKeyDown);
+      console.log(`Updated Player: ${source} (${type}) Poster: ${poster}`);
+    });
 
-        if (player) {
-          player.dispose();
-          window.player = undefined;
-        }
-      };
-    }
+    return () => {
+      console.log('Guess we could clean up something here if needed');
+    };
   });
 
   return (

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -167,7 +167,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         type: sourceType,
       },
     ],
-    autoplay: false,
+    autoplay: true,
     poster: poster, // thumb looks bad in app, and if autoplay, flashing poster is annoying
     plugins: {
       eventTracking: true,
@@ -406,6 +406,8 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   useEffect(() => {
     // For some reason the video player is responsible for detecting content type this way
     fetch(source, { method: 'HEAD' }).then(response => {
+      const player = window.player;
+
       if (!player) {
         console.log(`Our player was disposed, we should disregard the fetch result.`);
         return;

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -396,11 +396,13 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       if (player) {
         player.dispose();
         window.player = undefined;
+
+        console.log(`Disposed of video.js instance (unmounted)`);
       }
     }
   }, []);
 
-  // Update video player settings and reload it when props change
+  // Update video player and reload when source URL changes
   useEffect(() => {
     // For some reason the video player is responsible for detecting content type this way
     fetch(source, { method: 'HEAD' }).then(response => {
@@ -435,9 +437,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     });
 
     return () => {
-      console.log('Guess we could clean up something here if needed');
-    };
-  });
+      console.log('Cleanup after source update.');
+    }
+  }, [source]);
 
   return (
     reload && (

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -346,7 +346,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       if (!player) {
         return;
       }
-      
+
       // Add various event listeners to player
       player.one('play', onInitialPlay);
       player.on('volumechange', onVolumeChange);
@@ -355,7 +355,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
       // Replace volume bar with custom LBRY volume bar
       LbryVolumeBarClass.replaceExisting(player);
-      
+
       // initialize mobile UI
       player.mobileUi(); // Inits mobile version. No-op if Desktop.
 
@@ -367,9 +367,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     player.hlsQualitySelector({
       displayCurrentQuality: true,
     });
-
-    // Add reference to player to global scope
-    window.player = player;
 
     // fixes #3498 (https://github.com/lbryio/lbry-desktop/issues/3498)
     // summary: on firefox the focus would stick to the fullscreen button which caused buggy behavior with spacebar
@@ -383,6 +380,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     const vjsElement = createVideoPlayerDOM(containerRef.current);
     const vjsPlayer = initializeVideoPlayer(vjsElement);
 
+    // Add reference to player to global scope
+    window.player = vjsPlayer;
+
     // Add event listener for keyboard shortcuts
     window.addEventListener('keydown', handleKeyDown);
 
@@ -394,7 +394,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         player.dispose();
         window.player = undefined;
       }
-    }
+    };
   }, []);
 
   // Update video player and reload when source URL changes
@@ -411,9 +411,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
       // override type if we receive an .m3u8 (transcoded mp4)
       if (
-        response && 
-        response.redirected && 
-        response.url && 
+        response &&
+        response.redirected &&
+        response.url &&
         response.url.endsWith('m3u8')
       ) {
         type = 'application/x-mpegURL';
@@ -421,7 +421,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
       // Update player poster
       // note: the poster prop seems to return null usually.
-      if ( poster ) player.poster(poster);
+      if (poster) player.poster(poster);
 
       // Update player source
       player.src({


### PR DESCRIPTION
This is a refactor of the video.js component's lifecycle hooks.

Existing behavior can cause strange behavior and may cause more than 1 video to play at the same time. This is because when any prop is updated for the VideoViewer component, it causes the entire video.js instance to be recreated. 

Additionally it relies on a callback from an asynchronous function to begin the creation of a new video.js instance which further leads to unstable behavior. For instance, when the player is switching to a new source URL it begin a fetch to get the content's headers. While waiting for this fetch to return, if we close the player, it will be removed from the DOM by a parent component (FileRender). Our fetch will then finish and execute the callback which now creates a new videojs instance on a dom reference that has been removed. The result is a "zombie" video player that does not exist on the page, has no references to it that are accessible from the outer scope, and has now begun playing a video that we should have closed out.

To solve this, I refactored the video.js component so that it only creates a new instance on mount, and only removes and disposes of the player on unmount by scoping the `useEffect` hook to an empty array. 

from: https://reactjs.org/docs/hooks-effect.html
> If you want to run an effect and clean it up only once (on mount and unmount), you can pass an empty array ([]) as a second argument. This tells React that your effect doesn’t depend on any values from props or state, so it never needs to re-run. This isn’t handled as a special case — it follows directly from how the dependencies array always works.

There may still be better ways to approach this, and set values in react, but I'm not an expert in react yet, so open to suggestions and further improvements. However, this behavior should be more predictable and allow for this component to have additional properties set on it without interfering with the video. This also fixes the issues of double audio that I have been able to reproduce.

I dislike that a global `window` variable is needed to ensure we access the same instance of video js in our fetch callback, but it's just bad practice, not an issue that causes issues with the playback experience.

Overall, this should be more reliable when quickly switching between videos, and also reduce some load time slightly as it no longer needs to recreate the entire video player everytime the source changes.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #5328 

## What is the current behavior?

duplicated video.js players that cannot be controlled and play without an instance appearing on the page.

## What is the new behavior?

Only 1 video player will ever exist at a time on the page, and will only be recreated if unmounted.

## Other information

There may potentially be bugs related to the change of autoplay from `false` to `true` but I haven't run into any personally yet, and expect autoplay to be more consistent with this value set to `true`. 