### PR TITLE
Revert "Remove hack in Timestamp parser now that 'remark-breaks' has addressed the original problem."

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "electron-updater": "^4.2.4",
     "express": "^4.17.1",
     "if-env": "^1.0.4",
-	"remark-breaks": "^2.0.1",
 	"remove-markdown": "^0.3.0",
     "tempy": "^0.6.0",
     "videojs-logo": "^2.1.4"
@@ -185,6 +184,7 @@
     "redux-thunk": "^2.2.0",
     "remark": "^9.0.0",
     "remark-attr": "^0.8.3",
+	"remark-breaks": "^1.0.5",
     "remark-emoji": "^2.0.1",
     "remark-frontmatter": "^2.0.0",
     "remark-react": "^8.0.0",

--- a/ui/util/remark-timestamp.js
+++ b/ui/util/remark-timestamp.js
@@ -30,6 +30,13 @@ function findNextTimestamp(value, fromIndex, strictlyFromIndex) {
       }
     }
 
+    if (fromIndex > 0 && fromIndex >= match.index && fromIndex < match.index + match[0].length) {
+      // Skip previously-rejected word, preventing "62:01" from being tokenized as "2:01", for example.
+      // This assumes that a non-zero 'fromIndex' means that a previous lookup has failed.
+      begin = match.index + match[0].length;
+      continue;
+    }
+
     // Exclude trailing colons to allow "0:12: Start of section", for example.
     const str = match[0].replace(/:+$/, '');
 
@@ -77,7 +84,7 @@ function locateTimestamp(value, fromIndex) {
 }
 
 // Generate 'timestamp' markdown node
-const createTimestampNode = (text) => ({
+const createTimestampNode = text => ({
   type: TIMESTAMP_NODE_TYPE,
   value: text,
   children: [{ type: 'text', value: text }],
@@ -138,7 +145,7 @@ const transformer = (node, index, parent) => {
   }
 };
 
-const transform = (tree) => {
+const transform = tree => {
   visit(tree, [TIMESTAMP_NODE_TYPE], transformer);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9560,10 +9560,10 @@ remark-attr@^0.8.3:
     html-element-attributes "^2.0.0"
     md-attr-parser "^1.2.1"
 
-remark-breaks@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-2.0.1.tgz#5dfe54e5b9ab65cfa1e25d6810fb556dda1c8ec1"
-  integrity sha512-CZKI8xdPUnvMqPxYEIBBUg8C0B0kyn14lkW0abzhfh/P71YRIxCC3wvBh6AejQL602OxF6kNRl1x4HAZA07JyQ==
+remark-breaks@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-1.0.5.tgz#e9785f8b174f45c05af542fbeb18354b766e1139"
+  integrity sha512-lr8+TlJI273NjEqL27eUthPYPTCgXEj4NaLbnazS3bQaQL2FySlsbtgo52gE36fE1gWeQgkn1VdmWsoT+uA7FA==
 
 remark-emoji@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Reverts lbryio/lbry-desktop#5525

This hack is still needed. The page may break depending on the description of a claim