### PR TITLE
Mobile: make double-tap match the arrow keys (+/-5s instead of 10s)

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
@@ -13,7 +13,7 @@ const defaults = {
     iOS: false,
   },
   touchControls: {
-    seekSeconds: 10,
+    seekSeconds: 5,
     tapTimeout: 300,
     disableOnEnd: false,
   },


### PR DESCRIPTION
## Issue
One of the items in #5865 [Video shortcut issues](https://github.com/lbryio/lbry-desktop/issues/5865)

This one is not really an issue, but it would be nice to match what the arrow keys are doing. Also, in slower regions, seeking 10s will almost always end up buffering.
