### PR TITLE
fetch ads provider for all homepage videos (but still only show ads for unauth users)

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -122,7 +122,7 @@ function VideoViewer(props: Props) {
   const embedded = useContext(EmbedContext);
   const approvedVideo = Boolean(channelClaimId) && adApprovedChannelIds.includes(channelClaimId);
   const adsEnabled = ENABLE_PREROLL_ADS && !authenticated && !embedded && approvedVideo;
-  const [adUrl, setAdUrl, isFetchingAd] = useGetAds(adsEnabled);
+  const [adUrl, setAdUrl, isFetchingAd] = useGetAds(approvedVideo, adsEnabled);
   /* isLoading was designed to show loading screen on first play press, rather than completely black screen, but
   breaks because some browsers (e.g. Firefox) block autoplay but leave the player.play Promise pending */
   const [isLoading, setIsLoading] = useState(false);

--- a/ui/effects/use-get-ads.js
+++ b/ui/effects/use-get-ads.js
@@ -9,12 +9,14 @@ const PRE_ROLL_ADS_PROVIDER = 'https://tag.targeting.unrulymedia.com/rmp/216276/
 const ADS_CAP_LEVEL = 1 * 60 * 1000;
 const vastClient = new VASTClient(0, ADS_CAP_LEVEL);
 
-export function useGetAds(adsEnabled: boolean): [?string, (?string) => void, boolean] {
+export function useGetAds(approvedVideo: boolean, adsEnabled: boolean): [?string, (?string) => void, boolean] {
   const [isFetching, setIsFetching] = React.useState(true);
   const [adUrl, setAdUrl] = React.useState();
 
+  // Fetch ads for all approved videos, even if we won't show ads to the user
+  // Unruly needs more fetches before they will start returning ads ¯\_(ツ)_/¯
   React.useEffect(() => {
-    if (!adsEnabled) {
+    if (!approvedVideo) {
       setIsFetching(false);
       return;
     }
@@ -37,7 +39,7 @@ export function useGetAds(adsEnabled: boolean): [?string, (?string) => void, boo
           // Dummy video file
           //   const adUrl = 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4';
 
-          if (adUrl) {
+          if (adsEnabled && adUrl) {
             setAdUrl(adUrl);
           }
         }
@@ -47,7 +49,7 @@ export function useGetAds(adsEnabled: boolean): [?string, (?string) => void, boo
       .catch(() => {
         setIsFetching(false);
       });
-  }, [adsEnabled]);
+  }, [approvedVideo, adsEnabled]);
 
   return [adUrl, setAdUrl, isFetching];
 }


### PR DESCRIPTION
Unruly said we weren't sending enough fetches for them to start returning ads. Fetch for all homepages but only show ads for unauth users