### PR TITLE
don't set setting until preferences are ready

### DIFF
--- a/ui/component/userSignUp/index.js
+++ b/ui/component/userSignUp/index.js
@@ -1,6 +1,6 @@
 import REWARD_TYPES from 'rewards';
 import { connect } from 'react-redux';
-import { selectGetSyncIsPending, selectSyncHash } from 'redux/selectors/sync';
+import { selectGetSyncIsPending, selectSyncHash, selectPrefsReady } from 'redux/selectors/sync';
 import { doClaimRewardType } from 'redux/actions/rewards';
 import { doSetClientSetting } from 'redux/actions/settings';
 import { selectClaimedRewards, makeSelectIsRewardClaimPending } from 'redux/selectors/rewards';
@@ -22,11 +22,9 @@ import {
 import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { selectInterestedInYoutubeSync } from 'redux/selectors/app';
 import { doToggleInterestedInYoutubeSync } from 'redux/actions/app';
-import { doSetPrefsReady } from 'redux/actions/sync';
-
 import UserSignIn from './view';
 
-const select = state => ({
+const select = (state) => ({
   emailToVerify: selectEmailToVerify(state),
   user: selectUser(state),
   accessToken: selectAccessToken(state),
@@ -47,9 +45,10 @@ const select = state => ({
   hasSynced: Boolean(selectSyncHash(state)),
   creatingChannel: selectCreatingChannel(state),
   interestedInYoutubeSync: selectInterestedInYoutubeSync(state),
+  prefsReady: selectPrefsReady(state),
 });
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   fetchUser: () => dispatch(doUserFetch()),
   claimConfirmEmailReward: () =>
     dispatch(
@@ -65,7 +64,6 @@ const perform = dispatch => ({
     ),
   setClientSetting: (setting, value, pushToPrefs) => dispatch(doSetClientSetting(setting, value, pushToPrefs)),
   doToggleInterestedInYoutubeSync: () => dispatch(doToggleInterestedInYoutubeSync()),
-  setPrefsReady: () => dispatch(doSetPrefsReady()),
 });
 
 export default connect(select, perform)(UserSignIn);

--- a/ui/component/userSignUp/view.jsx
+++ b/ui/component/userSignUp/view.jsx
@@ -46,7 +46,7 @@ type Props = {
   rewardsAcknowledged: boolean,
   interestedInYoutubeSync: boolean,
   doToggleInterestedInYoutubeSync: () => void,
-  setPrefsReady: () => void,
+  prefsReady: boolean,
 };
 
 function UserSignUp(props: Props) {
@@ -72,7 +72,7 @@ function UserSignUp(props: Props) {
     setClientSetting,
     interestedInYoutubeSync,
     doToggleInterestedInYoutubeSync,
-    setPrefsReady,
+    prefsReady,
   } = props;
   const {
     location: { search, pathname },
@@ -90,12 +90,12 @@ function UserSignUp(props: Props) {
   const hasFetchedReward = useFetched(claimingReward);
   const previousHasVerifiedEmail = usePrevious(hasVerifiedEmail);
   const channelCount = channels ? channels.length : 0;
-  const hasClaimedEmailAward = claimedRewards.some(reward => reward.reward_type === REWARDS.TYPE_CONFIRM_EMAIL);
+  const hasClaimedEmailAward = claimedRewards.some((reward) => reward.reward_type === REWARDS.TYPE_CONFIRM_EMAIL);
   const hasYoutubeChannels = youtubeChannels && Boolean(youtubeChannels.length);
   const isYoutubeTransferComplete =
     hasYoutubeChannels &&
     youtubeChannels.every(
-      channel =>
+      (channel) =>
         channel.transfer_state === YOUTUBE_STATUSES.COMPLETED_TRANSFER ||
         channel.sync_status === YOUTUBE_STATUSES.YOUTUBE_SYNC_ABANDONDED
     );
@@ -136,11 +136,10 @@ function UserSignUp(props: Props) {
   }, [fetchUser]);
 
   React.useEffect(() => {
-    if (previousHasVerifiedEmail === false && hasVerifiedEmail) {
-      setPrefsReady();
+    if (previousHasVerifiedEmail === false && hasVerifiedEmail && prefsReady) {
       setSettingAndSync(SETTINGS.FIRST_RUN_STARTED, true);
     }
-  }, [hasVerifiedEmail, previousHasVerifiedEmail, setPrefsReady]);
+  }, [hasVerifiedEmail, previousHasVerifiedEmail, prefsReady]);
 
   React.useEffect(() => {
     // Don't claim the reward if sync is enabled until after a sync has been completed successfully


### PR DESCRIPTION
This doesn't fix the larger issue that is preventing the "first_run_started" value being actually saved in the wallet. But it should prevent users from losing subs when they run into the bug that prompts them to start the first run flow again.