### PR TITLE
prepareEdit: ensure 'incognito' is false when channel is active.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Autoplay looping to a previous video or itself ([#5711](https://github.com/lbryio/lbry-desktop/pull/5711))
 - Autoplay not working in mini-player mode ([#5716](https://github.com/lbryio/lbry-desktop/pull/5716))
+- Edited claim accidentally moved to 'Anonymous' ([#5767](https://github.com/lbryio/lbry-desktop/pull/5767))
 
 ## [0.50.1] - [2021-03-18]
 

--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -27,6 +27,7 @@ const perform = (dispatch) => ({
   openModal: (modal, props) => dispatch(doOpenModal(modal, props)),
   prepareEdit: (publishData, uri, fileInfo) => {
     if (publishData.signing_channel) {
+      dispatch(doSetIncognito(false));
       dispatch(doSetActiveChannel(publishData.signing_channel.claim_id));
     } else {
       dispatch(doSetIncognito(true));


### PR DESCRIPTION
## Issue
Closes #5720: [Edit: channel-selector should re-populate with original channel](https://github.com/lbryio/lbry-desktop/issues/5720)

## Notes
'incognito' was not set to false, causing the 'ChannelSelector' to select Anonymous.
