### PR TITLE
Video fixes

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -30,6 +30,7 @@ export type Player = {
   loadingSpinner: any,
   getChild: (string) => any,
   playbackRate: (?number) => number,
+  readyState: () => number,
   userActive: (?boolean) => boolean,
   overlay: (any) => void,
   mobileUi: (any) => void,

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -451,7 +451,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     return vjs;
   }
 
-  // This lifecycle hook is only called once (on mount)
+  // This lifecycle hook is only called once (on mount), or when `isAudio` changes.
   useEffect(() => {
     const vjsElement = createVideoPlayerDOM(containerRef.current);
     const vjsPlayer = initializeVideoPlayer(vjsElement);
@@ -475,7 +475,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         player.dispose();
       }
     };
-  }, []);
+  }, [isAudio]);
 
   // Update video player and reload when source URL changes
   useEffect(() => {

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -19,8 +19,8 @@ const PLAY_TIMEOUT_LIMIT = 2000;
 
 type Props = {
   position: number,
-  changeVolume: number => void,
-  changeMute: boolean => void,
+  changeVolume: (number) => void,
+  changeMute: (boolean) => void,
   source: string,
   contentType: string,
   thumbnail: string,
@@ -36,9 +36,9 @@ type Props = {
   doAnalyticsBuffer: (string, any) => void,
   claimRewards: () => void,
   savePosition: (string, number) => void,
-  clearPosition: string => void,
+  clearPosition: (string) => void,
   toggleVideoTheaterMode: () => void,
-  setVideoPlaybackRate: number => void,
+  setVideoPlaybackRate: (number) => void,
 };
 
 /*
@@ -94,7 +94,7 @@ function VideoViewer(props: Props) {
   }, [uri, previousUri]);
 
   function doTrackingBuffered(e: Event, data: any) {
-    fetch(source, { method: 'HEAD' }).then(response => {
+    fetch(source, { method: 'HEAD' }).then((response) => {
       data.playerPoweredBy = response.headers.get('x-powered-by');
       doAnalyticsBuffer(uri, data);
     });
@@ -150,12 +150,14 @@ function VideoViewer(props: Props) {
       // https://blog.videojs.com/autoplay-best-practices-with-video-js/#Programmatic-Autoplay-and-Success-Failure-Detection
       if (shouldPlay) {
         const playPromise = player.play();
-        const timeoutPromise = new Promise((resolve, reject) => setTimeout(() => reject(PLAY_TIMEOUT_ERROR), PLAY_TIMEOUT_LIMIT));
+        const timeoutPromise = new Promise((resolve, reject) =>
+          setTimeout(() => reject(PLAY_TIMEOUT_ERROR), PLAY_TIMEOUT_LIMIT)
+        );
 
-        Promise.race([playPromise, timeoutPromise]).catch(error => {
+        Promise.race([playPromise, timeoutPromise]).catch((error) => {
           if (PLAY_TIMEOUT_ERROR) {
             const retryPlayPromise = player.play();
-            Promise.race([retryPlayPromise, timeoutPromise]).catch(error => {
+            Promise.race([retryPlayPromise, timeoutPromise]).catch((error) => {
               setIsLoading(false);
               setIsPlaying(false);
             });
@@ -167,6 +169,7 @@ function VideoViewer(props: Props) {
       }
 
       setIsLoading(shouldPlay); // if we are here outside of an embed, we're playing
+
       player.on('tracking:buffered', doTrackingBuffered);
       player.on('tracking:firstplay', doTrackingFirstPlay);
       player.on('ended', onEnded);
@@ -175,9 +178,8 @@ function VideoViewer(props: Props) {
         setIsPlaying(false);
         handlePosition(player);
       });
-      player.on('error', function() {
+      player.on('error', () => {
         const error = player.error();
-
         if (error) {
           analytics.sentryError('Video.js error', error);
         }

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -98,11 +98,9 @@ function VideoViewer(props: Props) {
   useEffect(() => {
     vjsCallbackDataRef.current = {
       embedded: embedded,
-      muted: muted,
-      volume: volume,
       videoPlaybackRate: videoPlaybackRate,
     };
-  }, [embedded, muted, volume, videoPlaybackRate]);
+  }, [embedded, videoPlaybackRate]);
 
   function doTrackingBuffered(e: Event, data: any) {
     fetch(source, { method: 'HEAD' }).then((response) => {
@@ -148,10 +146,8 @@ function VideoViewer(props: Props) {
     }
   }
 
-  function restoreSavedSettings(player) {
+  function restorePlaybackRate(player) {
     if (!vjsCallbackDataRef.current.embedded) {
-      player.muted(vjsCallbackDataRef.current.muted);
-      player.volume(vjsCallbackDataRef.current.volume);
       player.playbackRate(vjsCallbackDataRef.current.videoPlaybackRate);
     }
   }
@@ -159,6 +155,9 @@ function VideoViewer(props: Props) {
   const onPlayerReady = useCallback(
     (player: Player) => {
       if (!embedded) {
+        player.muted(muted);
+        player.volume(volume);
+        player.playbackRate(videoPlaybackRate);
         addTheaterModeButton(player, toggleVideoTheaterMode);
       }
 
@@ -186,11 +185,11 @@ function VideoViewer(props: Props) {
 
       setIsLoading(shouldPlay); // if we are here outside of an embed, we're playing
 
-      // PR: #5535; Commit: "vjs: Fix 'Video-setting persistence broken'"
+      // PR: #5535
       // Move the restoration to a later `loadedmetadata` phase to counter the
       // delay from the header-fetch. This is a temp change until the next
       // re-factoring.
-      player.on('loadedmetadata', () => restoreSavedSettings(player));
+      player.on('loadedmetadata', () => restorePlaybackRate(player));
 
       player.on('tracking:buffered', doTrackingBuffered);
       player.on('tracking:firstplay', doTrackingFirstPlay);


### PR DESCRIPTION
## Issue
Closes #5450[: Video showing previous audio clip's thumbnail instead](https://github.com/lbryio/lbry-desktop/issues/5450)

## Notes
`createVideoPlayerDOM` depends on `isAudio`

## Issue
Closes #5513[: Video-setting persistence broken](https://github.com/lbryio/lbry-desktop/issues/5513)

## Notes
- Per videojs recommendation, the setting-restoration should be done after the video has been loaded, so the action was moved to `loadedmetadata`. This fixed the volume slider problem, and should have fixed the playbackRate too.
- For playbackRate, there is another special case where it gets reset to 1 (refer to comments in code).
- One caveat on moving to `loadedmetadata` is that the rate will be incorrect ("1") while the video is initially loading. 