### PR TITLE
Wunderbar: handle 'shift+home' key not highlighting text

### DIFF
--- a/ui/component/wunderbarSuggestions/view.jsx
+++ b/ui/component/wunderbarSuggestions/view.jsx
@@ -134,18 +134,20 @@ export default function WunderBarSuggestions(props: Props) {
         let begin;
         let final;
         let scrollPx;
+        let direction = 'none';
 
         if (isHome) {
           begin = 0;
           final = shiftKey ? cur : begin;
           scrollPx = 0;
+          direction = 'backward';
         } else {
           final = elem.value.length;
           begin = shiftKey ? cur : final;
           scrollPx = elem.scrollWidth - elem.clientWidth;
         }
 
-        elem.setSelectionRange(begin, final);
+        elem.setSelectionRange(begin, final, direction);
         elem.scrollLeft = scrollPx;
         return true;
       }


### PR DESCRIPTION
## Issue
- Patch for #5316: "Home and End keys not working in search box"

## Notes
Seems like 'shift+home' wasn't highlighting the text. 'shift+end' works.

Was pretty sure I tested that previously. Anyway, adding the direction variable seems to fix it.