### PR TITLE
Search: Get `uris` with same query as `doSearch`

### DIFF
--- a/ui/page/search/index.js
+++ b/ui/page/search/index.js
@@ -16,7 +16,11 @@ import SearchPage from './view';
 const select = (state, props) => {
   const showMature = makeSelectClientSetting(SETTINGS.SHOW_MATURE)(state);
   const urlParams = new URLSearchParams(props.location.search);
-  const urlQuery = urlParams.get('q') || null;
+  let urlQuery = urlParams.get('q') || null;
+  if (urlQuery) {
+    urlQuery = urlQuery.replace(/^lbry:\/\//i, '').replace(/\//, ' ');
+  }
+
   const query = makeSelectQueryWithOptions(
     urlQuery,
     showMature === false ? { nsfw: false, isBackgroundSearch: false } : { isBackgroundSearch: false }


### PR DESCRIPTION
## Issue
Closes #2731: [Searches with forward slashes returns no results](https://github.com/lbryio/lbry-desktop/issues/2731)

## Change
The slash-removal came from (https://github.com/lbryio/lbry-redux/commit/0db20834f9ff99d3ba7acd8e4e8ebb5a41f7e7b4).

Removing the 2 `replace(/\//, ' ')` from lbry-desktop fixes it, but this PR assumes the slash-removal is intentional to cover something else. So, we'll make the Search side do the same thing to match what's happening in `doSearch`.

A little bit ugly, but there's already a comment about this in `makeSelectSearchUris`, so it'll probably get cleaned up together in the future.
