### PR TITLE
Show extra "Sign In" button on Desktop

### DIFF
--- a/ui/component/header/view.jsx
+++ b/ui/component/header/view.jsx
@@ -162,8 +162,14 @@ const Header = (props: Props) => {
 
   const loginButtons = (
     <div className="header__auth-buttons">
-      <Button navigate={`/$/${PAGES.AUTH_SIGNIN}`} button="link" label={__('Log In')} className="mobile-hidden" />
-      <Button navigate={`/$/${PAGES.AUTH}`} button="primary" label={__('Sign Up')} />
+      {IS_WEB ? (
+        <>
+          <Button navigate={`/$/${PAGES.AUTH_SIGNIN}`} button="link" label={__('Log In')} className="mobile-hidden" />
+          <Button navigate={`/$/${PAGES.AUTH}`} button="primary" label={__('Sign Up')} />
+        </>
+      ) : (
+        <Button navigate={`/$/${PAGES.AUTH_SIGNIN}`} button="link" label={__('Sign In')} className="mobile-hidden" />
+      )}
     </div>
   );
 
@@ -286,7 +292,7 @@ const Header = (props: Props) => {
                   <BalanceButton className="header__navigation-item menu__title mobile-hidden" />
                 )}
 
-                {IS_WEB && !authenticated && loginButtons}
+                {!authenticated && loginButtons}
 
                 {(authenticated || !IS_WEB) && (
                   <Menu>
@@ -294,8 +300,8 @@ const Header = (props: Props) => {
                       aria-label={__('Your account')}
                       title={__('Your account')}
                       className={classnames('header__navigation-item', {
-                        'menu__title header__navigation-item--icon': !activeChannelUrl,
-                        'header__navigation-item--profile-pic': activeChannelUrl,
+                        'menu__title header__navigation-item--profile-pic': !activeChannelUrl,
+                        'header__navigation-item--profile-pic--active': activeChannelUrl,
                       })}
                       // @if TARGET='app'
                       onDoubleClick={(e) => {

--- a/ui/scss/component/_header.scss
+++ b/ui/scss/component/_header.scss
@@ -101,6 +101,11 @@
 }
 
 .header__navigation-item--profile-pic {
+  @extend .header__navigation-item--icon;
+  margin-left: var(--spacing-m);
+}
+
+.header__navigation-item--profile-pic--active {
   margin-left: var(--spacing-m);
 
   .channel-thumbnail {


### PR DESCRIPTION
## Issue
- Closes #3989[: [desktop] Better indication of being signed in / out on account header](https://github.com/lbryio/lbry-desktop/issues/3989)
- Also, I often got confused in development on whether I'm using `local` or `shared`.  Having something to indicate the logged-off status would be helpful.

## Notes
- Retained the ["Sign In" for Desktop, "Log In" for Web] labeling.

![image](https://user-images.githubusercontent.com/64950861/111066504-69ffe300-84fa-11eb-9891-33e1a187e755.png)
![image](https://user-images.githubusercontent.com/64950861/111066581-ae8b7e80-84fa-11eb-9d81-648981f54eb0.png)

