### PR TITLE
Add a title with the exact date to dateTime elements that use timeAgo

### DIFF
--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -52,7 +52,7 @@ class DateTime extends React.PureComponent<Props> {
         return null;
       }
 
-      return <span>{DateTime.getTimeAgoStr(date)}</span>;
+      return <span title={moment(date).format('MMMM Do, YYYY hh:mm A')}>{DateTime.getTimeAgoStr(date)}</span>;
     }
 
     return (


### PR DESCRIPTION
## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

## What is the current behavior?

It is impossible to know the exact date for some of these. For videos you can click into the video to get the date of the video (but not the time).

## What is the new behavior?

You can now hover your mouse on the "time ago" dates and a title will pop up with the exact timestamp.

Screenshots: (my mouse cursor is unfortunately not visible)

Video tile:

![video](https://user-images.githubusercontent.com/1991151/113458285-b25a4480-93c6-11eb-8b2f-70c05160e38d.png)

Comment:

![comment](https://user-images.githubusercontent.com/1991151/113458303-c0a86080-93c6-11eb-995f-d1dc76fbad64.png)

Channel about page:

![channel-about-page](https://user-images.githubusercontent.com/1991151/113458294-bd14d980-93c6-11eb-8344-f1ab82cd0e2b.png)


## Other information

Next I plan to see how hard it would be to introduce a setting to display time in 12-hour or 24-hour format. Please let me know if this is a change that you would like.
