### PR TITLE
Make dropdown menus actually dropdown

### DIFF
--- a/ui/scss/component/_animation.scss
+++ b/ui/scss/component/_animation.scss
@@ -70,7 +70,7 @@
 
 @keyframes menu-animate-in {
   0% {
-    transform: translateY(-80px);
+    transform: translateY(var(--header-height));
     opacity: 0;
   }
   100% {

--- a/ui/scss/component/_animation.scss
+++ b/ui/scss/component/_animation.scss
@@ -70,7 +70,7 @@
 
 @keyframes menu-animate-in {
   0% {
-    transform: translateY(var(--header-height));
+    transform: translateY(calc(var(--header-height) * -1));
     opacity: 0;
   }
   100% {

--- a/ui/scss/component/_animation.scss
+++ b/ui/scss/component/_animation.scss
@@ -70,11 +70,11 @@
 
 @keyframes menu-animate-in {
   0% {
-    transform: scaleY(0);
+    transform: translateY(-80px);
     opacity: 0;
   }
   100% {
-    transform: scaleY(1);
+    transform: translateY(0);
     opacity: 1;
   }
 }


### PR DESCRIPTION
I was annoyed that our dropdown menus didn't actually... dropdown.

![odysee-dropdown-animation](https://user-images.githubusercontent.com/45262335/105785412-aae26f00-5f2f-11eb-87bf-903366274eaf.gif)

So I fixed them:

![lbry-dropdown-animation](https://user-images.githubusercontent.com/45262335/105785437-b766c780-5f2f-11eb-80e0-64a0b34c3765.gif)

The CSS change uses a translation instead of a scalar operation to translate the popover menu down 80px rather than expanding by scaling about the center of Y.

Translated 80px because that is the height of the top bar, and for some reason the popover component will affect the scroll position if it renders offscreen. That is, if we were to translate by 100px, it being partially offpage when it is first created will cause the page scroll up by 20px.

I looked into why it is that way, and it's because the popover menu is rendered as `position:absolute` and the position depends on the scroll location. Seems like this really should just be a `position:fixed`, but I don't want to open that Pandora's box potentially.

tldr: better dropdown animation.