### PR TITLE
Linux: Don't add extra call to associate 'lbry://'

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -46,7 +46,10 @@ let lbryFirst;
 
 const appState = {};
 
-app.setAsDefaultProtocolClient('lbry');
+if (process.platform !== 'linux') {
+  app.setAsDefaultProtocolClient('lbry');
+}
+
 app.name = 'LBRY';
 app.setAppUserModelId('io.lbry.LBRY');
 app.commandLine.appendSwitch('force-color-profile', 'srgb');


### PR DESCRIPTION
## Issue
Potentially closes #4729[: LBRY desktop auto-sets itself as default application for opening html files in Linux file managers like nemo after logout and login or a cold/warm boot](https://github.com/lbryio/lbry-desktop/issues/4729)

- https://gitlab.freedesktop.org/xdg/xdg-utils/-/issues/180:
    - It appears that there is a piece of code in xdg that defaults the type to 'text/html' if the parameter is empty. I'm not sure if that's entirely xdg's fault, or it's the way Electron's `setAsDefaultProtocolClient` uses it.
    - `setAsDefaultProtocolClient` is called on app startup, causing the incorrect 'text/html' association every LBRY starts.

## Changes
In Linux Mint at least, it seems like the `protocols` entry in `electron-builder.json` is enough to associate the LBRY protocol to this app. The extra `setAsDefaultProtocolClient` seems unnecessary.

My test method:
With `setAsDefaultProtocolClient` removed for Linux,
- `<a href="lbry://xxx">` still opens the app.
- `<a href="lbry://xxx">` does not open the app if the `protocols` entry is removed from `electron-build.json` (confirming that it's doing it's job).