### PR TITLE
Fix invalid DOM

### DIFF
--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -182,7 +182,7 @@ function ClaimPreviewTile(props: Props) {
           <TruncatedText text={title || (claim && claim.name)} lines={isChannel ? 1 : 2} />
           {isChannel && (
             <div className="claim-tile__about">
-              <UriIndicator uri={uri} link />
+              <UriIndicator uri={uri} />
             </div>
           )}
           <ClaimMenuList uri={uri} />


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/45262335/111037117-92db8780-83d7-11eb-8ea4-8c2f716acaf3.png)

Because using a `URI` with the `link` attribute nested in a `NavLink` generates an `a` tag within an `a` tag.

Both point to the same location anyways - and normally we don't even show channels on the odysee homepage (so this isn't an issue normally) but on dev it can cause errors and cause the client to show an error screen.

Fix: we remove the link aspect since it's not needed and problematic