### PR TITLE
GoogleVideoSearch: fix duration

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -191,7 +191,7 @@ function buildGoogleVideoMetadata(claimUri, claim) {
     thumbnailUrl: `${claimThumbnail}`,
     uploadDate: `${new Date(releaseTime * 1000).toISOString()}`,
     // --- Recommended ---
-    duration: moment.duration(claim.duration).toISOString(),
+    duration: moment.duration(claim.duration * 1000).toISOString(),
     contentUrl: generateDirectUrl(claim.name, claim.claim_id),
     embedUrl: generateEmbedUrl(claim.name, claim.claim_id),
   };


### PR DESCRIPTION
## Issue
The wrong `duration` value is being set in the Google Video metadata, causing the indexed data to be incorrect.  

## Changes
Forgot that `moment.duration()` takes in ms. 