### PR TITLE
fix wrong word 'downloads' to 'purchases'

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -143,7 +143,7 @@
   "Purchase and tip confirmations": "Purchase and tip confirmations",
   "Always confirm before purchasing content or tipping": "Always confirm before purchasing content or tipping",
   "Only confirm purchases or tips over a certain amount": "Only confirm purchases or tips over a certain amount",
-  "When this option is chosen, LBRY won't ask you to confirm downloads or tips below your chosen amount.": "When this option is chosen, LBRY won't ask you to confirm downloads or tips below your chosen amount.",
+  "When this option is chosen, LBRY won't ask you to confirm purchases or tips below your chosen amount.": "When this option is chosen, LBRY won't ask you to confirm purchases or tips below your chosen amount.",
   "Content settings": "Content settings",
   "Notifications": "Notifications",
   "Show Desktop Notifications": "Show Desktop Notifications",

--- a/ui/page/settingsAdvanced/view.jsx
+++ b/ui/page/settingsAdvanced/view.jsx
@@ -331,7 +331,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
 
                   <p className="help">
                     {__(
-                      "When this option is chosen, LBRY won't ask you to confirm downloads or tips below your chosen amount."
+                      "When this option is chosen, LBRY won't ask you to confirm purchases or tips below your chosen amount."
                     )}
                   </p>
                 </React.Fragment>


### PR DESCRIPTION
PR basic info:

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Details:

Change the word 'download' to 'purchase' in 2 files ([source code](https://github.com/lbryio/lbry-desktop/blob/master/ui/page/settingsAdvanced/view.jsx) and [translation strings file](https://github.com/lbryio/lbry-desktop/blob/master/static/app-strings.json)).

Change reason:
This change is located in the [Advanced Setting Page](https://github.com/lbryio/lbry-desktop/blob/master/ui/page/settingsAdvanced/view.jsx) and it asked whether the app send a confirmation message when the user is going to make a payment higher than a certain value. **Notice that you make payment through purchasing and tipping, rather than downloading.** I'm a translator working on [transifex](https://www.transifex.com/user/profile/johnspirit/) and found this bug when I'm translating it to Chinese. There are also [one comment](https://www.transifex.com/lbry/lbry-desktop/translate/#zh-Hans/app-strings/291656035?q=reviewed%3Ano) in transifex referring to the aformentioned problem.

