### PR TITLE
Fix unencoded StatusBar on Desktop

### DIFF
--- a/ui/component/common/status-bar.jsx
+++ b/ui/component/common/status-bar.jsx
@@ -41,7 +41,7 @@ class StatusBar extends React.PureComponent<Props, State> {
 
   render() {
     const { hoverUrl, show } = this.state;
-    return <div className={classnames('status-bar', { visible: show })}>{hoverUrl}</div>;
+    return <div className={classnames('status-bar', { visible: show })}>{decodeURI(hoverUrl)}</div>;
   }
 }
 


### PR DESCRIPTION
Fixes
![image](https://user-images.githubusercontent.com/64950861/110496781-cd6fc680-8130-11eb-9b0f-b647143cc868.png)
to
![image](https://user-images.githubusercontent.com/64950861/110496835-da8cb580-8130-11eb-9830-edda57e94263.png)
just like in the web browsers