### PR TITLE
GoogleVideoSearch: fix blank description; invalid thumbnails

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -191,10 +191,18 @@ function buildGoogleVideoMetadata(claimUri, claim) {
     thumbnailUrl: `${claimThumbnail}`,
     uploadDate: `${new Date(releaseTime * 1000).toISOString()}`,
     // --- Recommended ---
-    duration: moment.duration(claim.duration * 1000).toISOString(),
+    duration: claim.duration ? moment.duration(claim.duration * 1000).toISOString() : undefined,
     contentUrl: generateDirectUrl(claim.name, claim.claim_id),
     embedUrl: generateEmbedUrl(claim.name, claim.claim_id),
   };
+
+  if (
+    !googleVideoMetadata.description.replace(/\s/g, '').length ||
+    googleVideoMetadata.thumbnailUrl.startsWith('data:image') ||
+    !googleVideoMetadata.thumbnailUrl.startsWith('http')
+  ) {
+    return '';
+  }
 
   return (
     '<script type="application/ld+json">\n' + JSON.stringify(googleVideoMetadata, null, '  ') + '\n' + '</script>\n'


### PR DESCRIPTION
## Issue
Closes #5923 video metadata issues

## Notes
- Description & Thumbnail
    - Since these are "musts", we just drop the metadata if the values are not good.
    - For thumbnails, future claims should have correct thumbnails after `5925 Fix thumbnail-checking and block 'data:image'`. For existing claims, we'll just skip the metadata to avoid the crawler error. Users can easily update their thumbnails.
    - For the `OlivOliv` thumbnail url case, I wasn't sure whether to go all out to fetch and verify each thumbnail. I ended up just checking whether it starts with `http(s)`
- Duration
    - There are claims without this field.  Just exclude this field from the metadata (instead of everything entirely) since `duration` is just a "recommended" field.
