### PR TITLE
Hotfix: Make VideoJs's internal reference stateful

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/*
 ./node_modules/**
 **/node_modules/**
+web/dist/**

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -233,6 +233,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
   function retryVideoAfterFailure() {
     const player = playerRef.current;
+    console.log(player);
     if (player) {
       setReload(Date.now());
       showTapButton(TAP.NONE);
@@ -420,8 +421,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
   // Update video player and reload when source URL changes
   useEffect(() => {
-    const player = playerRef.current;
-
     // For some reason the video player is responsible for detecting content type this way
     fetch(source, { method: 'HEAD' }).then(response => {
       const player = playerRef.current;

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -158,16 +158,7 @@ class LbryVolumeBarClass extends videojs.getComponent(VIDEOJS_VOLUME_BAR_CLASS) 
 properties for this component should be kept to ONLY those that if changed should REQUIRE an entirely new videojs element
  */
 export default React.memo<Props>(function VideoJs(props: Props) {
-  const {
-    autoplay,
-    startMuted,
-    source,
-    sourceType,
-    poster,
-    isAudio,
-    onPlayerReady,
-    toggleVideoTheaterMode,
-  } = props;
+  const { autoplay, startMuted, source, sourceType, poster, isAudio, onPlayerReady, toggleVideoTheaterMode } = props;
 
   const [reload, setReload] = useState('initial');
 
@@ -240,10 +231,8 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   }
 
   function retryVideoAfterFailure() {
-    if (player) {
-      setReload(Date.now());
-      showTapButton(TAP.NONE);
-    }
+    setReload(Date.now());
+    showTapButton(TAP.NONE);
   }
 
   function onInitialPlay() {
@@ -428,12 +417,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       let type = sourceType;
 
       // override type if we receive an .m3u8 (transcoded mp4)
-      if (
-        response &&
-        response.redirected &&
-        response.url &&
-        response.url.endsWith('m3u8')
-      ) {
+      if (response && response.redirected && response.url && response.url.endsWith('m3u8')) {
         type = 'application/x-mpegURL';
       }
 
@@ -447,7 +431,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         type: type,
       });
     });
-  }, [source]);
+  }, [source, reload]);
 
   return (
     reload && (

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -233,7 +233,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
   function retryVideoAfterFailure() {
     const player = playerRef.current;
-    console.log(player);
     if (player) {
       setReload(Date.now());
       showTapButton(TAP.NONE);


### PR DESCRIPTION
Discovered while reviewing https://github.com/lbryio/lbry-desktop/pull/5401

VideoJs's reference to itself was not stateful, and was possible for the component to lose it's state and the reference to itself due a rerender.

A hacky way around this was using `window.player` to store the reference globally, but that's bad practice. Instead we should maintain state within the component and persist state across renders.

This seems like a more "react-y" way of doing this. 