### PR TITLE
Remove deprecated http to https replacement in thumbnail urls

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -73,7 +73,7 @@ function ChannelThumbnail(props: Props) {
           alt={__('Channel profile picture')}
           className="channel-thumbnail__default"
           src={!thumbError && thumbnailPreview ? thumbnailPreview : Gerbil}
-          onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
+          onError={() => setThumbError(true)}
         />
       )}
       {showThumb && (
@@ -85,7 +85,7 @@ function ChannelThumbnail(props: Props) {
               alt={__('Channel profile picture')}
               className="channel-thumbnail__custom"
               src={!thumbError ? thumbnailPreview || thumbnail : Gerbil}
-              onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
+              onError={() => setThumbError(true)}
             />
           )}
         </>

--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -35,8 +35,8 @@ function ChannelThumbnail(props: Props) {
   } = props;
   const [thumbError, setThumbError] = React.useState(false);
   const shouldResolve = claim === undefined;
-  const thumbnail = rawThumbnail && rawThumbnail.trim().replace(/^http:\/\//i, 'https://');
-  const thumbnailPreview = rawThumbnailPreview && rawThumbnailPreview.trim().replace(/^http:\/\//i, 'https://');
+  const thumbnail = rawThumbnail && rawThumbnail.trim();
+  const thumbnailPreview = rawThumbnailPreview && rawThumbnailPreview.trim();
   const channelThumbnail = thumbnail || thumbnailPreview;
   const showThumb = (!obscure && !!thumbnail) || thumbnailPreview;
   // Generate a random color class based on the first letter of the channel name

--- a/ui/component/fileThumbnail/view.jsx
+++ b/ui/component/fileThumbnail/view.jsx
@@ -18,7 +18,7 @@ type Props = {
 
 function FileThumbnail(props: Props) {
   const { claim, uri, doResolveUri, thumbnail: rawThumbnail, children, allowGifs = false, className } = props;
-  const passedThumbnail = rawThumbnail && rawThumbnail.trim().replace(/^http:\/\//i, 'https://');
+  const passedThumbnail = rawThumbnail && rawThumbnail.trim();
   const thumbnailFromClaim =
     uri && claim && claim.value && claim.value.thumbnail ? claim.value.thumbnail.url : undefined;
   const thumbnail = passedThumbnail || thumbnailFromClaim;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/3751

## What is the current behavior?

## What is the new behavior?

## Other information

The bug is already fixed, this PR only gets rid of a deprecated comment and the http to https replacement (no longer needed).
