### PR TITLE
Undo CDN images on channel banner and profile

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import Gerbil from './gerbil.png';
 import FreezeframeWrapper from 'component/fileThumbnail/FreezeframeWrapper';
 import ChannelStakedIndicator from 'component/channelStakedIndicator';
-import { getThumbnailCdnUrl } from 'util/thumbnail';
 
 type Props = {
   thumbnail: ?string,
@@ -68,14 +67,6 @@ function ChannelThumbnail(props: Props) {
     );
   }
 
-  let url = channelThumbnail;
-  // @if TARGET='web'
-  // Pass image urls through a compression proxy
-  if (thumbnail) {
-    url = getThumbnailCdnUrl({ thumbnail });
-  }
-  // @endif
-
   return (
     <div
       className={classnames('channel-thumbnail', className, {
@@ -88,7 +79,7 @@ function ChannelThumbnail(props: Props) {
         <img
           alt={__('Channel profile picture')}
           className="channel-thumbnail__default"
-          src={!thumbError && url ? url : Gerbil}
+          src={!thumbError && thumbnailPreview ? thumbnailPreview : Gerbil}
           onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
         />
       )}
@@ -100,7 +91,7 @@ function ChannelThumbnail(props: Props) {
             <img
               alt={__('Channel profile picture')}
               className="channel-thumbnail__custom"
-              src={!thumbError && url ? url : Gerbil}
+              src={!thumbError ? thumbnailPreview || thumbnail : Gerbil}
               onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
             />
           )}

--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -2,7 +2,6 @@
 import * as ICONS from 'constants/icons';
 import * as PAGES from 'constants/pages';
 import React from 'react';
-import { getThumbnailCdnUrl } from 'util/thumbnail';
 import { parseURI } from 'lbry-redux';
 import { YOUTUBE_STATUSES } from 'lbryinc';
 import Page from 'component/page';
@@ -163,7 +162,7 @@ function ChannelPage(props: Props) {
         {cover && (
           <img
             className={classnames('channel-cover__custom', { 'channel__image--blurred': channelIsBlocked })}
-            src={IS_WEB ? getThumbnailCdnUrl({ thumbnail: cover, height: 200, width: 1000, quality: 100 }) : cover}
+            src={cover}
           />
         )}
         <div className="channel__primary-info">


### PR DESCRIPTION
Assuming the change for now is simply to revert, this PR helps to do that.
`util/thumbnail :: getThumbnailCdnUrl` is retained for future use.

## Issue
Closes #5564: [Don't use optimized URLs on channel pages (profile/banner)](https://github.com/lbryio/lbry-desktop/issues/5564)