### PR TITLE
Repost: fix "author" label + "can't use Annoymous"

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#bf728f8716385749370de9a1edee50b267d61fa4",
+    "lbry-redux": "lbryio/lbry-redux#9eb308c58ee0dd020c23e59633c647879321cfcd",
     "lbryinc": "lbryio/lbryinc#7faea40d87b78ec91b901c62f501499dc4737025",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#9eb308c58ee0dd020c23e59633c647879321cfcd",
+    "lbry-redux": "lbryio/lbry-redux#f449d7916cacb9e61f19afc84cecac6182cde6d6",
     "lbryinc": "lbryio/lbryinc#7faea40d87b78ec91b901c62f501499dc4737025",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/ui/component/repostCreate/index.js
+++ b/ui/component/repostCreate/index.js
@@ -17,7 +17,7 @@ import {
   selectFetchingMyChannels,
 } from 'lbry-redux';
 import { doToast } from 'redux/actions/notifications';
-import { selectActiveChannelClaim } from 'redux/selectors/app';
+import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
 import RepostCreate from './view';
 
 const select = (state, props) => ({
@@ -37,6 +37,7 @@ const select = (state, props) => ({
   isResolvingEnteredRepost: props.repostUri && makeSelectIsUriResolving(`lbry://${props.repostUri}`)(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   fetchingMyChannels: selectFetchingMyChannels(state),
+  incognito: selectIncognito(state),
 });
 
 export default connect(select, {

--- a/ui/component/repostCreate/view.jsx
+++ b/ui/component/repostCreate/view.jsx
@@ -42,6 +42,7 @@ type Props = {
   isResolvingEnteredRepost: boolean,
   activeChannelClaim: ?ChannelClaim,
   fetchingMyChannels: boolean,
+  incognito: boolean,
 };
 
 function RepostCreate(props: Props) {
@@ -67,6 +68,7 @@ function RepostCreate(props: Props) {
     isResolvingEnteredRepost,
     activeChannelClaim,
     fetchingMyChannels,
+    incognito,
   } = props;
 
   const defaultName = name || (claim && claim.name) || '';
@@ -281,7 +283,7 @@ function RepostCreate(props: Props) {
       doRepost({
         name: enteredRepostName,
         bid: creditsToString(repostBid),
-        channel_id: activeChannelClaim ? activeChannelClaim.claim_id : undefined,
+        channel_id: activeChannelClaim && !incognito ? activeChannelClaim.claim_id : undefined,
         claim_id: repostClaimId,
       }).then((repostClaim: StreamClaim) => {
         doCheckPendingClaims();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6898,9 +6898,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#9eb308c58ee0dd020c23e59633c647879321cfcd:
+lbry-redux@lbryio/lbry-redux#f449d7916cacb9e61f19afc84cecac6182cde6d6:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/9eb308c58ee0dd020c23e59633c647879321cfcd"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/f449d7916cacb9e61f19afc84cecac6182cde6d6"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6898,9 +6898,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#bf728f8716385749370de9a1edee50b267d61fa4:
+lbry-redux@lbryio/lbry-redux#9eb308c58ee0dd020c23e59633c647879321cfcd:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/bf728f8716385749370de9a1edee50b267d61fa4"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/9eb308c58ee0dd020c23e59633c647879321cfcd"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
## Issue
- Closes #5673[: Reposts are all listed under "Annoymous"](https://github.com/lbryio/lbry-desktop/issues/5673)
    - Requires `lbry-redux::PR_391`
- Fixes #5661[: can't choose anonymous from channel on repost page](https://github.com/lbryio/lbry-desktop/issues/5661)