### PR TITLE
Markdown: don't convert '[label](uri)' to embeds.

### DIFF
--- a/ui/component/markdownLink/view.jsx
+++ b/ui/component/markdownLink/view.jsx
@@ -67,7 +67,10 @@ function MarkdownLink(props: Props) {
       const possibleLbryUrl = linkPathPlusHash ? `lbry://${linkPathPlusHash.replace(/:/g, '#')}` : undefined;
 
       const lbryLinkIsValid = possibleLbryUrl && isURIValid(possibleLbryUrl);
-      if (lbryLinkIsValid) {
+      const isMarkdownLinkWithLabel =
+        children && Array.isArray(children) && React.Children.count(children) === 1 && children.toString() !== href;
+
+      if (lbryLinkIsValid && !isMarkdownLinkWithLabel) {
         lbryUrlFromLink = possibleLbryUrl;
       }
     }


### PR DESCRIPTION
## Issue
Closes #4936[: Don't process markdown formatting as lbry:// url previews](https://github.com/lbryio/lbry-desktop/issues/4936)

## Approach
Fix by assuming the link is the non-labelled format if the `text` is the same as `href`.

This opens up one corner-case that we can't handle, which is when the user explicitly set the label using the href, e.g. `[https://lbry.tv/befreeonlbry](https://lbry.tv/befreeonlbry)`. This will still resolve to an embed. There's not enough data at the parsed (remark) level to know if the label was autofilled by the parser or given by user -- we would need to parse the content ourself before `remark`, which I think is not worth it.

## Aside/Reminder
If you see that the link doesn't resolve to an embed regardless of the format used, that's probably just due to `5636: Disable video previews in comments/posts made by channels below a certain channel staked level`