### PR TITLE
Minor improvement: if not live yet, say users are waiting instead of watching

### DIFF
--- a/ui/component/fileSubtitle/view.jsx
+++ b/ui/component/fileSubtitle/view.jsx
@@ -8,17 +8,18 @@ type Props = {
   uri: string,
   livestream?: boolean,
   activeViewers?: number,
+  stateOfViewers: string,
 };
 
 function FileSubtitle(props: Props) {
-  const { uri, livestream = false, activeViewers = 0 } = props;
+  const { uri, livestream = false, activeViewers = 0, stateOfViewers } = props;
 
   return (
     <div className="media__subtitle--between">
       <div className="file__viewdate">
         {livestream ? <span>{__('Right now')}</span> : <DateTime uri={uri} show={DateTime.SHOW_DATE} />}
         {livestream ? (
-          <span>{__('%viewer_count% currently watching', { viewer_count: activeViewers })}</span>
+          <span>{__('%viewer_count% currently %viewer_state%', { viewer_count: activeViewers, viewer_state: stateOfViewers })}</span>
         ) : (
           <FileViewCount uri={uri} />
         )}

--- a/ui/component/fileTitleSection/view.jsx
+++ b/ui/component/fileTitleSection/view.jsx
@@ -20,10 +20,11 @@ type Props = {
   isNsfwBlocked: boolean,
   livestream?: boolean,
   activeViewers?: number,
+  stateOfViewers: string,
 };
 
 function FileTitleSection(props: Props) {
-  const { title, uri, nsfw, isNsfwBlocked, livestream = false, activeViewers } = props;
+  const { title, uri, nsfw, isNsfwBlocked, livestream = false, activeViewers, stateOfViewers } = props;
 
   return (
     <Card
@@ -43,7 +44,7 @@ function FileTitleSection(props: Props) {
       body={
         <React.Fragment>
           <ClaimInsufficientCredits uri={uri} />
-          <FileSubtitle uri={uri} livestream={livestream} activeViewers={activeViewers} />
+          <FileSubtitle uri={uri} livestream={livestream} activeViewers={activeViewers} stateOfViewers={stateOfViewers} />
         </React.Fragment>
       }
       actions={

--- a/ui/component/livestreamLayout/view.jsx
+++ b/ui/component/livestreamLayout/view.jsx
@@ -41,7 +41,7 @@ export default function LivestreamLayout(props: Props) {
             })}
           </div>
         )}
-        <FileTitleSection uri={uri} livestream isLive={isLive} activeViewers={activeViewers} />
+        <FileTitleSection uri={uri} livestream isLive={isLive} activeViewers={activeViewers} stateOfViewers={isLive ? "watching" : "waiting"} />
       </div>
       <LivestreamComments uri={uri} />
     </>

--- a/ui/component/livestreamLayout/view.jsx
+++ b/ui/component/livestreamLayout/view.jsx
@@ -41,7 +41,13 @@ export default function LivestreamLayout(props: Props) {
             })}
           </div>
         )}
-        <FileTitleSection uri={uri} livestream isLive={isLive} activeViewers={activeViewers} stateOfViewers={isLive ? "watching" : "waiting"} />
+        <FileTitleSection
+          uri={uri}
+          livestream
+          isLive={isLive}
+          activeViewers={activeViewers}
+          stateOfViewers={isLive ? __('watching') : __('waiting')}
+        />
       </div>
       <LivestreamComments uri={uri} />
     </>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

Livestream says people are watching but at the same time that it isn't live yet

![](https://i.postimg.cc/tCHFsy1k/image.png)

## What is the new behavior?

Says it isn't live but there are people waiting to watch it

![](https://i.postimg.cc/KjCLfSQG/image.png)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
