### PR TITLE
videojs: make control bar slightly transparent.

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -387,7 +387,7 @@
   }
 
   .vjs-control-bar {
-    background-color: #000000;
+    background-color: rgba(0, 0, 0, 0.8);
 
     .vjs-remaining-time {
       display: none;


### PR DESCRIPTION
## Issue


It's not actually cropped -- the control bar was opaque.

## Change
Use 0.80 opacity to somewhat see the full picture.

Using 0.5 or less would be even better, but due to the default tiny size of the control bar, the text becomes unreadable (it's readable if you zoom the browser to get larger text). Don't want to mess with sizing for now, so using 0.80 to get the best of both worlds.

![image](https://user-images.githubusercontent.com/64950861/106465165-8f013f00-64d4-11eb-93d3-090474247199.png)

