### PR TITLE
disconnect from comment websocket when leaving livestream page

### DIFF
--- a/ui/component/livestreamComments/index.js
+++ b/ui/component/livestreamComments/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { makeSelectClaimForUri } from 'lbry-redux';
-import { doCommentSocketConnect } from 'redux/actions/websocket';
+import { doCommentSocketConnect, doCommentSocketDisconnect } from 'redux/actions/websocket';
 import { doCommentList } from 'redux/actions/comments';
 import { makeSelectTopLevelCommentsForUri, selectIsFetchingComments } from 'redux/selectors/comments';
 import LivestreamFeed from './view';
@@ -11,4 +11,4 @@ const select = (state, props) => ({
   fetchingComments: selectIsFetchingComments(state),
 });
 
-export default connect(select, { doCommentSocketConnect, doCommentList })(LivestreamFeed);
+export default connect(select, { doCommentSocketConnect, doCommentSocketDisconnect, doCommentList })(LivestreamFeed);

--- a/ui/component/livestreamComments/view.jsx
+++ b/ui/component/livestreamComments/view.jsx
@@ -13,13 +13,23 @@ type Props = {
   activeViewers: number,
   embed?: boolean,
   doCommentSocketConnect: (string, string) => void,
+  doCommentSocketDisconnect: (string) => void,
   doCommentList: (string) => void,
   comments: Array<Comment>,
   fetchingComments: boolean,
 };
 
 export default function LivestreamFeed(props: Props) {
-  const { claim, uri, embed, doCommentSocketConnect, comments, doCommentList, fetchingComments } = props;
+  const {
+    claim,
+    uri,
+    embed,
+    doCommentSocketConnect,
+    doCommentSocketDisconnect,
+    comments,
+    doCommentList,
+    fetchingComments,
+  } = props;
   const commentsRef = React.createRef();
   const hasScrolledComments = React.useRef();
   const [performedInitialScroll, setPerformedInitialScroll] = React.useState(false);
@@ -31,7 +41,13 @@ export default function LivestreamFeed(props: Props) {
       doCommentList(uri);
       doCommentSocketConnect(uri, claimId);
     }
-  }, [claimId, uri]);
+
+    return () => {
+      if (claimId) {
+        doCommentSocketDisconnect(claimId);
+      }
+    };
+  }, [claimId, uri, doCommentList, doCommentSocketConnect, doCommentSocketDisconnect]);
 
   React.useEffect(() => {
     const element = commentsRef.current;

--- a/ui/component/livestreamLayout/view.jsx
+++ b/ui/component/livestreamLayout/view.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { BITWAVE_EMBED_URL } from 'constants/livestream';
+// import { BITWAVE_EMBED_URL } from 'constants/livestream';
 import React from 'react';
 import FileTitleSection from 'component/fileTitleSection';
 import LivestreamComments from 'component/livestreamComments';
@@ -22,7 +22,7 @@ export default function LivestreamLayout(props: Props) {
       <div className="section card-stack">
         <div className="file-render file-render--video livestream">
           <div className="file-viewer">
-            <iframe src={`${BITWAVE_EMBED_URL}/${'doomtube'}?skin=odysee&autoplay=1`} scrolling="no" allowFullScreen />
+            {/* <iframe src={`${BITWAVE_EMBED_URL}/${'doomtube'}?skin=odysee&autoplay=1`} scrolling="no" allowFullScreen /> */}
           </div>
         </div>
 


### PR DESCRIPTION
To prevent people from connecting multiple times if they navigate away, then come back.

The websocket handler will now reconnect on `onerror` events, and do nothing for `onclose` events. This allows manually disconnecting from a specific websocket connection.