### PR TITLE
vjs i18n: Fix "undefined" error due to hidden ctrls

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -253,44 +253,48 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     // as the listener to update static texts.
     const player = playerRef.current;
     if (player) {
-      const controlBar = player.getChild('controlBar');
-      switch (e.type) {
-        case 'play':
-          controlBar.getChild('PlayToggle').controlText(__('Pause (space)'));
-          break;
-        case 'pause':
-          controlBar.getChild('PlayToggle').controlText(__('Play (space)'));
-          break;
-        case 'volumechange':
-          controlBar
-            .getChild('VolumePanel')
-            .getChild('MuteToggle')
-            .controlText(player.muted() || player.volume() === 0 ? __('Unmute (m)') : __('Mute (m)'));
-          break;
-        case 'fullscreenchange':
-          controlBar
-            .getChild('FullscreenToggle')
-            .controlText(player.isFullscreen() ? __('Exit Fullscreen (f)') : __('Fullscreen (f)'));
-          break;
-        case 'loadstart':
-          // --- Do everything ---
-          controlBar.getChild('PlaybackRateMenuButton').controlText(__('Playback Rate (<, >)'));
-          controlBar.getChild('QualityButton').controlText(__('Quality'));
-          resolveCtrlText({ type: 'play' });
-          resolveCtrlText({ type: 'pause' });
-          resolveCtrlText({ type: 'volumechange' });
-          resolveCtrlText({ type: 'fullscreenchange' });
-          // (1) The 'Theater mode' button should probably be changed to a class
-          // so that we can use getChild() with a specific name. There might be
-          // clashes if we add a new button in the future.
-          // (2) We'll have to get 'makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)'
-          // as a prop here so we can say "Theater mode|Default mode" instead of
-          // "Toggle Theather mode".
-          controlBar.getChild('Button').controlText(__('Toggle Theater mode (t)'));
-          break;
-        default:
-          if (isDev) throw Error('Unexpected: ' + e.type);
-          break;
+      try {
+        const controlBar = player.getChild('controlBar');
+        switch (e.type) {
+          case 'play':
+            controlBar.getChild('PlayToggle').controlText(__('Pause (space)'));
+            break;
+          case 'pause':
+            controlBar.getChild('PlayToggle').controlText(__('Play (space)'));
+            break;
+          case 'volumechange':
+            controlBar
+              .getChild('VolumePanel')
+              .getChild('MuteToggle')
+              .controlText(player.muted() || player.volume() === 0 ? __('Unmute (m)') : __('Mute (m)'));
+            break;
+          case 'fullscreenchange':
+            controlBar
+              .getChild('FullscreenToggle')
+              .controlText(player.isFullscreen() ? __('Exit Fullscreen (f)') : __('Fullscreen (f)'));
+            break;
+          case 'loadstart':
+            // --- Do everything ---
+            controlBar.getChild('PlaybackRateMenuButton').controlText(__('Playback Rate (<, >)'));
+            controlBar.getChild('QualityButton').controlText(__('Quality'));
+            resolveCtrlText({ type: 'play' });
+            resolveCtrlText({ type: 'pause' });
+            resolveCtrlText({ type: 'volumechange' });
+            resolveCtrlText({ type: 'fullscreenchange' });
+            // (1) The 'Theater mode' button should probably be changed to a class
+            // so that we can use getChild() with a specific name. There might be
+            // clashes if we add a new button in the future.
+            // (2) We'll have to get 'makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)'
+            // as a prop here so we can say "Theater mode|Default mode" instead of
+            // "Toggle Theather mode".
+            controlBar.getChild('Button').controlText(__('Toggle Theater mode (t)'));
+            break;
+          default:
+            if (isDev) throw Error('Unexpected: ' + e.type);
+            break;
+        }
+      } catch (err) {
+        // Fail silently -- it'll just be due to hidden controls.
       }
     }
   }


### PR DESCRIPTION
## Issue
The change in making the "Quality" component hidden by default exposed a minor error in `resolveCtrlText` for not handling hidden components.

Luckily, videojs cathes the error and became a no-op, so it didn't crash the app.

## Change
Add a try-catch block to handle any temp-removal of components in the future.

## Note
This is a touch up for PR #5584