### PR TITLE
Fix broken 'Open File' icon color

### DIFF
--- a/ui/component/fileDownloadLink/view.jsx
+++ b/ui/component/fileDownloadLink/view.jsx
@@ -13,7 +13,7 @@ type Props = {
   fileInfo: ?FileListItem,
   openModal: (id: string, { path: string }) => void,
   pause: () => void,
-  download: string => void,
+  download: (string) => void,
   costInfo: ?{ cost: string },
   buttonType: ?string,
   showLabel: ?boolean,
@@ -91,6 +91,7 @@ function FileDownloadLink(props: Props) {
     return hideOpenButton ? null : (
       <Button
         button={buttonType}
+        className={buttonType ? undefined : 'button--file-action'}
         title={openLabel}
         label={showLabel ? openLabel : null}
         icon={ICONS.EXTERNAL}


### PR DESCRIPTION
## Issue
![image](https://user-images.githubusercontent.com/64950861/108937921-21d36a80-768a-11eb-8c9c-f6b3f1fd679f.png)

The removal of `svg` from `media__subtitle` in 09b689ba made the icon black.

## Fix
Both 'Open File' and 'Download' should have the same css class in the first place.