### PR TITLE
stop linting my web build files please

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/*
 ./node_modules/**
 **/node_modules/**
+web/dist/**


### PR DESCRIPTION
I never ran the linter locally when PR'ing because I would get some many linting errors I wouldn't even be able to scroll up far enough to see the relevant errors.

This is because the lint command will lint all `.js` and `.jsx` files in the `web/` directory... which includes `web/dist/**`.

This PR just adds `web/dist/**` to the `.eslintignore` file so that build files don't get linted, and brings some sanity to running `yarn lint`.