### PR TITLE
Fetch and display last release changes from GitHub in modal upgrade &…

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -214,7 +214,7 @@
   "Skip": "Skip",
   "An updated version of LBRY is now available.": "An updated version of LBRY is now available.",
   "Your version is out of date and may be unreliable or insecure.": "Your version is out of date and may be unreliable or insecure.",
-  "A new version of LBRY is ready for you.": "A new version of LBRY is ready for you.",
+  "A new version %release_tag% of LBRY is ready for you.": "A new version %release_tag% of LBRY is ready for you.",
   "Want to know what has changed? See the %release_notes%.": "Want to know what has changed? See the %release_notes%.",
   "release notes": "release notes",
   "Read the FAQ": "Read the FAQ",

--- a/ui/component/lastReleaseChanges/index.js
+++ b/ui/component/lastReleaseChanges/index.js
@@ -1,0 +1,3 @@
+import LastReleaseChanges from './view';
+
+export default LastReleaseChanges;

--- a/ui/component/lastReleaseChanges/view.jsx
+++ b/ui/component/lastReleaseChanges/view.jsx
@@ -1,0 +1,88 @@
+// @flow
+import React, { useState, useEffect } from 'react';
+import remark from 'remark';
+import reactRenderer from 'remark-react';
+import Button from 'component/button';
+import I18nMessage from 'component/i18nMessage';
+
+type Props = {
+  hideReleaseVersion?: boolean,
+};
+
+const LastReleaseChanges = (props: Props) => {
+  const { hideReleaseVersion } = props;
+  const [releaseTag, setReleaseTag] = useState('');
+  const [releaseChanges, setReleaseChanges] = useState('');
+  const [fetchingReleaseChanges, setFetchingReleaseChanges] = useState(false);
+  const [fetchReleaseFailed, setFetchReleaseFailed] = useState(false);
+
+  const releaseVersionTitle = (
+    <p>
+      {!hideReleaseVersion && __('A new version %release_tag% of LBRY is ready for you.', { release_tag: releaseTag })}
+    </p>
+  );
+  const seeReleaseNotes = (
+    <p className="help">
+      <I18nMessage
+        tokens={{
+          release_notes: (
+            <Button button="link" label={__('release notes')} href="https://github.com/lbryio/lbry-desktop/releases" />
+          ),
+        }}
+      >
+        Want to know what has changed? See the %release_notes%.
+      </I18nMessage>
+    </p>
+  );
+
+  useEffect(() => {
+    const lastReleaseUrl = 'https://api.github.com/repos/lbryio/lbry-desktop/releases/latest';
+    const options = {
+      method: 'GET',
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    };
+
+    setFetchingReleaseChanges(true);
+    fetch(lastReleaseUrl, options)
+      .then(response => response.json())
+      .then(response => {
+        setReleaseTag(response.tag_name);
+        setReleaseChanges(response.body);
+        setFetchingReleaseChanges(false);
+        setFetchReleaseFailed(false);
+      })
+      .catch(() => {
+        setFetchingReleaseChanges(false);
+        setFetchReleaseFailed(true);
+      });
+  }, []);
+
+  if (fetchingReleaseChanges) {
+    return <p>{__('Loading...')}</p>;
+  }
+
+  if (fetchReleaseFailed) {
+    return (
+      <div>
+        {releaseVersionTitle}
+        {seeReleaseNotes}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {releaseVersionTitle}
+      <p>
+        {
+          remark()
+            .use(reactRenderer)
+            .processSync(releaseChanges).contents
+        }
+      </p>
+      {seeReleaseNotes}
+    </div>
+  );
+};
+
+export default LastReleaseChanges;

--- a/ui/component/lastReleaseChanges/view.jsx
+++ b/ui/component/lastReleaseChanges/view.jsx
@@ -1,7 +1,6 @@
 // @flow
 import React, { useState, useEffect } from 'react';
-import remark from 'remark';
-import reactRenderer from 'remark-react';
+import MarkdownPreview from 'component/common/markdown-preview';
 import Button from 'component/button';
 import I18nMessage from 'component/i18nMessage';
 
@@ -74,11 +73,7 @@ const LastReleaseChanges = (props: Props) => {
     <div>
       {releaseVersionTitle}
       <p>
-        {
-          remark()
-            .use(reactRenderer)
-            .processSync(releaseChanges).contents
-        }
+        <MarkdownPreview content={releaseChanges} />
       </p>
       {seeReleaseNotes}
     </div>

--- a/ui/modal/modalAutoUpdateDownloaded/view.jsx
+++ b/ui/modal/modalAutoUpdateDownloaded/view.jsx
@@ -1,70 +1,45 @@
 // @flow
-import React from 'react';
+import React, { useState } from 'react';
 // @if TARGET='app'
 import { ipcRenderer } from 'electron';
 // @endif
 import { Modal } from 'modal/modal';
-import Button from 'component/button';
-import I18nMessage from 'component/i18nMessage';
+import LastReleaseChanges from 'component/lastReleaseChanges';
 
 type Props = {
   closeModal: any => any,
   declineAutoUpdate: () => any,
 };
 
-type State = {
-  disabled: boolean,
+const ModalAutoUpdateDownloaded = (props: Props) => {
+  const { closeModal, declineAutoUpdate } = props;
+  const [disabled, setDisabled] = useState(false);
+
+  const handleConfirm = () => {
+    setDisabled(true);
+    ipcRenderer.send('autoUpdateAccepted');
+  };
+
+  const handleAbort = () => {
+    declineAutoUpdate();
+    closeModal();
+  };
+
+  return (
+    <Modal
+      isOpen
+      type="confirm"
+      contentLabel={__('Upgrade Downloaded')}
+      title={__('LBRY leveled up')}
+      confirmButtonLabel={__('Upgrade Now')}
+      abortButtonLabel={__('Not Now')}
+      confirmButtonDisabled={disabled}
+      onConfirmed={handleConfirm}
+      onAborted={handleAbort}
+    >
+      <LastReleaseChanges />
+    </Modal>
+  );
 };
-
-class ModalAutoUpdateDownloaded extends React.PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      disabled: false,
-    };
-  }
-
-  render() {
-    const { closeModal, declineAutoUpdate } = this.props;
-
-    return (
-      <Modal
-        isOpen
-        type="confirm"
-        contentLabel={__('Upgrade Downloaded')}
-        title={__('LBRY leveled up')}
-        confirmButtonLabel={__('Upgrade Now')}
-        abortButtonLabel={__('Not Now')}
-        confirmButtonDisabled={this.state.disabled}
-        onConfirmed={() => {
-          this.setState({ disabled: true });
-          ipcRenderer.send('autoUpdateAccepted');
-        }}
-        onAborted={() => {
-          declineAutoUpdate();
-          closeModal();
-        }}
-      >
-        <p>{__('A new version of LBRY is ready for you.')}</p>
-        <p className="help">
-          <I18nMessage
-            tokens={{
-              release_notes: (
-                <Button
-                  button="link"
-                  label={__('release notes')}
-                  href="https://github.com/lbryio/lbry-desktop/releases"
-                />
-              ),
-            }}
-          >
-            Want to know what has changed? See the %release_notes%.
-          </I18nMessage>
-        </p>
-      </Modal>
-    );
-  }
-}
 
 export default ModalAutoUpdateDownloaded;

--- a/ui/modal/modalUpgrade/view.jsx
+++ b/ui/modal/modalUpgrade/view.jsx
@@ -1,8 +1,7 @@
 // @flow
 import React from 'react';
 import { Modal } from 'modal/modal';
-import Button from 'component/button';
-import I18nMessage from 'component/i18nMessage';
+import LastReleaseChanges from 'component/lastReleaseChanges';
 
 type Props = {
   downloadUpgrade: () => void,
@@ -28,21 +27,7 @@ class ModalUpgrade extends React.PureComponent<Props> {
           {__('An updated version of LBRY is now available.')}{' '}
           {__('Your version is out of date and may be unreliable or insecure.')}
         </p>
-        <p className="help">
-          <I18nMessage
-            tokens={{
-              release_notes: (
-                <Button
-                  button="link"
-                  label={__('release notes')}
-                  href="https://github.com/lbryio/lbry-desktop/releases"
-                />
-              ),
-            }}
-          >
-            Want to know what has changed? See the %release_notes%.
-          </I18nMessage>
-        </p>
+        <LastReleaseChanges hideReleaseVersion />
       </Modal>
     );
   }


### PR DESCRIPTION
… modal auto update downloaded

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/2186

## What is the current behavior?

When a new version of the app is available, the user can see those by checking the releases on Github.

## What is the new behavior?

When a new version of the app is available, the user can see the new changes of the latest release in the app.
The release log is fetched using GitHub's release service: https://docs.github.com/en/rest/reference/repos#releases

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

![image](https://user-images.githubusercontent.com/1719111/106529287-016c2200-64c9-11eb-8774-6925d15d4040.png)
