### PR TITLE
Touch up for active-channel refactoring

### DIFF
--- a/ui/component/publishName/view.jsx
+++ b/ui/component/publishName/view.jsx
@@ -74,6 +74,7 @@ function PublishName(props: Props) {
           name="content_name"
           value={name}
           error={nameError}
+          disabled={isStillEditing}
           onChange={handleNameChange}
           onBlur={() => setBlurred(true)}
         />


### PR DESCRIPTION
## Issue
Closes #5563: [don't allow URL change on edit](https://github.com/lbryio/lbry-desktop/issues/5563)

## Note
- `<PublishName>` lost the `disabled` info after the re-arrangement.  
- Note: old logic was:
```
const formDisabled = (fileFormDisabled && !editingURI) || emptyPostError || publishing;
disabled = isStillEditing || formDisabled
```
