### PR TITLE
Fix broken markdown editor border color

### DIFF
--- a/ui/scss/component/_markdown-editor.scss
+++ b/ui/scss/component/_markdown-editor.scss
@@ -55,6 +55,10 @@
 .form-field--SimpleMDE {
   margin-top: var(--spacing-l);
 
+  .cm-s-easymde {
+    border-color: var(--color-input-border);
+  }
+
   .cm-s-easymde .CodeMirror-cursor {
     border-left: 1px solid var(--color-editor-cursor);
   }


### PR DESCRIPTION
## Issue
The border became white recently, which made it look "focused" all the time. 
Confirmed with Sean that the change wasn't intentional.

![image](https://user-images.githubusercontent.com/64950861/109274878-f5b51680-784e-11eb-94bb-2c804249455e.png)
