### PR TITLE
hide quality selector by default

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
@@ -37,6 +37,9 @@ class HlsQualitySelectorPlugin {
     // Create the quality button.
     this.createQualityButton();
 
+    // Hide quality selector by default
+    this._qualityButton.hide();
+
     // Bind event listeners
     this.bindPlayerEvents();
 


### PR DESCRIPTION
Just hides the hls-quality-selector button from the UI until metadata is loaded that indicates multiple quality levels are available.

This will hide the "auto" button that currently appears while waiting for the video's pre-fetch to complete indicating whether the file in an mp4 or m3u8 file.