### PR TITLE
Remove markdown from og and description header tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "electron-updater": "^4.2.4",
     "express": "^4.17.1",
     "if-env": "^1.0.4",
-    "remark-breaks": "^2.0.1",
+	"remark-breaks": "^2.0.1",
+	"remove-markdown": "^0.3.0",
     "tempy": "^0.6.0",
     "videojs-logo": "^2.1.4"
   },

--- a/web/src/html.js
+++ b/web/src/html.js
@@ -14,6 +14,7 @@ const { getClaim } = require('./chainquery');
 const { parseURI } = require('lbry-redux');
 const fs = require('fs');
 const path = require('path');
+const removeMd = require('remove-markdown');
 const { getJsBundleId } = require('../bundle-id.js');
 const jsBundleId = getJsBundleId();
 
@@ -47,18 +48,19 @@ function escapeHtmlProperty(property) {
 //
 function buildOgMetadata(overrideOptions = {}) {
   const { title, description } = overrideOptions;
+  const cleanDescription = removeMd(description || SITE_DESCRIPTION);
   const head =
     `<title>${SITE_TITLE}</title>\n` +
     `<meta property="og:url" content="${URL}" />\n` +
     `<meta property="og:title" content="${title || OG_HOMEPAGE_TITLE || SITE_TITLE}" />\n` +
     `<meta property="og:site_name" content="${SITE_NAME || SITE_TITLE}"/>\n` +
-    `<meta property="og:description" content="${description || SITE_DESCRIPTION}" />\n` +
+    `<meta property="og:description" content="${cleanDescription}" />\n` +
     `<meta property="og:image" content="${OG_IMAGE_URL || `${URL}/public/v2-og.png`}" />\n` +
     '<meta name="twitter:card" content="summary_large_image"/>\n' +
     `<meta name="twitter:title" content="${(title && title + OG_TITLE_SUFFIX) ||
       OG_HOMEPAGE_TITLE ||
       SITE_TITLE}" />\n` +
-    `<meta name="twitter:description" content="${description || SITE_DESCRIPTION}" />\n` +
+    `<meta name="twitter:description" content="${cleanDescription}" />\n` +
     `<meta name="twitter:image" content="${OG_IMAGE_URL || `${URL}/public/v2-og.png`}"/>\n` +
     `<meta name="twitter:url" content="${URL}" />\n` +
     '<meta property="fb:app_id" content="1673146449633983" />\n' +
@@ -97,18 +99,19 @@ function buildClaimOgMetadata(uri, claim, overrideOptions = {}) {
   // Allow for ovverriding default claim based og metadata
   const title = overrideOptions.title || claimTitle;
   const description = overrideOptions.description || claimDescription;
+  const cleanDescription = removeMd(description);
 
   let head = '';
 
   head += '<meta charset="utf8"/>';
   head += `<title>${title}</title>`;
-  head += `<meta name="description" content="${description}"/>`;
+  head += `<meta name="description" content="${cleanDescription}"/>`;
   if (claim.tags) {
     head += `<meta name="keywords" content="${claim.tags.toString()}"/>`;
   }
 
   head += `<meta name="twitter:image" content="${claimThumbnail}"/>`;
-  head += `<meta property="og:description" content="${description}"/>`;
+  head += `<meta property="og:description" content="${cleanDescription}"/>`;
   head += `<meta property="og:image" content="${claimThumbnail}"/>`;
   head += `<meta property="og:locale" content="${claimLanguage}"/>`;
   head += `<meta property="og:site_name" content="${SITE_NAME}"/>`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9673,6 +9673,11 @@ remark@^9.0.0:
     remark-stringify "^5.0.0"
     unified "^6.0.0"
 
+remove-markdown@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/remove-markdown/-/remove-markdown-0.3.0.tgz#5e4b667493a93579728f3d52ecc1db9ca505dc98"
+  integrity sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/3575

## What is the current behavior?

Raw markdown syntax is being displayed in `og:description` and `description` header tags.

## What is the new behavior?

Markdown is removed from `og:description` and `description` header tags.

## Other information

**NOTE**: Please double check if these changes indeed solve the issue. I tried testing it using `yarn dev:web` but the `og:description` content was always the value of `SITE_DESCRIPTION`. I tried using the production build; using the dev web server (`yarn dev:web-server`); and even with `pm2` just in case but the descriptions weren't generated as seen in lbry.tv.
