### PR TITLE
Fix broken video embed

### DIFF
--- a/ui/component/fileRenderInline/index.js
+++ b/ui/component/fileRenderInline/index.js
@@ -1,14 +1,14 @@
 import { connect } from 'react-redux';
 import { makeSelectFileInfoForUri, makeSelectStreamingUrlForUri } from 'lbry-redux';
 import { doClaimEligiblePurchaseRewards } from 'redux/actions/rewards';
-import { makeSelectFileRenderModeForUri, makeSelectIsPlaying } from 'redux/selectors/content';
+import { makeSelectFileRenderModeForUri, selectPrimaryUri } from 'redux/selectors/content';
 import { withRouter } from 'react-router';
 import { doAnalyticsView } from 'redux/actions/app';
 import FileRenderInline from './view';
 
 const select = (state, props) => ({
   fileInfo: makeSelectFileInfoForUri(props.uri)(state),
-  isPlaying: makeSelectIsPlaying(props.uri)(state),
+  isPlaying: selectPrimaryUri(state) === props.uri,
   streamingUrl: makeSelectStreamingUrlForUri(props.uri)(state),
   renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
 });

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -29,7 +29,7 @@ export const selectPlayingUri = createSelector(selectState, (state) => state.pla
 export const selectPrimaryUri = createSelector(selectState, (state) => state.primaryUri);
 
 export const makeSelectIsPlaying = (uri: string) =>
-  createSelector(selectPlayingUri, (playingUri) => playingUri && playingUri.uri === uri);
+  createSelector(selectPrimaryUri, (primaryUri) => primaryUri === uri);
 
 export const makeSelectIsPlayerFloating = (location: UrlLocation) =>
   createSelector(selectPrimaryUri, selectPlayingUri, selectClaimsByUri, (primaryUri, playingUri, claimsByUri) => {


### PR DESCRIPTION
## Issue
- Closes #5811: Video-embed in markdown-post is broken
- Re-opens #4959: Deleting MD from downloads list causes spinning icon to run forever

## Changes
- Revert "Fix 'makeSelectIsPlaying' to look at 'playing' instead of 'primary'." dabdc980a1ff1446d03353192e19f9291340ca88.
- Revert "Fix 'isPlaying' to reflect 'playing' instead of 'primary' URI" 351890decff63a19db177bfb631edb6cb8a44d63.

Reverting means `Deleting MD from downloads list causes spinning icon to run forever 4959` gets re-opened, but this is a way less severe issue.  Will re-visit 4959 later.

## Notes to reviewer
The revert is very safe in the sense that it  is very localized (only affects `FileRenderInline` and `FileRenderInitiator`) -- we are back to original code.  I think there are no recent changes that would impact this.