### PR TITLE
Restore "view" button when downloaded file is deleted

### DIFF
--- a/ui/component/fileRenderInline/index.js
+++ b/ui/component/fileRenderInline/index.js
@@ -1,14 +1,14 @@
 import { connect } from 'react-redux';
 import { makeSelectFileInfoForUri, makeSelectStreamingUrlForUri } from 'lbry-redux';
 import { doClaimEligiblePurchaseRewards } from 'redux/actions/rewards';
-import { makeSelectFileRenderModeForUri, selectPrimaryUri } from 'redux/selectors/content';
+import { makeSelectFileRenderModeForUri, makeSelectIsPlaying } from 'redux/selectors/content';
 import { withRouter } from 'react-router';
 import { doAnalyticsView } from 'redux/actions/app';
 import FileRenderInline from './view';
 
 const select = (state, props) => ({
   fileInfo: makeSelectFileInfoForUri(props.uri)(state),
-  isPlaying: selectPrimaryUri(state) === props.uri,
+  isPlaying: makeSelectIsPlaying(props.uri)(state),
   streamingUrl: makeSelectStreamingUrlForUri(props.uri)(state),
   renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
 });

--- a/ui/component/fileRenderInline/index.js
+++ b/ui/component/fileRenderInline/index.js
@@ -13,7 +13,7 @@ const select = (state, props) => ({
   renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
 });
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   triggerAnalyticsView: (uri, timeToStart) => dispatch(doAnalyticsView(uri, timeToStart)),
   claimRewards: () => dispatch(doClaimEligiblePurchaseRewards()),
 });

--- a/ui/redux/actions/file.js
+++ b/ui/redux/actions/file.js
@@ -22,7 +22,7 @@ export function doOpenFileInFolder(path) {
 }
 
 export function doOpenFileInShell(path) {
-  return dispatch => {
+  return (dispatch) => {
     const success = shell.openPath(path);
     if (!success) {
       dispatch(doOpenFileInFolder(path));
@@ -31,7 +31,7 @@ export function doOpenFileInShell(path) {
 }
 
 export function doDeleteFile(outpoint, deleteFromComputer, abandonClaim, cb) {
-  return dispatch => {
+  return (dispatch) => {
     if (abandonClaim) {
       const [txid, nout] = outpoint.split(':');
       dispatch(doAbandonClaim(txid, Number(nout), cb));
@@ -67,7 +67,7 @@ export function doDeleteFileAndMaybeGoBack(uri, deleteFromComputer, abandonClaim
     }
 
     actions.push(
-      doDeleteFile(outpoint || claimOutpoint, deleteFromComputer, abandonClaim, abandonState => {
+      doDeleteFile(outpoint || claimOutpoint, deleteFromComputer, abandonClaim, (abandonState) => {
         if (abandonState === ABANDON_STATES.DONE) {
           if (abandonClaim) {
             dispatch(goBack());

--- a/ui/redux/actions/file.js
+++ b/ui/redux/actions/file.js
@@ -77,7 +77,7 @@ export function doDeleteFileAndMaybeGoBack(uri, deleteFromComputer, abandonClaim
       })
     );
 
-    if (playingUri === uri) {
+    if (playingUri && playingUri.uri === uri) {
       actions.push(doSetPlayingUri({ uri: null }));
     }
     // it would be nice to stay on the claim if you just want to delete it

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -25,10 +25,11 @@ const HISTORY_ITEMS_PER_PAGE = 50;
 
 export const selectState = (state: any) => state.content || {};
 
-export const selectPlayingUri = createSelector(selectState, state => state.playingUri);
-export const selectPrimaryUri = createSelector(selectState, state => state.primaryUri);
+export const selectPlayingUri = createSelector(selectState, (state) => state.playingUri);
+export const selectPrimaryUri = createSelector(selectState, (state) => state.primaryUri);
 
-export const makeSelectIsPlaying = (uri: string) => createSelector(selectPrimaryUri, primaryUri => primaryUri === uri);
+export const makeSelectIsPlaying = (uri: string) =>
+  createSelector(selectPrimaryUri, (primaryUri) => primaryUri === uri);
 
 export const makeSelectIsPlayerFloating = (location: UrlLocation) =>
   createSelector(selectPrimaryUri, selectPlayingUri, selectClaimsByUri, (primaryUri, playingUri, claimsByUri) => {
@@ -55,9 +56,9 @@ export const makeSelectContentPositionForUri = (uri: string) =>
     return state.positions[id] ? state.positions[id][outpoint] : null;
   });
 
-export const selectHistory = createSelector(selectState, state => state.history || []);
+export const selectHistory = createSelector(selectState, (state) => state.history || []);
 
-export const selectHistoryPageCount = createSelector(selectHistory, history =>
+export const selectHistoryPageCount = createSelector(selectHistory, (history) =>
   Math.ceil(history.length / HISTORY_ITEMS_PER_PAGE)
 );
 
@@ -69,10 +70,10 @@ export const makeSelectHistoryForPage = (page: number) =>
   });
 
 export const makeSelectHistoryForUri = (uri: string) =>
-  createSelector(selectHistory, history => history.find(i => i.uri === uri));
+  createSelector(selectHistory, (history) => history.find((i) => i.uri === uri));
 
 export const makeSelectHasVisitedUri = (uri: string) =>
-  createSelector(makeSelectHistoryForUri(uri), history => Boolean(history));
+  createSelector(makeSelectHistoryForUri(uri), (history) => Boolean(history));
 
 export const makeSelectNextUnplayedRecommended = (uri: string) =>
   createSelector(
@@ -118,11 +119,11 @@ export const makeSelectNextUnplayedRecommended = (uri: string) =>
           }
 
           const channel = claim && claim.signing_channel;
-          if (channel && blockedChannels.some(blockedUri => blockedUri === channel.permanent_url)) {
+          if (channel && blockedChannels.some((blockedUri) => blockedUri === channel.permanent_url)) {
             continue;
           }
 
-          if (!history.some(item => item.uri === recommendedForUri[i])) {
+          if (!history.some((item) => item.uri === recommendedForUri[i])) {
             return recommendedForUri[i];
           }
         }
@@ -130,12 +131,12 @@ export const makeSelectNextUnplayedRecommended = (uri: string) =>
     }
   );
 
-export const selectRecentHistory = createSelector(selectHistory, history => {
+export const selectRecentHistory = createSelector(selectHistory, (history) => {
   return history.slice(0, RECENT_HISTORY_AMOUNT);
 });
 
 export const makeSelectCategoryListUris = (uris: ?Array<string>, channel: string) =>
-  createSelector(makeSelectClaimsInChannelForCurrentPageState(channel), channelClaims => {
+  createSelector(makeSelectClaimsInChannelForCurrentPageState(channel), (channelClaims) => {
     if (uris) return uris;
 
     if (channelClaims) {
@@ -153,7 +154,7 @@ export const makeSelectShouldObscurePreview = (uri: string) =>
 
 // should probably be in lbry-redux, yarn link was fighting me
 export const makeSelectFileExtensionForUri = (uri: string) =>
-  createSelector(makeSelectFileNameForUri(uri), fileName => {
+  createSelector(makeSelectFileNameForUri(uri), (fileName) => {
     return fileName && path.extname(fileName).substring(1);
   });
 

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -29,7 +29,7 @@ export const selectPlayingUri = createSelector(selectState, (state) => state.pla
 export const selectPrimaryUri = createSelector(selectState, (state) => state.primaryUri);
 
 export const makeSelectIsPlaying = (uri: string) =>
-  createSelector(selectPrimaryUri, (primaryUri) => primaryUri === uri);
+  createSelector(selectPlayingUri, (playingUri) => playingUri && playingUri.uri === uri);
 
 export const makeSelectIsPlayerFloating = (location: UrlLocation) =>
   createSelector(selectPrimaryUri, selectPlayingUri, selectClaimsByUri, (primaryUri, playingUri, claimsByUri) => {


### PR DESCRIPTION
## Issue
Closes #4959: `Deleting MD from downloads list causes spinning icon to run forever`
Closes #5077: `player doesn't close when video deleted`

## New behavior
The "view" eye button now appears in this scenario, just like it was back in Oct 2020.

## Changes
The following is my understanding (please correct me if I'm wrong; been wondering about it for a while):
- `primaryUri` - the URI of the file page
- `playingUri` - the URI for the media that's currently playing. It's usually the same as `primaryUri`, but could be something else for the case of Floating Player.

The components were looking at `primary`, plus comparisons with `playing` weren't done correctly (it's an object, not string).