### PR TITLE
Add tooltip to embed's Title and Home button

### DIFF
--- a/ui/component/fileViewerEmbeddedTitle/view.jsx
+++ b/ui/component/fileViewerEmbeddedTitle/view.jsx
@@ -28,9 +28,15 @@ function FileViewerEmbeddedTitle(props: Props) {
   return (
     <div className="file-viewer__embedded-header">
       <div className="file-viewer__embedded-gradient" />
-      <Button label={title} button="link" className="file-viewer__embedded-title" {...contentLinkProps} />
+      <Button
+        label={title}
+        aria-label={title}
+        button="link"
+        className="file-viewer__embedded-title"
+        {...contentLinkProps}
+      />
       <div className="file-viewer__embedded-info">
-        <Button className="file-viewer__overlay-logo" icon={ICONS.LBRY} {...lbryLinkProps} />
+        <Button className="file-viewer__overlay-logo" icon={ICONS.LBRY} aria-label={__('Home')} {...lbryLinkProps} />
         {isInApp && <FilePrice uri={uri} />}
       </div>
     </div>


### PR DESCRIPTION
## Issue
- Most titles don't fit the embed container width. I wish to know what the title is without having to click on it first.
- Also, add clarity that the LBRY icon brings you Home.
![image](https://user-images.githubusercontent.com/64950861/109488582-b857bf80-7ac0-11eb-97bf-8ef6b0c1d94f.png)

## Changes
Just the usual tool-tip addition to a button/link.