### PR TITLE
Fix first claim nsfw result being hidden even if nsfw is enabled

### DIFF
--- a/ui/component/claimPreview/index.js
+++ b/ui/component/claimPreview/index.js
@@ -22,7 +22,7 @@ const select = (state, props) => ({
   pending: props.uri && makeSelectClaimIsPending(props.uri)(state),
   claim: props.uri && makeSelectClaimForUri(props.uri)(state),
   reflectingProgress: props.uri && makeSelectReflectingClaimForUri(props.uri)(state),
-  obscureNsfw: !selectShowMatureContent(state),
+  obscureNsfw: selectShowMatureContent(state) === false,
   claimIsMine: props.uri && makeSelectClaimIsMine(props.uri)(state),
   isResolvingUri: props.uri && makeSelectIsUriResolving(props.uri)(state),
   isResolvingRepost: props.uri && makeSelectIsUriResolving(props.repostUrl)(state),

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -81,6 +81,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     getFile,
     resolveUri,
     // claim properties
+    // is the claim consider nsfw?
     nsfw,
     claimIsMine,
     isSubscribed,
@@ -100,6 +101,8 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     // modifiers
     customShouldHide,
     showNullPlaceholder,
+    // value from show mature content user setting
+    // true if the user doesn't wanna see nsfw content
     obscureNsfw,
     showUserBlocked,
     showUnresolvedClaim,
@@ -220,7 +223,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     return <ClaimPreviewLoading isChannel={isChannelUri} type={type} />;
   }
 
-  if (claim && showNullPlaceholder && shouldHide && nsfw) {
+  if (claim && showNullPlaceholder && shouldHide && nsfw && obscureNsfw) {
     return (
       <ClaimPreviewHidden
         message={__('Mature content hidden by your preferences')}


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/5245

## What is the current behavior?

When searching, if the first claim is nsfw and the user has the nsfw enabled (meaning, show mature content = true), the claim is hidden because "Mature content hidden by your preferences".

## What is the new behavior?

When the user has nsfw enabled, if the first result is nsfw it won't be hidden because of nsfw settings.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
