### PR TITLE
correctly set active channel on edits

### DIFF
--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -9,7 +9,7 @@ import {
 import { makeSelectCostInfoForUri } from 'lbryinc';
 import { doSetPlayingUri } from 'redux/actions/content';
 import { doToast } from 'redux/actions/notifications';
-import { doOpenModal } from 'redux/actions/app';
+import { doOpenModal, doSetActiveChannel, doSetIncognito } from 'redux/actions/app';
 import fs from 'fs';
 import FileActions from './view';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
@@ -23,11 +23,19 @@ const select = (state, props) => ({
   myChannels: selectMyChannelClaims(state),
 });
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   openModal: (modal, props) => dispatch(doOpenModal(modal, props)),
-  prepareEdit: (publishData, uri, fileInfo) => dispatch(doPrepareEdit(publishData, uri, fileInfo, fs)),
+  prepareEdit: (publishData, uri, fileInfo) => {
+    if (publishData.signing_channel) {
+      dispatch(doSetActiveChannel(publishData.signing_channel.claim_id));
+    } else {
+      dispatch(doSetIncognito(true));
+    }
+
+    dispatch(doPrepareEdit(publishData, uri, fileInfo, fs));
+  },
   clearPlayingUri: () => dispatch(doSetPlayingUri({ uri: null })),
-  doToast: options => dispatch(doToast(options)),
+  doToast: (options) => dispatch(doToast(options)),
 });
 
 export default connect(select, perform)(FileActions);


### PR DESCRIPTION
The active channel wasn't being set properly on edits. So if you had channel a selected as the active channel, then tried to edit a claim made by channel b, it wouldn't work.