### PR TITLE
(redux) doFetchTransactions: bump pageSize to 999999; remove doFetchSupport

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#7e173446838b381491492526ff29ca8312819879",
+    "lbry-redux": "lbryio/lbry-redux#e5c0b5f0a62ce040c683483213c3ec566732f4e5",
     "lbryinc": "lbryio/lbryinc#8f9a58bfc8312a65614fd7327661cdcc502c4e59",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6951,9 +6951,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#7e173446838b381491492526ff29ca8312819879:
+lbry-redux@lbryio/lbry-redux#e5c0b5f0a62ce040c683483213c3ec566732f4e5:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/7e173446838b381491492526ff29ca8312819879"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/e5c0b5f0a62ce040c683483213c3ec566732f4e5"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
## Issue
Follow-up for #5899 Re-add ability to export transactions

## Note
I think this one was missed when merging in 5899. Oddly, I couldn't find the PR for the lbry-redux side in the Closed section. Either I forgot to create the PR, or something went wrong because I re-used an old branch name back then.