### PR TITLE
Make zoom level persistent on Desktop

### DIFF
--- a/ui/constants/settings.js
+++ b/ui/constants/settings.js
@@ -24,3 +24,4 @@ export const DARK_MODE_TIMES = 'dark_mode_times';
 export const ENABLE_SYNC = 'enable_sync';
 export const TO_TRAY_WHEN_CLOSED = 'to_tray_when_closed';
 export const ENABLE_PUBLISH_PREVIEW = 'enable-publish-preview';
+export const DESKTOP_WINDOW_ZOOM = 'desktop_window_zoom';

--- a/ui/effects/use-zoom.js
+++ b/ui/effects/use-zoom.js
@@ -44,4 +44,8 @@ export default function useHover(ref) {
     window.addEventListener('wheel', handleWheel);
     return () => window.removeEventListener('wheel', handleWheel);
   }, []);
+
+  useEffect(() => {
+    changeZoomFactor(ZOOM.LOAD_FROM_LOCAL_STORAGE);
+  }, []);
 }

--- a/ui/redux/reducers/settings.js
+++ b/ui/redux/reducers/settings.js
@@ -49,6 +49,7 @@ const defaultState = {
     [SETTINGS.TILE_LAYOUT]: true,
     [SETTINGS.VIDEO_THEATER_MODE]: false,
     [SETTINGS.VIDEO_PLAYBACK_RATE]: 1,
+    [SETTINGS.DESKTOP_WINDOW_ZOOM]: 1,
 
     [SETTINGS.DARK_MODE_TIMES]: {
       from: { hour: '21', min: '00', formattedTime: '21:00' },

--- a/ui/util/zoomWindow.js
+++ b/ui/util/zoomWindow.js
@@ -1,10 +1,12 @@
 import { webFrame } from 'electron';
+import { SETTINGS } from 'lbry-redux';
 const isDev = process.env.NODE_ENV !== 'production';
 
 export const ZOOM = {
   INCREMENT: 'INCREMENT',
   DECREMENT: 'DECREMENT',
   RESET: 'RESET',
+  LOAD_FROM_LOCAL_STORAGE: 'LOAD_FROM_LOCAL_STORAGE',
 };
 
 function getNextZoomFactor(curFactor, isIncreasing) {
@@ -24,19 +26,29 @@ function getNextZoomFactor(curFactor, isIncreasing) {
 export function changeZoomFactor(action) {
   const ZOOM_DFLT_FACTOR = 1.0;
   const curFactor = webFrame.getZoomFactor();
+  let newFactor = null;
 
   switch (action) {
     case ZOOM.INCREMENT:
-      webFrame.setZoomFactor(getNextZoomFactor(curFactor, true));
+      newFactor = getNextZoomFactor(curFactor, true);
       break;
     case ZOOM.DECREMENT:
-      webFrame.setZoomFactor(getNextZoomFactor(curFactor, false));
+      newFactor = getNextZoomFactor(curFactor, false);
       break;
     case ZOOM.RESET:
-      webFrame.setZoomFactor(ZOOM_DFLT_FACTOR);
+      newFactor = ZOOM_DFLT_FACTOR;
+      break;
+    case ZOOM.LOAD_FROM_LOCAL_STORAGE:
+      newFactor = parseFloat(window.localStorage.getItem(SETTINGS.DESKTOP_WINDOW_ZOOM));
+      if (isNaN(newFactor)) {
+        newFactor = ZOOM_DFLT_FACTOR;
+      }
       break;
     default:
       if (isDev) throw new Error('changeZoomFactor: unexpected action');
-      break;
+      return;
   }
+
+  webFrame.setZoomFactor(newFactor);
+  window.localStorage.setItem(SETTINGS.DESKTOP_WINDOW_ZOOM, newFactor);
 }


### PR DESCRIPTION
## Change
Zoom on Desktop always starts with 1.0 -- this PR makes the setting persistent, matching the `web` behavior.

## ?
- Do I need to sync `DESKTOP_WINDOW_ZOOM` to `lbry-redux` if this is Desktop-only?