### PR TITLE
hls options is deprecated. Use vhs instead.

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
@@ -66,7 +66,7 @@ class HlsQualitySelectorPlugin {
    * @return {*} - videojs-hls-contrib plugin.
    */
   getHls() {
-    return this.player.tech({ IWillNotUseThisInPlugins: true }).hls;
+    return this.player.tech({ IWillNotUseThisInPlugins: true }).vhs;
   }
 
   /**

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
@@ -50,8 +50,8 @@ class HlsQualitySelectorPlugin {
   }
 
   updatePlugin() {
-    // If there is the HLS tech
-    if (this.getHls()) {
+    // If there is the VHS tech
+    if (this.getVhs()) {
       // Show quality selector
       this._qualityButton.show();
     } else {
@@ -61,11 +61,21 @@ class HlsQualitySelectorPlugin {
   }
 
   /**
-   * Returns HLS Plugin
+   * Deprecated, returns VHS plugin
    *
-   * @return {*} - videojs-hls-contrib plugin.
+   * @return {*} - videojs-http-streaming plugin.
    */
   getHls() {
+    console.warn('hls-quality-selector: WARN: Using getHls options is deprecated. Use getVhs instead.')
+    return this.getVhs();
+  }
+
+  /**
+   * Returns VHS Plugin
+   *
+   * @return {*} - videojs-http-streaming plugin.
+   */
+  getVhs() {
     return this.player.tech({ IWillNotUseThisInPlugins: true }).vhs;
   }
 


### PR DESCRIPTION
Fixes this warning in the web console:
`VIDEOJS: WARN: Using hls options is deprecated. Use vhs instead.`

**V**ideo.js-**H**ttp-**S**treaming has replaced `hls` tech, and deprecated `.tech().hls` in favor of the more generic and broad `.tech().vhs`

This just modifies our custom hls-quality-selector plugin to use the new tech name so that we don't throw needless warnings out from video.js

Additionally renames internal `getHls()` to `getVhs` to match internal function, and provide deprecation warning in case someone for some reason is attempting to access our internal state externally.

Adds backwards compatibility with `getHls()` by proxying function to `getVhs` with the addition of a deprecation warning.