### PR TITLE
Highlight comments made by content owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Japanese, Afrikaans, Filipino, Thai and Vietnamese language support ([#5684](https://github.com/lbryio/lbry-desktop/issues/5684))
+- Highlight comments made by content owner _community pr!_ ([#5744](https://github.com/lbryio/lbry-desktop/pull/5744))
 
 ### Changed
 
@@ -21,6 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Autoplay looping to a previous video or itself ([#5711](https://github.com/lbryio/lbry-desktop/pull/5711))
 - Autoplay not working in mini-player mode ([#5716](https://github.com/lbryio/lbry-desktop/pull/5716))
 - Edited claim accidentally moved to 'Anonymous' ([#5767](https://github.com/lbryio/lbry-desktop/pull/5767))
+
+## [0.50.2] - [2021-04-2]
+
+### Changed
+
+- Disable PDFs until security issue is fixed
 
 ## [0.50.1] - [2021-03-18]
 

--- a/ui/component/comment/index.js
+++ b/ui/component/comment/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectStakedLevelForChannelUri, makeSelectThumbnailForUri, selectMyChannelClaims } from 'lbry-redux';
+import { makeSelectStakedLevelForChannelUri, makeSelectClaimForUri, makeSelectThumbnailForUri, selectMyChannelClaims } from 'lbry-redux';
 import { doCommentUpdate } from 'redux/actions/comments';
 import { makeSelectChannelIsMuted } from 'redux/selectors/blocked';
 import { doToast } from 'redux/actions/notifications';
@@ -11,6 +11,7 @@ import { selectPlayingUri } from 'redux/selectors/content';
 import Comment from './view';
 
 const select = (state, props) => ({
+  claim: makeSelectClaimForUri(props.uri)(state),
   thumbnail: props.authorUri && makeSelectThumbnailForUri(props.authorUri)(state),
   channelIsBlocked: props.authorUri && makeSelectChannelIsMuted(props.authorUri)(state),
   commentingEnabled: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -25,6 +25,7 @@ import UriIndicator from 'component/uriIndicator';
 type Props = {
   clearPlayingUri: () => void,
   uri: string,
+  claim: StreamClaim,
   author: ?string, // LBRY Channel Name, e.g. @channel
   authorUri: string, // full LBRY Channel URI: lbry://@channel#123...
   commentId: string, // sha256 digest identifying the comment
@@ -59,6 +60,7 @@ const ESCAPE_KEY = 27;
 function Comment(props: Props) {
   const {
     clearPlayingUri,
+    claim,
     uri,
     author,
     authorUri,
@@ -98,6 +100,7 @@ function Comment(props: Props) {
   const dislikesCount = (othersReacts && othersReacts.dislike) || 0;
   const totalLikesAndDislikes = likesCount + dislikesCount;
   const slimedToDeath = totalLikesAndDislikes >= 5 && dislikesCount / totalLikesAndDislikes > 0.8;
+  const commentByOwnerOfContent = claim && claim.signing_channel && claim.signing_channel.permanent_url === authorUri;
 
   let channelOwnerOfContent;
   try {
@@ -197,7 +200,14 @@ function Comment(props: Props) {
               {!author ? (
                 <span className="comment__author">{__('Anonymous')}</span>
               ) : (
-                <UriIndicator className="comment__author" link external={livestream} uri={authorUri} />
+                <UriIndicator
+                  className={classnames('comment__author', {
+                    'comment__author--creator': commentByOwnerOfContent,
+                  })}
+                  link
+                  external={livestream}
+                  uri={authorUri}
+                />
               )}
               {!livestream && (
                 <Button

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -179,8 +179,9 @@ $thumbnailWidthSmall: 1rem;
 }
 
 .comment__meta-information {
-  justify-content: flex-start;
   display: flex;
+  justify-content: flex-start;
+  align-items: center;
   height: 100%;
 }
 
@@ -189,13 +190,6 @@ $thumbnailWidthSmall: 1rem;
 
   .icon {
     padding-top: 1px;
-  }
-}
-
-.comment__creator {
-  .icon {
-    padding-top: 1px;
-    stroke: var(--color-primary);
   }
 }
 
@@ -223,11 +217,13 @@ $thumbnailWidthSmall: 1rem;
 }
 
 .comment__author--creator {
-  @extend .comment__meta-information;
-  padding-left: var(--spacing-xxs);
-  padding-right: var(--spacing-xxs);
+  padding: 0 3px;
   background-color: var(--color-primary-alt);
   border-radius: var(--border-radius);
+
+  &.button--uri-indicator {
+    color: var(--color-link);
+  }
 }
 
 .comment__time {

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -192,6 +192,13 @@ $thumbnailWidthSmall: 1rem;
   }
 }
 
+.comment__creator {
+  .icon {
+    padding-top: 1px;
+    stroke: var(--color-primary);
+  }
+}
+
 .comment__message {
   word-break: break-word;
   max-width: 35rem;
@@ -213,6 +220,14 @@ $thumbnailWidthSmall: 1rem;
   text-overflow: ellipsis;
   margin-right: var(--spacing-xs);
   height: 100%;
+}
+
+.comment__author--creator {
+  @extend .comment__meta-information;
+  padding-left: var(--spacing-xxs);
+  padding-right: var(--spacing-xxs);
+  background-color: var(--color-primary-alt);
+  border-radius: var(--border-radius);
 }
 
 .comment__time {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

In filled comment sections it gets hard to track the Content Creator's own comments, also it could happen that someone has the same channel name and profile picture as the file owner

## What is the new behavior?

Added a highlight to the creator's own comments, making it better for visualization also to verify it is the actual owner.

Image example from this video: https://lbry.tv/@LBRY-Invest:c/How-to-earn-LBC-on-LBRY-Odysee:d

![](https://i.postimg.cc/4xmpFcpY/image.png)

## Other information

I just don't know how I feel about the colors, maybe this could be improved?

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
