### PR TITLE
Swap: Don't copy the currency, only amount

### DIFF
--- a/ui/component/copyableText/view.jsx
+++ b/ui/component/copyableText/view.jsx
@@ -11,10 +11,11 @@ type Props = {
   label?: string,
   primaryButton?: boolean,
   name?: string,
+  onCopy?: (string) => string,
 };
 
 export default function CopyableText(props: Props) {
-  const { copyable, doToast, snackMessage, label, primaryButton = false, name } = props;
+  const { copyable, doToast, snackMessage, label, primaryButton = false, name, onCopy } = props;
 
   const input = useRef();
 
@@ -22,7 +23,11 @@ export default function CopyableText(props: Props) {
     const topRef = input.current;
     if (topRef && topRef.input && topRef.input.current) {
       topRef.input.current.select();
+      if (onCopy) {
+        onCopy(topRef.input.current);
+      }
     }
+
     document.execCommand('copy');
   }
 

--- a/ui/component/walletSwap/view.jsx
+++ b/ui/component/walletSwap/view.jsx
@@ -533,7 +533,18 @@ function WalletSwap(props: Props) {
             </>
           )}
           <div className="confirm__label">{__('Send')}</div>
-          <CopyableText primaryButton copyable={getCoinSendAmountStr(coin)} snackMessage={__('Amount copied.')} />
+          <CopyableText
+            primaryButton
+            copyable={getCoinSendAmountStr(coin)}
+            snackMessage={__('Amount copied.')}
+            onCopy={(inputElem) => {
+              const inputStr = inputElem.value;
+              const selectEndIndex = inputStr.lastIndexOf(' ');
+              if (selectEndIndex > -1 && inputStr.substring(0, selectEndIndex).match(/[\d.]/)) {
+                inputElem.setSelectionRange(0, selectEndIndex, 'forward');
+              }
+            }}
+          />
           {getGap()}
           <div className="confirm__label">{__('To')}</div>
           <CopyableText primaryButton copyable={getCoinAddress(coin)} snackMessage={__('Address copied.')} />
@@ -665,7 +676,9 @@ function WalletSwap(props: Props) {
     <Form onSubmit={handleStartSwap}>
       <Card
         title={<I18nMessage tokens={{ lbc: <LbcSymbol size={22} /> }}>Swap Crypto for %lbc%</I18nMessage>}
-        subtitle={__('Send crypto to the address provided and you will be sent an equivalent amount of Credits. You can pay with BCH, LTC, ETH, USDC or DAI after starting the swap.')}
+        subtitle={__(
+          'Send crypto to the address provided and you will be sent an equivalent amount of Credits. You can pay with BCH, LTC, ETH, USDC or DAI after starting the swap.'
+        )}
         actions={getActionElement()}
         nag={nag ? <Nag relative type={nag.type} message={__(nag.msg)} /> : null}
       />


### PR DESCRIPTION
## Issue
Part of #5873[: Rounds 2 of LBC swaps](https://github.com/lbryio/lbry-desktop/issues/5873)

## Notes
It was an intended feature to include the currency -- I can paste the full string into my note book, while pasting into wallet apps like Exodus will automatically trim off the currency anyway.

Regardless, removed the 'feature' :D

## Approach
Updated `CopyableText` with `onCopy` prop that allows the client to override the full text selection.