### PR TITLE
Hotfix: Fix autoplay issues for embedded players

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -45,6 +45,7 @@ type Props = {
   onPlayerReady: Player => void,
   isAudio: boolean,
   startMuted: boolean,
+  autoplay: boolean,
   toggleVideoTheaterMode: () => void,
 };
 
@@ -157,28 +158,37 @@ class LbryVolumeBarClass extends videojs.getComponent(VIDEOJS_VOLUME_BAR_CLASS) 
 properties for this component should be kept to ONLY those that if changed should REQUIRE an entirely new videojs element
  */
 export default React.memo<Props>(function VideoJs(props: Props) {
-  const { startMuted, source, sourceType, poster, isAudio, onPlayerReady, toggleVideoTheaterMode } = props;
+  const {
+    autoplay,
+    startMuted,
+    source,
+    sourceType,
+    poster,
+    isAudio,
+    onPlayerReady,
+    toggleVideoTheaterMode,
+  } = props;
+
   const [reload, setReload] = useState('initial');
 
   let player: ?Player;
   const containerRef = useRef();
   const videoJsOptions = {
     ...VIDEO_JS_OPTIONS,
+    autoplay: autoplay,
+    muted: startMuted,
     sources: [
       {
         src: source,
         type: sourceType,
       },
     ],
-    autoplay: true,
     poster: poster, // thumb looks bad in app, and if autoplay, flashing poster is annoying
     plugins: {
       eventTracking: true,
       overlay: OVERLAY.OVERLAY_DATA,
     },
   };
-
-  videoJsOptions.muted = startMuted;
 
   const tapToUnmuteRef = useRef();
   const tapToRetryRef = useRef();

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -15,6 +15,7 @@ import LoadingScreen from 'component/common/loading-screen';
 import { addTheaterModeButton } from './internal/theater-mode';
 
 const PLAY_TIMEOUT_ERROR = 'play_timeout_error';
+const PLAY_TIMEOUT_LIMIT = 2000;
 
 type Props = {
   position: number,
@@ -149,9 +150,7 @@ function VideoViewer(props: Props) {
       // https://blog.videojs.com/autoplay-best-practices-with-video-js/#Programmatic-Autoplay-and-Success-Failure-Detection
       if (shouldPlay) {
         const playPromise = player.play();
-        const timeoutPromise = new Promise((resolve, reject) => {
-          setTimeout(() => reject(PLAY_TIMEOUT_ERROR), 2000);
-        });
+        const timeoutPromise = new Promise((resolve, reject) => setTimeout(() => reject(PLAY_TIMEOUT_ERROR), PLAY_TIMEOUT_LIMIT));
 
         Promise.race([playPromise, timeoutPromise]).catch(error => {
           if (PLAY_TIMEOUT_ERROR) {
@@ -221,11 +220,12 @@ function VideoViewer(props: Props) {
       <VideoJs
         source={source}
         isAudio={isAudio}
-        poster={isAudio || (embedded && !autoplayIfEmbedded) ? thumbnail : null}
+        poster={isAudio || (embedded && !autoplayIfEmbedded) ? thumbnail : ''}
         sourceType={forcePlayer ? 'video/mp4' : contentType}
         onPlayerReady={onPlayerReady}
         startMuted={autoplayIfEmbedded}
         toggleVideoTheaterMode={toggleVideoTheaterMode}
+        autoplay={!embedded || autoplayIfEmbedded}
       />
     </div>
   );


### PR DESCRIPTION
Adds new `autoplay` prop to `VideoJs` component for specifying the value of `autoplay` passed to `video.js` player.

Copy pastes the old logic (used to calculate `shouldPlay` into this new property, and passes it to `VideoJs` component.

The result should be that in cases where `shouldPlay` is false, player would behave identically to previous behavior (before refactoring) by setting the `autoplay` flag to false, and *not* calling the function to try and begin autoplaying.

`shouldPlay` will return false when player is embedded *and* `autoplayIfEmbedded` is *also* false. Therefore, this should not impact the improvements made on LBRY / Odysee that we received from turning autoplay to `true`.

Partially resolves #5391