### PR TITLE
Display default image for channel thumbnail on error

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -72,7 +72,8 @@ function ChannelThumbnail(props: Props) {
         <img
           alt={__('Channel profile picture')}
           className="channel-thumbnail__default"
-          src={thumbnailPreview || Gerbil}
+          src={!thumbError && thumbnailPreview ? thumbnailPreview : Gerbil}
+          onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
         />
       )}
       {showThumb && (


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/3751

## What is the current behavior?

When the channel thumbnail can't be loaded, nothing gets displayed.

## What is the new behavior?

When the channel thumbnail can't be loaded, a default image is displayed.

## Other information
