### PR TITLE
get out of (adsense) jail free

### DIFF
--- a/web/component/ads/view.jsx
+++ b/web/component/ads/view.jsx
@@ -8,7 +8,29 @@ import I18nMessage from 'component/i18nMessage';
 import Button from 'component/button';
 import classnames from 'classnames';
 // $FlowFixMe
+
 import { NO_ADS_CHANNEL_IDS } from 'homepages';
+
+const NO_ADS_TEXT_KEYWORDS = [
+  'juifs',
+  'holocaust',
+  'orona',
+  'vaccin',
+  'pcr',
+  'covid',
+  'pfizer',
+  'propogand',
+  'conspira',
+  'pandem',
+  'moutons',
+  'negroes',
+  'sars-cov',
+  'vacuna',
+  'blancs',
+  'whites',
+  'silvano trotta',
+  'covid-19',
+];
 
 const ADS_URL = '//assets.revcontent.com/master/delivery.js';
 const IS_MOBILE = typeof window.orientation !== 'undefined';
@@ -27,7 +49,7 @@ type Props = {
   type: string,
   small: boolean,
   theme: string,
-  claim: GenericClaim,
+  claim: Claim,
   isMature: boolean,
 };
 
@@ -43,8 +65,34 @@ function Ads(props: Props) {
   let googleInit;
 
   const channelId = claim && claim.signing_channel && claim.signing_channel.claim_id;
+  let claimString: string = '';
+  if (claim) claimString = claim.name;
+  if (claim && claim.value) {
+    if (claim.value.tags) {
+      claimString = claimString + claim.value.tags.join(',');
+    }
+    if (claim.value.description) {
+      claimString = claimString + claim.value.description;
+    }
+    if (claim.value.title) {
+      claimString = claimString + claim.value.title;
+    }
+  }
+  claimString = claimString.toLowerCase();
 
-  const isBlocked = isMature || (NO_ADS_CHANNEL_IDS && NO_ADS_CHANNEL_IDS.includes(channelId));
+  const checkStringForAdsense = (text, words) => {
+    for (let i = 0; i < words.length; i++) {
+      if (text.includes(words[i])) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const isBlocked =
+    isMature ||
+    (NO_ADS_CHANNEL_IDS && NO_ADS_CHANNEL_IDS.includes(channelId)) ||
+    checkStringForAdsense(claimString, NO_ADS_TEXT_KEYWORDS);
   useEffect(() => {
     if (SHOW_ADS && type === 'video') {
       let script;


### PR DESCRIPTION
I decided to concatenate the tags into the name, title, and description, set to lowercase, and check some truncated strings ('vaccin') to catch the majority of offenders with a single early-exit for loop and a short array.
Tested on steve, this seemed to allow ads on david pakman's minimum wage videos, but not the ones that mention vaccines.