### PR TITLE
Level: Apply to 'comments' only + simplify image link

### DIFF
--- a/ui/component/channelAbout/index.js
+++ b/ui/component/channelAbout/index.js
@@ -1,10 +1,9 @@
 import { connect } from 'react-redux';
-import { makeSelectMetadataItemForUri, makeSelectClaimForUri, makeSelectStakedLevelForChannelUri } from 'lbry-redux';
+import { makeSelectMetadataItemForUri, makeSelectClaimForUri } from 'lbry-redux';
 import ChannelAbout from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  stakedLevel: makeSelectStakedLevelForChannelUri(props.uri)(state),
   description: makeSelectMetadataItemForUri(props.uri, 'description')(state),
   website: makeSelectMetadataItemForUri(props.uri, 'website_url')(state),
   email: makeSelectMetadataItemForUri(props.uri, 'email')(state),

--- a/ui/component/channelAbout/view.jsx
+++ b/ui/component/channelAbout/view.jsx
@@ -17,7 +17,6 @@ type Props = {
   email: ?string,
   website: ?string,
   languages: Array<string>,
-  stakedLevel?: number,
 };
 
 const formatEmail = (email: string) => {
@@ -30,7 +29,7 @@ const formatEmail = (email: string) => {
 };
 
 function ChannelAbout(props: Props) {
-  const { claim, uri, description, email, website, languages, stakedLevel } = props;
+  const { claim, uri, description, email, website, languages } = props;
   const claimId = claim && claim.claim_id;
 
   return (
@@ -41,7 +40,7 @@ function ChannelAbout(props: Props) {
             <>
               <label>{__('Description')}</label>
               <div className="media__info-text media__info-text--constrained">
-                <MarkdownPreview content={description} stakedLevel={stakedLevel} />
+                <MarkdownPreview content={description} />
               </div>
             </>
           )}

--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -15,7 +15,6 @@ import { formattedTimestamp, inlineTimestamp } from 'util/remark-timestamp';
 import ZoomableImage from 'component/zoomableImage';
 import { CHANNEL_STAKED_LEVEL_VIDEO_COMMENTS, SIMPLE_SITE } from 'config';
 import Button from 'component/button';
-import Icon from 'component/common/icon';
 import * as ICONS from 'constants/icons';
 
 type SimpleTextProps = {
@@ -99,19 +98,14 @@ const SimpleImageLink = (props: ImageLinkProps) => {
   }
 
   return (
-    <div className="preview-link__img--no-preview">
-      <Button
-        button="link"
-        icon={ICONS.IMAGE}
-        iconSize={28}
-        iconRight={ICONS.EXTERNAL}
-        label={title || alt}
-        title={title || alt}
-        className="button--external-link"
-        href={src}
-      />
-      {helpText && <Icon className="icon--help" icon={ICONS.HELP} tooltip size={24} customTooltipText={helpText} />}
-    </div>
+    <Button
+      button="link"
+      iconRight={ICONS.EXTERNAL}
+      label={title || alt || src}
+      title={helpText || title || alt || src}
+      className="button--external-link"
+      href={src}
+    />
   );
 };
 

--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -131,7 +131,7 @@ const REPLACE_REGEX = /(<iframe\s+src=["'])(.*?(?=))(["']\s*><\/iframe>)/g;
 // ****************************************************************************
 
 function isStakeEnoughForPreview(stakedLevel) {
-  return stakedLevel && stakedLevel >= CHANNEL_STAKED_LEVEL_VIDEO_COMMENTS;
+  return !stakedLevel || stakedLevel >= CHANNEL_STAKED_LEVEL_VIDEO_COMMENTS;
 }
 
 // ****************************************************************************

--- a/ui/component/fileRender/index.js
+++ b/ui/component/fileRender/index.js
@@ -6,8 +6,6 @@ import {
   makeSelectDownloadPathForUri,
   makeSelectStreamingUrlForUri,
   SETTINGS,
-  makeSelectStakedLevelForChannelUri,
-  makeSelectChannelForClaimUri,
 } from 'lbry-redux';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { makeSelectFileRenderModeForUri, makeSelectFileExtensionForUri } from 'redux/selectors/content';
@@ -15,11 +13,9 @@ import FileRender from './view';
 
 const select = (state, props) => {
   const autoplay = props.embedded ? false : makeSelectClientSetting(SETTINGS.AUTOPLAY)(state);
-  const channelUri = makeSelectChannelForClaimUri(props.uri)(state);
   return {
     currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),
     claim: makeSelectClaimForUri(props.uri)(state),
-    stakedLevel: makeSelectStakedLevelForChannelUri(channelUri)(state),
     thumbnail: makeSelectThumbnailForUri(props.uri)(state),
     contentType: makeSelectContentTypeForUri(props.uri)(state),
     downloadPath: makeSelectDownloadPathForUri(props.uri)(state),

--- a/ui/component/fileRender/view.jsx
+++ b/ui/component/fileRender/view.jsx
@@ -35,7 +35,6 @@ type Props = {
   thumbnail: string,
   desktopPlayStartTime?: number,
   className?: string,
-  stakedLevel?: number,
 };
 
 class FileRender extends React.PureComponent<Props> {
@@ -79,7 +78,6 @@ class FileRender extends React.PureComponent<Props> {
       uri,
       renderMode,
       desktopPlayStartTime,
-      stakedLevel,
     } = this.props;
     const source = streamingUrl;
 
@@ -104,7 +102,7 @@ class FileRender extends React.PureComponent<Props> {
           <DocumentViewer
             source={{
               // @if TARGET='app'
-              file: options => fs.createReadStream(downloadPath, options),
+              file: (options) => fs.createReadStream(downloadPath, options),
               // @endif
               stream: source,
               fileExtension,
@@ -112,7 +110,6 @@ class FileRender extends React.PureComponent<Props> {
             }}
             renderMode={renderMode}
             theme={currentTheme}
-            stakedLevel={stakedLevel}
           />
         );
       case RENDER_MODES.DOCX:
@@ -134,7 +131,7 @@ class FileRender extends React.PureComponent<Props> {
           <ComicBookViewer
             source={{
               // @if TARGET='app'
-              file: options => fs.createReadStream(downloadPath, options),
+              file: (options) => fs.createReadStream(downloadPath, options),
               // @endif
               stream: source,
             }}

--- a/ui/component/viewers/documentViewer.jsx
+++ b/ui/component/viewers/documentViewer.jsx
@@ -15,7 +15,6 @@ type Props = {
     stream: string,
     contentType: string,
   },
-  stakedLevel?: number,
 };
 
 type State = {
@@ -76,11 +75,11 @@ class DocumentViewer extends React.PureComponent<Props, State> {
 
   renderDocument() {
     const { content } = this.state;
-    const { source, theme, renderMode, stakedLevel } = this.props;
+    const { source, theme, renderMode } = this.props;
     const { contentType } = source;
 
     return renderMode === RENDER_MODES.MARKDOWN ? (
-      <MarkdownPreview content={content} isMarkdownPost promptLinks stakedLevel={stakedLevel} />
+      <MarkdownPreview content={content} isMarkdownPost promptLinks />
     ) : (
       <CodeViewer value={content} contentType={contentType} theme={theme} />
     );

--- a/ui/scss/component/_markdown-preview.scss
+++ b/ui/scss/component/_markdown-preview.scss
@@ -253,29 +253,6 @@
     width: 8rem;
   }
 
-  .preview-link__img--no-preview {
-    margin: var(--spacing-s) var(--spacing-m);
-    padding: var(--spacing-s);
-    background-color: var(--color-card-background);
-
-    border-bottom-left-radius: var(--border-radius);
-    border-bottom-right-radius: var(--border-radius);
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-
-    .button {
-      max-width: 90%;
-    }
-  }
-
   .preview-link__description {
     margin-top: var(--spacing-s);
   }


### PR DESCRIPTION
- Fix "channel levels" being applied to all MarkdownPreview usages
- SimpleImageLink: simplify (back to basic link) + use 'src' as last resort 
- Only apply Staked Levels to Comments (allow it in Posts)

![image](https://user-images.githubusercontent.com/64950861/114078018-01c6d600-98db-11eb-801b-16ab37e56cf2.png)
