### PR TITLE
Improve sidenav subscriptions appearance

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -13,6 +13,7 @@ type Props = {
   thumbnailPreview: ?string,
   obscure?: boolean,
   small?: boolean,
+  verysmall?: boolean,
   allowGifs?: boolean,
   claim: ?ChannelClaim,
   doResolveUri: (string) => void,
@@ -29,6 +30,7 @@ function ChannelThumbnail(props: Props) {
     thumbnailPreview: rawThumbnailPreview,
     obscure,
     small = false,
+    verysmall,
     allowGifs = false,
     claim,
     doResolveUri,
@@ -61,7 +63,12 @@ function ChannelThumbnail(props: Props) {
 
   if (channelThumbnail && channelThumbnail.endsWith('gif') && !allowGifs) {
     return (
-      <FreezeframeWrapper src={channelThumbnail} className={classnames('channel-thumbnail', className)}>
+      <FreezeframeWrapper src={channelThumbnail} className={classnames('channel-thumbnail', className, {
+        [colorClassName]: !showThumb,
+        'channel-thumbnail--small': small,
+        'channel-thumbnail--verysmall': verysmall,
+        'channel-thumbnail--resolving': isResolving,
+      })}>
         {!hideStakedIndicator && <ChannelStakedIndicator uri={uri} claim={claim} />}
       </FreezeframeWrapper>
     );
@@ -72,6 +79,7 @@ function ChannelThumbnail(props: Props) {
       className={classnames('channel-thumbnail', className, {
         [colorClassName]: !showThumb,
         'channel-thumbnail--small': small,
+        'channel-thumbnail--verysmall': verysmall,
         'channel-thumbnail--resolving': isResolving,
       })}
     >

--- a/ui/component/sideNavigation/index.js
+++ b/ui/component/sideNavigation/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
-import { selectPurchaseUriSuccess, doClearPurchasedUriSuccess } from 'lbry-redux';
+import { doResolveUris, selectPurchaseUriSuccess, doClearPurchasedUriSuccess } from 'lbry-redux';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectUserVerifiedEmail, selectUser } from 'redux/selectors/user';
 import { selectHomepageData, selectLanguage } from 'redux/selectors/settings';
@@ -23,4 +23,5 @@ const select = (state) => ({
 export default connect(select, {
   doSignOut,
   doClearPurchasedUriSuccess,
+  doResolveUris
 })(SideNavigation);

--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -8,6 +8,8 @@ import classnames from 'classnames';
 import Icon from 'component/common/icon';
 import NotificationBubble from 'component/notificationBubble';
 import I18nMessage from 'component/i18nMessage';
+import ChannelThumbnail from 'component/channelThumbnail';
+import ChannelTitle from 'component/channelTitle';
 import { PINNED_LABEL_1, PINNED_URI_1, PINNED_URI_2, PINNED_LABEL_2, SIMPLE_SITE } from 'config';
 // @if TARGET='app'
 import { IS_MAC } from 'component/app/view';
@@ -46,6 +48,7 @@ type Props = {
   doClearPurchasedUriSuccess: () => void,
   user: ?User,
   homepageData: any,
+  doResolveUris: (Array<string>) => void,
 };
 
 type SideNavLink = {
@@ -72,6 +75,7 @@ function SideNavigation(props: Props) {
     unseenCount,
     homepageData,
     user,
+    doResolveUris,
   } = props;
 
   const { EXTRA_SIDEBAR_LINKS } = homepageData;
@@ -271,6 +275,16 @@ function SideNavigation(props: Props) {
     return () => window.removeEventListener('keydown', handleKeydown);
   }, [sidebarOpen, setSidebarOpen, isAbsolute]);
 
+  React.useEffect(() => {
+    if (subscriptions.length > 0) {
+      const subscriptionUris = subscriptions.map(({ uri }) => {
+        return uri;
+      });
+
+      doResolveUris(subscriptionUris);
+    }
+  }, [doResolveUris]);
+
   const unAuthNudge = (
     <div className="navigation__auth-nudge">
       <span>
@@ -350,10 +364,11 @@ function SideNavigation(props: Props) {
                   <li key={uri} className="navigation-link__wrapper">
                     <Button
                       navigate={uri}
-                      label={channelName}
                       className="navigation-link"
                       activeClass="navigation-link--active"
-                    />
+                    ><ChannelThumbnail uri={uri} verysmall={true} />
+                      <ChannelTitle uri={uri} />
+                    </Button>
                   </li>
                 ))}
               </ul>
@@ -433,10 +448,11 @@ function SideNavigation(props: Props) {
                     <li key={uri} className="navigation-link__wrapper">
                       <Button
                         navigate={uri}
-                        label={channelName}
                         className="navigation-link"
                         activeClass="navigation-link--active"
-                      />
+                      ><ChannelThumbnail uri={uri} verysmall={true} />
+                      <ChannelTitle uri={uri} />
+                    </Button>
                     </li>
                   ))}
                 </ul>

--- a/ui/scss/component/_channel.scss
+++ b/ui/scss/component/_channel.scss
@@ -77,6 +77,11 @@ $metadata-z-index: 1;
   width: 3rem;
 }
 
+.channel-thumbnail--verysmall {
+  height: 2rem;
+  width: 2rem;
+}
+
 .chanel-thumbnail--waiting {
   background-color: var(--color-gray-5);
   border-radius: var(--border-radius);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

Currently the sidenav shows subscriptions only as their handle (@ lbry, @ odysee)

## What is the new behavior?

Changed it to show the channel thumbnail and title instead, to look better

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
