### PR TITLE
Report claims via right-click

### DIFF
--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -5,7 +5,7 @@ import { NavLink, withRouter } from 'react-router-dom';
 import classnames from 'classnames';
 import { SIMPLE_SITE } from 'config';
 import { parseURI, convertToShareLink } from 'lbry-redux';
-import { openCopyLinkMenu } from 'util/context-menu';
+import { openClaimPreviewMenu } from 'util/context-menu';
 import { formatLbryUrlForWeb } from 'util/url';
 import { isEmpty } from 'util/object';
 import FileThumbnail from 'component/fileThumbnail';
@@ -193,10 +193,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     // @if TARGET='app'
     e.preventDefault();
     e.stopPropagation();
-    if (claim) {
-      const shareLink = convertToShareLink(claim.canonical_url || claim.permanent_url);
-      openCopyLinkMenu(shareLink.replace(/#/g, ':'), e);
-    }
+    openClaimPreviewMenu(claim, e);
     // @endif
   }
 

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -4,8 +4,10 @@ import React, { useEffect, forwardRef } from 'react';
 import { NavLink, withRouter } from 'react-router-dom';
 import classnames from 'classnames';
 import { SIMPLE_SITE } from 'config';
-import { parseURI, convertToShareLink } from 'lbry-redux';
+import { parseURI } from 'lbry-redux';
+// @if TARGET='app'
 import { openClaimPreviewMenu } from 'util/context-menu';
+// @endif
 import { formatLbryUrlForWeb } from 'util/url';
 import { isEmpty } from 'util/object';
 import FileThumbnail from 'component/fileThumbnail';

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -14,7 +14,9 @@ import { parseURI } from 'lbry-redux';
 import FileProperties from 'component/fileProperties';
 import FileDownloadLink from 'component/fileDownloadLink';
 import ClaimRepostAuthor from 'component/claimRepostAuthor';
+// @if TARGET='app'
 import { openClaimPreviewMenu } from 'util/context-menu';
+// @endif
 
 type Props = {
   uri: string,

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -14,6 +14,7 @@ import { parseURI } from 'lbry-redux';
 import FileProperties from 'component/fileProperties';
 import FileDownloadLink from 'component/fileDownloadLink';
 import ClaimRepostAuthor from 'component/claimRepostAuthor';
+import { openClaimPreviewMenu } from 'util/context-menu';
 
 type Props = {
   uri: string,
@@ -150,10 +151,19 @@ function ClaimPreviewTile(props: Props) {
     );
   }
 
+  function handleContextMenu(e) {
+    // @if TARGET='app'
+    e.preventDefault();
+    e.stopPropagation();
+    openClaimPreviewMenu(claim, e);
+    // @endif
+  }
+
   return (
     <li
       role="link"
       onClick={handleClick}
+      onContextMenu={handleContextMenu}
       className={classnames('card claim-preview--tile', {
         'claim-preview__wrapper--channel': isChannel,
       })}

--- a/ui/util/context-menu.js
+++ b/ui/util/context-menu.js
@@ -107,6 +107,7 @@ export function openSnippetMenu(codeMirror, event) {
 }
 
 export function openClaimPreviewMenu(claim, event) {
+  // @if TARGET='app'
   let templates = [];
 
   if (claim) {
@@ -135,6 +136,7 @@ export function openClaimPreviewMenu(claim, event) {
   if (templates.length !== 0) {
     remote.Menu.buildFromTemplate(templates).popup({});
   }
+  // @endif
 }
 
 // Block context menu

--- a/ui/util/context-menu.js
+++ b/ui/util/context-menu.js
@@ -1,4 +1,4 @@
-import { clipboard, remote } from 'electron';
+import { clipboard, remote, shell } from 'electron';
 import { convertToShareLink } from 'lbry-redux';
 const isDev = process.env.NODE_ENV !== 'production';
 
@@ -111,10 +111,21 @@ export function openClaimPreviewMenu(claim, event) {
 
   if (claim) {
     const shareLink = convertToShareLink(claim.canonical_url || claim.permanent_url);
+    const claimId = claim.claim_id;
+
     templates.push({
       label: 'Copy link',
       click: () => {
         clipboard.writeText(shareLink);
+      },
+    });
+
+    templates.push({ type: 'separator' });
+
+    templates.push({
+      label: 'Report content',
+      click: () => {
+        shell.openExternal(`https://lbry.com/dmca/${claimId}`);
       },
     });
   }

--- a/ui/util/context-menu.js
+++ b/ui/util/context-menu.js
@@ -119,7 +119,11 @@ export function openClaimPreviewMenu(claim, event) {
     });
   }
 
-  openContextMenu(event, templates);
+  injectDevelopmentTemplate(event, templates);
+
+  if (templates.length !== 0) {
+    remote.Menu.buildFromTemplate(templates).popup({});
+  }
 }
 
 // Block context menu

--- a/ui/util/context-menu.js
+++ b/ui/util/context-menu.js
@@ -1,4 +1,5 @@
 import { clipboard, remote } from 'electron';
+import { convertToShareLink } from 'lbry-redux';
 const isDev = process.env.NODE_ENV !== 'production';
 
 function injectDevelopmentTemplate(event, templates) {
@@ -105,15 +106,19 @@ export function openSnippetMenu(codeMirror, event) {
   openContextMenu(event, templates, false, selection);
 }
 
-export function openCopyLinkMenu(text, event) {
-  const templates = [
-    {
+export function openClaimPreviewMenu(claim, event) {
+  let templates = [];
+
+  if (claim) {
+    const shareLink = convertToShareLink(claim.canonical_url || claim.permanent_url);
+    templates.push({
       label: 'Copy link',
       click: () => {
-        clipboard.writeText(text);
+        clipboard.writeText(shareLink);
       },
-    },
-  ];
+    });
+  }
+
   openContextMenu(event, templates);
 }
 


### PR DESCRIPTION
## Issue
Closes #5500 [Allow right click + report feature on tiles ](https://github.com/lbryio/lbry-desktop/issues/5500)

## Changes
- Refactored context-menu code so that both Claim Preview and Claim Tile uses the same popup.
- Added ability to Report from the context menu.

_I left the commits separated to hopefully ease the review process. Feel free to squash if necessary._