### PR TITLE
Fix #5795 - Claim images not lazy loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Lazy-load claim images to improve app responsiveness ([#5795](https://github.com/lbryio/lbry-desktop/issues/5795))
 - Fix display of upload date and view count on smaller screens ([#5822](https://github.com/lbryio/lbry-desktop/issues/5822))
 - Autoplay looping to a previous video or itself ([#5711](https://github.com/lbryio/lbry-desktop/pull/5711))
 - Autoplay not working in mini-player mode ([#5716](https://github.com/lbryio/lbry-desktop/pull/5716))

--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import Gerbil from './gerbil.png';
 import FreezeframeWrapper from 'component/fileThumbnail/FreezeframeWrapper';
 import ChannelStakedIndicator from 'component/channelStakedIndicator';
-import useLazyLoading from '../../util/useLazyLoading';
+import useLazyLoading from 'effects/use-lazy-loading';
 
 type Props = {
   thumbnail: ?string,

--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import Gerbil from './gerbil.png';
 import FreezeframeWrapper from 'component/fileThumbnail/FreezeframeWrapper';
 import ChannelStakedIndicator from 'component/channelStakedIndicator';
+import useLazyLoading from '../../util/useLazyLoading';
 
 type Props = {
   thumbnail: ?string,
@@ -42,6 +43,7 @@ function ChannelThumbnail(props: Props) {
   const thumbnailPreview = rawThumbnailPreview && rawThumbnailPreview.trim().replace(/^http:\/\//i, 'https://');
   const channelThumbnail = thumbnail || thumbnailPreview;
   const showThumb = (!obscure && !!thumbnail) || thumbnailPreview;
+  const thumbnailRef = React.useRef(null);
   // Generate a random color class based on the first letter of the channel name
   const { channelName } = parseURI(uri);
   let initializer;
@@ -58,6 +60,8 @@ function ChannelThumbnail(props: Props) {
       doResolveUri(uri);
     }
   }, [doResolveUri, shouldResolve, uri]);
+
+  useLazyLoading(thumbnailRef, 0.25, [showThumb]);
 
   if (channelThumbnail && channelThumbnail.endsWith('gif') && !allowGifs) {
     return (
@@ -77,9 +81,10 @@ function ChannelThumbnail(props: Props) {
     >
       {!showThumb && (
         <img
+          ref={thumbnailRef}
           alt={__('Channel profile picture')}
           className="channel-thumbnail__default"
-          src={!thumbError && thumbnailPreview ? thumbnailPreview : Gerbil}
+          data-src={!thumbError && thumbnailPreview ? thumbnailPreview : Gerbil}
           onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
         />
       )}
@@ -89,9 +94,10 @@ function ChannelThumbnail(props: Props) {
             <div className="chanel-thumbnail--waiting">{__('This will be visible in a few minutes.')}</div>
           ) : (
             <img
+              ref={thumbnailRef}
               alt={__('Channel profile picture')}
               className="channel-thumbnail__custom"
-              src={!thumbError ? thumbnailPreview || thumbnail : Gerbil}
+              data-src={!thumbError ? thumbnailPreview || thumbnail : Gerbil}
               onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
             />
           )}

--- a/ui/component/fileThumbnail/FreezeframeWrapper.jsx
+++ b/ui/component/fileThumbnail/FreezeframeWrapper.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Freezeframe from './FreezeframeLite';
-import useLazyLoading from '../../util/useLazyLoading';
+import useLazyLoading from 'effects/use-lazy-loading';
 
 const FreezeframeWrapper = (props) => {
   const imgRef = React.useRef();

--- a/ui/component/fileThumbnail/FreezeframeWrapper.jsx
+++ b/ui/component/fileThumbnail/FreezeframeWrapper.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Freezeframe from './FreezeframeLite';
+import useLazyLoading from '../../util/useLazyLoading';
 
 const FreezeframeWrapper = (props) => {
   const imgRef = React.useRef();
@@ -13,10 +14,12 @@ const FreezeframeWrapper = (props) => {
     freezeframe.current = new Freezeframe(imgRef.current);
   }, []);
 
+  useLazyLoading(imgRef);
+
   return (
     <div className={classnames(className, 'freezeframe-wrapper')}>
       <>
-        <img ref={imgRef} src={src} className="freezeframe-img" />
+        <img ref={imgRef} data-src={src} className="freezeframe-img" />
         {children}
       </>
     </div>

--- a/ui/component/fileThumbnail/view.jsx
+++ b/ui/component/fileThumbnail/view.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import FreezeframeWrapper from './FreezeframeWrapper';
 import Placeholder from './placeholder.png';
 import classnames from 'classnames';
+import useLazyLoading from '../../util/useLazyLoading';
 
 type Props = {
   uri: string,
@@ -12,7 +13,7 @@ type Props = {
   children?: Node,
   allowGifs: boolean,
   claim: ?StreamClaim,
-  doResolveUri: string => void,
+  doResolveUri: (string) => void,
   className?: string,
 };
 
@@ -23,12 +24,15 @@ function FileThumbnail(props: Props) {
     uri && claim && claim.value && claim.value.thumbnail ? claim.value.thumbnail.url : undefined;
   const thumbnail = passedThumbnail || thumbnailFromClaim;
   const hasResolvedClaim = claim !== undefined;
+  const thumbnailRef = React.useRef(null);
 
   React.useEffect(() => {
     if (!hasResolvedClaim && uri) {
       doResolveUri(uri);
     }
   }, [hasResolvedClaim, uri, doResolveUri]);
+
+  useLazyLoading(thumbnailRef);
 
   if (!allowGifs && thumbnail && thumbnail.endsWith('gif')) {
     return (
@@ -46,9 +50,12 @@ function FileThumbnail(props: Props) {
   }
   // @endif
 
+  const thumnailUrl = url ? url.replace(/'/g, "\\'") : '';
+
   return (
     <div
-      style={{ backgroundImage: `url('${url ? url.replace(/'/g, "\\'") : ''}')` }}
+      ref={thumbnailRef}
+      data-background-image={thumnailUrl}
       className={classnames('media__thumb', className, {
         'media__thumb--resolving': !hasResolvedClaim,
       })}

--- a/ui/component/fileThumbnail/view.jsx
+++ b/ui/component/fileThumbnail/view.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import FreezeframeWrapper from './FreezeframeWrapper';
 import Placeholder from './placeholder.png';
 import classnames from 'classnames';
-import useLazyLoading from '../../util/useLazyLoading';
+import useLazyLoading from 'effects/use-lazy-loading';
 
 type Props = {
   uri: string,

--- a/ui/effects/use-lazy-loading.js
+++ b/ui/effects/use-lazy-loading.js
@@ -1,3 +1,5 @@
+// @flow
+import type { ElementRef } from 'react';
 import { useEffect } from 'react';
 
 /**
@@ -6,7 +8,11 @@ import { useEffect } from 'react';
  * @param {Number} [threshold=0.5] - The percent visible in order for loading to begin.
  * @param {Array<>} [deps=[]] - The dependencies this lazy-load is reliant on.
  */
-export default function useLazyLoading(elementRef, threshold = 0.25, deps = []) {
+export default function useLazyLoading(
+  elementRef: { current: ?ElementRef<any> },
+  threshold: number = 0.25,
+  deps: Array<any> = []
+) {
   useEffect(() => {
     if (!elementRef.current) {
       return;
@@ -22,6 +28,7 @@ export default function useLazyLoading(elementRef, threshold = 0.25, deps = []) 
 
             // useful for lazy loading img tags
             if (target.dataset.src) {
+              // $FlowFixMe
               target.src = target.dataset.src;
               return;
             }
@@ -41,7 +48,5 @@ export default function useLazyLoading(elementRef, threshold = 0.25, deps = []) 
     );
 
     lazyLoadingObserver.observe(elementRef.current);
-
-    // re-run whenever the element ref changes
   }, deps);
 }

--- a/ui/util/useLazyLoading.js
+++ b/ui/util/useLazyLoading.js
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+/**
+ * Helper React hook for lazy loading images
+ * @param elementRef - A React useRef instance to the element to lazy load.
+ * @param {Number} [threshold=0.5] - The percent visible in order for loading to begin.
+ * @param {Array<>} [deps=[]] - The dependencies this lazy-load is reliant on.
+ */
+export default function useLazyLoading(elementRef, threshold = 0.25, deps = []) {
+  useEffect(() => {
+    if (!elementRef.current) {
+      return;
+    }
+
+    const lazyLoadingObserver = new IntersectionObserver(
+      (entries, observer) => {
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio >= threshold) {
+            const { target } = entry;
+
+            observer.unobserve(target);
+
+            // useful for lazy loading img tags
+            if (target.dataset.src) {
+              target.src = target.dataset.src;
+              return;
+            }
+
+            // useful for lazy loading background images on divs
+            if (target.dataset.backgroundImage) {
+              target.style.backgroundImage = `url(${target.dataset.backgroundImage})`;
+            }
+          }
+        });
+      },
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold,
+      }
+    );
+
+    lazyLoadingObserver.observe(elementRef.current);
+
+    // re-run whenever the element ref changes
+  }, deps);
+}


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #5795

## What is the current behavior?

All claim images and channel thumbnails are queued when a page is loaded; this slows down the app's overall responsiveness when many claim images are encountered on a page.

## What is the new behavior?

Claim images and channel thumbnails are queued as they enter the user's viewport (when about 25% of the image container is shown). This frees up network resources and makes the app feel quicker.

## Other information

Before the change, 37 image requests and a total of 60, were initiated on this page when only 4 claims are visible in the viewport.
![before](https://user-images.githubusercontent.com/1214300/113816935-5f67f080-972a-11eb-9388-cc6a8f2eda37.png)

After the change, only 11 image requests are made and a total of 28 requests when those same 4 claims are visible. This is ~53% reduction in total requests.
![after](https://user-images.githubusercontent.com/1214300/113816940-63940e00-972a-11eb-8f51-179cea6999c1.png)
