### PR TITLE
Batch-resolves channel page query

### DIFF
--- a/ui/component/channelContent/index.js
+++ b/ui/component/channelContent/index.js
@@ -34,7 +34,7 @@ const select = (state, props) => {
 };
 
 const perform = (dispatch) => ({
-  doResolveUris: (uris) => dispatch(doResolveUris(uris)),
+  doResolveUris: (uris, returnCachedUris) => dispatch(doResolveUris(uris, returnCachedUris)),
 });
 
 export default withRouter(connect(select, perform)(ChannelPage));

--- a/ui/component/channelContent/index.js
+++ b/ui/component/channelContent/index.js
@@ -6,6 +6,7 @@ import {
   makeSelectClaimIsMine,
   makeSelectTotalPagesInChannelSearch,
   makeSelectClaimForUri,
+  doResolveUris,
   SETTINGS,
 } from 'lbry-redux';
 import { makeSelectChannelIsMuted } from 'redux/selectors/blocked';
@@ -32,4 +33,8 @@ const select = (state, props) => {
   };
 };
 
-export default withRouter(connect(select)(ChannelPage));
+const perform = (dispatch) => ({
+  doResolveUris: (uris) => dispatch(doResolveUris(uris)),
+});
+
+export default withRouter(connect(select, perform)(ChannelPage));

--- a/ui/component/channelContent/view.jsx
+++ b/ui/component/channelContent/view.jsx
@@ -30,6 +30,7 @@ type Props = {
   showMature: boolean,
   tileLayout: boolean,
   viewHiddenChannels: boolean,
+  doResolveUris: (Array<string>, boolean) => void,
 };
 
 function ChannelContent(props: Props) {
@@ -46,6 +47,7 @@ function ChannelContent(props: Props) {
     showMature,
     tileLayout,
     viewHiddenChannels,
+    doResolveUris,
   } = props;
   const claimsInChannel = (claim && claim.meta.claims_in_channel) || 0;
   const [searchQuery, setSearchQuery] = React.useState('');
@@ -77,6 +79,11 @@ function ChannelContent(props: Props) {
             const urls = results.map(({ name, claimId }) => {
               return `lbry://${name}#${claimId}`;
             });
+
+            // Batch-resolve the urls before calling 'setSearchResults', as the
+            // latter will immediately cause the tiles to resolve, ending up
+            // calling doResolveUri one by one before the batched one.
+            doResolveUris(urls, true);
 
             setSearchResults(urls);
           })

--- a/ui/scss/component/_placeholder.scss
+++ b/ui/scss/component/_placeholder.scss
@@ -25,6 +25,7 @@
     width: 100%;
     height: 2.5rem;
     margin-left: 0;
+    margin-top: var(--spacing-s);
   }
 
   &.claim-tile__info {


### PR DESCRIPTION
## Issue
Closes #5597[ batch resolves on channel search page](https://github.com/lbryio/lbry-desktop/issues/5597)

## Changes
Do a batch-resolve immediate after getting the results and before setting the result variable, as the latter would result in the Claim* components resolving individually.

## Notes
I enabled `returnCachedClaims` -- I assumed that's a reasonable thing to do. I don't see other places use it, though, so highlighting it here.
