### PR TITLE
Concept to push live channels to the top of the sidebar

### DIFF
--- a/ui/component/sideNavigation/index.js
+++ b/ui/component/sideNavigation/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
-import { selectPurchaseUriSuccess, doClearPurchasedUriSuccess } from 'lbry-redux';
+import { selectPurchaseUriSuccess, doClearPurchasedUriSuccess, makeSelectClaimForUri } from 'lbry-redux';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectUserVerifiedEmail, selectUser } from 'redux/selectors/user';
 import { selectHomepageData, selectLanguage } from 'redux/selectors/settings';
@@ -9,16 +9,22 @@ import { selectUnseenNotificationCount } from 'redux/selectors/notifications';
 
 import SideNavigation from './view';
 
-const select = (state) => ({
-  subscriptions: selectSubscriptions(state),
-  followedTags: selectFollowedTags(state),
-  language: selectLanguage(state), // trigger redraw on language change
-  email: selectUserVerifiedEmail(state),
-  purchaseSuccess: selectPurchaseUriSuccess(state),
-  unseenCount: selectUnseenNotificationCount(state),
-  user: selectUser(state),
-  homepageData: selectHomepageData(state),
-});
+const select = (state) => {
+  const subscriptions = selectSubscriptions(state);
+  return {
+    claims: subscriptions.map(({ uri }) => (
+      makeSelectClaimForUri(uri)(state)
+      )),
+    subscriptions,
+    followedTags: selectFollowedTags(state),
+    language: selectLanguage(state), // trigger redraw on language change
+    email: selectUserVerifiedEmail(state),
+    purchaseSuccess: selectPurchaseUriSuccess(state),
+    unseenCount: selectUnseenNotificationCount(state),
+    user: selectUser(state),
+    homepageData: selectHomepageData(state),
+  };
+};
 
 export default connect(select, {
   doSignOut,


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?

You can only find which channels are live right now in the following tab, in the middle of other subscriptions posts

## What is the new behavior?

Channels that are live would appear first on the sidebar, I didn't have any actual live channels that I follow to test this so I had added 2 test ones: (they show up with the camera icon, just a concept should be improved ofc)

![](https://i.postimg.cc/0NRvJ3bx/image.png)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
