### PR TITLE
Do not propagate double click event on search input

### DIFF
--- a/ui/component/wunderbarSuggestions/view.jsx
+++ b/ui/component/wunderbarSuggestions/view.jsx
@@ -17,6 +17,7 @@ import { useHistory } from 'react-router';
 import { formatLbryUrlForWeb } from 'util/url';
 import useThrottle from 'effects/use-throttle';
 import Yrbl from 'component/yrbl';
+import type { ElementRef } from 'react';
 
 const WEB_DEV_PREFIX = `${URL_DEV}/`;
 const WEB_LOCAL_PREFIX = `${URL_LOCAL}/`;
@@ -40,7 +41,7 @@ type Props = {
 
 export default function WunderBarSuggestions(props: Props) {
   const { navigateToSearchPage, doShowSnackBar, doResolveUris, showMature, isMobile, doCloseMobileSearch } = props;
-  const inputRef = React.useRef();
+  const inputRef: ElementRef<any> = React.useRef();
   const isFocused = inputRef && inputRef.current && inputRef.current === document.activeElement;
 
   const {
@@ -152,7 +153,27 @@ export default function WunderBarSuggestions(props: Props) {
     }
 
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+
+    // @if TARGET='app'
+    function handleDoubleClick(event) {
+      if (!inputRef.current) {
+        return;
+      }
+
+      event.stopPropagation();
+    }
+
+    inputRef.current.addEventListener('dblclick', handleDoubleClick);
+    // @endif
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      // @if TARGET='app'
+      if (inputRef.current) {
+        inputRef.current.removeEventListener('dblclick', handleDoubleClick);
+      }
+      // @endif
+    };
   }, [inputRef]);
 
   React.useEffect(() => {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

N/A

## What is the current behavior?
When double clicking the search box in non-mobile view, the window will maximize. This is a little annoying because it's common (at least for me) to double click to select a word in an input field, or triple click to select all text (triple clicking is currently impossible because of the maximizing).

![](https://static.jk0.dev/double-click-lbry.gif)

## What is the new behavior?
Double clicking the search box does not maximize the window.
I'm unfamiliar with this code, so I wasn't really sure what the testing procedure is. I just confirmed it fixed the issue in electron and didn't break the web version/mobile view. I only tested on Linux.

## Other information
#4208 Introduced double-clicking to maximize the window. This code did prevent double clicking the search box maximizing the window.
1203006 Seems to have subsequently removed this.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
