### PR TITLE
Restore video loading circle

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -453,6 +453,11 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         src: source,
         type: type,
       });
+
+      // PR #5570: Temp workaround to avoid double Play button until the next re-architecture.
+      if (!player.paused()) {
+        player.bigPlayButton.hide();
+      }
     });
   }, [source, reload]);
 


### PR DESCRIPTION
## Issue
Closes #5554[: Video: loading circle sometimes does not appear until 2nd click](https://github.com/lbryio/lbry-desktop/issues/5554)

## What's happening
videojs behavior:
(a) A `src` change makes the Play button re-appear.
(b) An `onPlay` (or `play()`) makes the button go away.

Due to the `m3u8` header async fetch (i.e. return is potentially delayed), the initial `onPlay` (which cleared the button) that happened after user clicked Play gets negated by a potentially-delayed `src` change.  

![image](https://user-images.githubusercontent.com/64950861/108820038-92c94280-75f6-11eb-8141-da544074d703.png)

## Approach
I believe in our use case, a change in `src` always means "change src and resume play". A `src` change always comes from a Play action, and we don't pause (don't need to anyway) the player during the change.

So, hiding the button after `src` is changed seems reasonable.

## New behavior
We now see the spinning loading circle when video is loading, as it was originally.

## Aside
Is there a non-async alternative to the header fetching?  Seems to be the root of many problems.  When the fetch is fast, we avoid the double `onPlay`
![image](https://user-images.githubusercontent.com/64950861/108820724-927d7700-75f7-11eb-8f7d-4336e3fe8d7a.png)
