### PR TITLE
Fixes #5822 display of upload date and view count on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix display of upload date and view count on smaller screens ([#5822](https://github.com/lbryio/lbry-desktop/issues/5822))
 - Autoplay looping to a previous video or itself ([#5711](https://github.com/lbryio/lbry-desktop/pull/5711))
 - Autoplay not working in mini-player mode ([#5716](https://github.com/lbryio/lbry-desktop/pull/5716))
 - Edited claim accidentally moved to 'Anonymous' ([#5767](https://github.com/lbryio/lbry-desktop/pull/5767))

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -691,14 +691,20 @@ video::-internal-media-controls-overlay-cast-button {
 .file__viewdate {
   display: flex;
   justify-content: space-between;
+  flex-direction: column;
   margin-bottom: var(--spacing-s);
 
-  @media (min-width: $breakpoint-small) {
-    flex-direction: column;
-    margin-bottom: 0;
+  > :first-child {
+    margin-bottom: var(--spacing-s);
+  }
+
+  @media (max-width: $breakpoint-medium) {
+    flex-direction: row;
+    justify-content: start;
 
     > :first-child {
-      margin-bottom: var(--spacing-s);
+      margin-bottom: 0;
+      margin-right: 1rem;
     }
   }
 }

--- a/ui/scss/component/_media.scss
+++ b/ui/scss/component/_media.scss
@@ -57,12 +57,13 @@
 .media__subtitle--between {
   @extend .media__subtitle;
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-direction: row;
 
-  @media (min-width: $breakpoint-small) {
-    justify-content: space-between;
-    align-items: flex-end;
-    flex-direction: row;
+  // smaller screen
+  @media (max-width: $breakpoint-medium) {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #5822 

## What is the current behavior?

Upload date and view count are displayed vertically on with little horizontal space.

![media_meta_below_1150px_before](https://user-images.githubusercontent.com/1214300/113497139-b4e79780-94b5-11eb-8c80-c521459b16ec.png)

## What is the new behavior?

Upload date and view count are displayed horizontally with more horizontal space.

![media_meta_below_1150px_after](https://user-images.githubusercontent.com/1214300/113497145-cb8dee80-94b5-11eb-890e-5807f89dc5b2.png)
