### PR TITLE
Don't clear all notifications when only 1 is clicked. 

### DIFF
--- a/ui/redux/actions/notifications.js
+++ b/ui/redux/actions/notifications.js
@@ -45,7 +45,7 @@ export function doNotificationList() {
   return (dispatch: Dispatch) => {
     dispatch({ type: ACTIONS.NOTIFICATION_LIST_STARTED });
     return Lbryio.call('notification', 'list', { is_app_readable: true })
-      .then(response => {
+      .then((response) => {
         const notifications = response || [];
         const channelsToResolve = notifications
           .filter((notification: WebNotification) => {
@@ -59,7 +59,7 @@ export function doNotificationList() {
               return false;
             }
           })
-          .map(notification => {
+          .map((notification) => {
             if (notification.notification_rule === NOTIFICATIONS.NEW_CONTENT) {
               return notification.notification_parameters.device.target;
             } else {
@@ -70,7 +70,7 @@ export function doNotificationList() {
         dispatch(doResolveUris(channelsToResolve));
         dispatch({ type: ACTIONS.NOTIFICATION_LIST_COMPLETED, data: { notifications } });
       })
-      .catch(error => {
+      .catch((error) => {
         dispatch({ type: ACTIONS.NOTIFICATION_LIST_FAILED, data: { error } });
       });
   };
@@ -83,8 +83,8 @@ export function doReadNotifications() {
     const unreadNotifications =
       notifications &&
       notifications
-        .filter(notification => !notification.is_read)
-        .map(notification => notification.id)
+        .filter((notification) => !notification.is_read)
+        .map((notification) => notification.id)
         .join(',');
 
     dispatch({ type: ACTIONS.NOTIFICATION_READ_STARTED });
@@ -92,7 +92,7 @@ export function doReadNotifications() {
       .then(() => {
         dispatch({ type: ACTIONS.NOTIFICATION_READ_COMPLETED });
       })
-      .catch(error => {
+      .catch((error) => {
         dispatch({ type: ACTIONS.NOTIFICATION_READ_FAILED, data: { error } });
       });
   };
@@ -110,7 +110,7 @@ export function doSeeNotifications(notificationIds: Array<string>) {
           },
         });
       })
-      .catch(error => {
+      .catch((error) => {
         dispatch({ type: ACTIONS.NOTIFICATION_SEEN_FAILED, data: { error } });
       });
   };
@@ -121,7 +121,8 @@ export function doSeeAllNotifications() {
     const state = getState();
     const notifications = selectNotifications(state);
     const unSeenNotifications =
-      notifications && notifications.filter(notification => !notification.is_seen).map(notification => notification.id);
+      notifications &&
+      notifications.filter((notification) => !notification.is_seen).map((notification) => notification.id);
 
     dispatch(doSeeNotifications(unSeenNotifications));
   };

--- a/ui/redux/reducers/notifications.js
+++ b/ui/redux/reducers/notifications.js
@@ -55,7 +55,8 @@ export default handleActions(
     },
     [ACTIONS.NOTIFICATION_READ_COMPLETED]: (state, action) => {
       const { notifications } = state;
-      const newNotifications = notifications && notifications.map(notification => ({ ...notification, is_read: true }));
+      const newNotifications =
+        notifications && notifications.map((notification) => ({ ...notification, is_read: true }));
       return {
         ...state,
         notifications: newNotifications,
@@ -69,7 +70,7 @@ export default handleActions(
     [ACTIONS.NOTIFICATION_SEEN_COMPLETED]: (state, action) => {
       const { notifications } = state;
       const { notificationIds } = action.data;
-      const newNotifications = notifications.map(notification => {
+      const newNotifications = notifications.map((notification) => {
         if (notificationIds.includes(notification.id)) {
           return { ...notification, is_seen: true };
         }
@@ -85,7 +86,7 @@ export default handleActions(
     [ACTIONS.NOTIFICATION_DELETE_COMPLETED]: (state, action) => {
       const { notifications } = state;
       const { notificationId } = action.data;
-      const newNotifications = notifications.filter(notification => {
+      const newNotifications = notifications.filter((notification) => {
         return notification.id !== notificationId;
       });
 

--- a/ui/redux/reducers/notifications.js
+++ b/ui/redux/reducers/notifications.js
@@ -55,8 +55,16 @@ export default handleActions(
     },
     [ACTIONS.NOTIFICATION_READ_COMPLETED]: (state, action) => {
       const { notifications } = state;
+      const { notificationIds } = action.data;
       const newNotifications =
-        notifications && notifications.map((notification) => ({ ...notification, is_read: true }));
+        notifications &&
+        notifications.map((notification) => {
+          if (notificationIds.includes(notification.id)) {
+            return { ...notification, is_read: true };
+          } else {
+            return { ...notification };
+          }
+        });
       return {
         ...state,
         notifications: newNotifications,


### PR DESCRIPTION
## Issue:
Closes #5515[: All videos marked as read when clicking a single notification from notification list](https://github.com/lbryio/lbry-desktop/issues/5515)

## Change:
- Augment `doReadNotifications` to only clear the given IDs. If the argument is `null` or is not a valid array (e.g. when used as a click handlers, the click event object is passed in), all notifications will be cleared.

- Augment `NOTIFICATION_READ_COMPLETED` to only clear the given IDs.

## Notes:
- Wasn't sure of the API will fail if the ID is invalid (not in the list), so I start from `unreadNotifications` first, then only filtering it further with the given ID. Otherwise, we could just skip the `unreadNotifications` filtering.