### PR TITLE
Add Node 14 Support and Testing to CICD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     name: 'build'
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 14.x]
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     name: 'build'
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
We shouldn't have any issues upgrading to Node 14, and as such, we should begin the upgrade process now as 14 is still in Active LTS, and 10 will be reaching EOL soon.

Better to begin the upgrade process early by adding Node 14 CICD testing to our pipeline.

![image](https://user-images.githubusercontent.com/45262335/110382003-26473e00-800f-11eb-9eae-2b6edf36f4e9.png)
