### PR TITLE
Restore 'duplicate claim URL' msg while waiting for 3704

### DIFF
--- a/ui/component/publishName/index.js
+++ b/ui/component/publishName/index.js
@@ -10,18 +10,19 @@ import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
 import { doSetActiveChannel } from 'redux/actions/app';
 import PublishPage from './view';
 
-const select = state => ({
+const select = (state) => ({
   name: makeSelectPublishFormValue('name')(state),
+  uri: makeSelectPublishFormValue('uri')(state),
   isStillEditing: selectIsStillEditing(state),
   myClaimForUri: selectMyClaimForUri(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   incognito: selectIncognito(state),
 });
 
-const perform = dispatch => ({
-  updatePublishForm: value => dispatch(doUpdatePublishForm(value)),
+const perform = (dispatch) => ({
+  updatePublishForm: (value) => dispatch(doUpdatePublishForm(value)),
   prepareEdit: (claim, uri) => dispatch(doPrepareEdit(claim, uri)),
-  setActiveChannel: claimId => dispatch(doSetActiveChannel(claimId)),
+  setActiveChannel: (claimId) => dispatch(doSetActiveChannel(claimId)),
 });
 
 export default connect(select, perform)(PublishPage);


### PR DESCRIPTION
## Issue
Closes #5575[: Show "URL already used" msg when publishing](https://github.com/lbryio/lbry-desktop/issues/5575)

## Notes
Seems like `uri` just got accidentally removed from db87125d

