### PR TITLE
Show and mark active live channels on homepage

### DIFF
--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -41,6 +41,7 @@ type Props = {
   showMature: boolean,
   showHiddenByUser?: boolean,
   properties?: (Claim) => void,
+  live?: boolean,
 };
 
 function ClaimPreviewTile(props: Props) {
@@ -62,6 +63,7 @@ function ClaimPreviewTile(props: Props) {
     showMature,
     showHiddenByUser,
     properties,
+    live,
   } = props;
   const isRepost = claim && claim.repost_channel_url;
   const shouldFetch = claim === undefined;
@@ -155,12 +157,18 @@ function ClaimPreviewTile(props: Props) {
     );
   }
 
+  let liveProperty = null;
+  if (live === true) {
+    liveProperty = (claim) => <>LIVE</>;
+  }
+
   return (
     <li
       role="link"
       onClick={handleClick}
       className={classnames('card claim-preview--tile', {
         'claim-preview__wrapper--channel': isChannel,
+        'claim-preview__live': live,
       })}
     >
       <NavLink {...navLinkProps}>
@@ -173,7 +181,7 @@ function ClaimPreviewTile(props: Props) {
               </div>
               {/* @endif */}
               <div className="claim-preview__file-property-overlay">
-                <FileProperties uri={uri} small properties={properties} />
+                <FileProperties uri={uri} small properties={liveProperty || properties} />
               </div>
             </React.Fragment>
           )}

--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -1,5 +1,11 @@
 import { connect } from 'react-redux';
-import { doClaimSearch, selectClaimSearchByQuery, selectFetchingClaimSearchByQuery, SETTINGS } from 'lbry-redux';
+import {
+  doClaimSearch,
+  selectClaimSearchByQuery,
+  selectFetchingClaimSearchByQuery,
+  SETTINGS,
+  selectClaimsByUri,
+} from 'lbry-redux';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
 import { makeSelectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
 import { selectModerationBlockList } from 'redux/selectors/comments';
@@ -8,6 +14,7 @@ import ClaimListDiscover from './view';
 
 const select = (state) => ({
   claimSearchByQuery: selectClaimSearchByQuery(state),
+  claimsByUri: selectClaimsByUri(state),
   fetchingClaimSearchByQuery: selectFetchingClaimSearchByQuery(state),
   showNsfw: selectShowMatureContent(state),
   hideReposts: makeSelectClientSetting(SETTINGS.HIDE_REPOSTS)(state),

--- a/ui/effects/use-get-livestreams.js
+++ b/ui/effects/use-get-livestreams.js
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react';
+import { BITWAVE_LIVE_API } from 'constants/livestream';
+
+/**
+ * Gets latest livestream info list. Returns null (instead of a blank object)
+ * when there are no active livestreams.
+ *
+ * @param refreshMs
+ * @returns {{livestreamMap: null, loading: boolean}}
+ */
+export default function useGetLivestreams(refreshMs: number) {
+  const [loading, setLoading] = React.useState(true);
+  const [livestreamMap, setLivestreamMap] = React.useState(null);
+
+  React.useEffect(() => {
+    function checkCurrentLivestreams() {
+      fetch(BITWAVE_LIVE_API)
+        .then((res) => res.json())
+        .then((res) => {
+          setLoading(false);
+          if (!res.data) {
+            setLivestreamMap(null);
+            return;
+          }
+
+          const livestreamMap = res.data.reduce((acc, curr) => {
+            acc[curr.claimId] = curr;
+            return acc;
+          }, {});
+
+          setLivestreamMap(livestreamMap);
+        })
+        .catch((err) => {
+          setLoading(false);
+        });
+    }
+
+    checkCurrentLivestreams();
+
+    if (refreshMs > 0) {
+      let fetchInterval = setInterval(checkCurrentLivestreams, refreshMs);
+      return () => {
+        if (fetchInterval) {
+          clearInterval(fetchInterval);
+        }
+      };
+    }
+  }, []);
+
+  return { livestreamMap, loading };
+}

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -9,6 +9,7 @@ import ClaimTilesDiscover from 'component/claimTilesDiscover';
 import Icon from 'component/common/icon';
 import I18nMessage from 'component/i18nMessage';
 import LbcSymbol from 'component/common/lbc-symbol';
+import useGetLivestreams from 'effects/use-get-livestreams';
 
 type Props = {
   authenticated: boolean,
@@ -24,6 +25,7 @@ function HomePage(props: Props) {
   const showPersonalizedTags = (authenticated || !IS_WEB) && followedTags && followedTags.length > 0;
   const showIndividualTags = showPersonalizedTags && followedTags.length < 5;
   const { default: getHomepage } = homepageData;
+  const { livestreamMap } = useGetLivestreams(0);
 
   const rowData: Array<RowDataItem> = getHomepage(
     authenticated,
@@ -91,7 +93,7 @@ function HomePage(props: Props) {
             </h1>
           )}
 
-          <ClaimTilesDiscover {...options} />
+          <ClaimTilesDiscover {...options} livestreamMap={livestreamMap} />
           {(route || link) && (
             <Button
               className="claim-grid__title--secondary"

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -93,7 +93,7 @@ function HomePage(props: Props) {
             </h1>
           )}
 
-          <ClaimTilesDiscover {...options} livestreamMap={livestreamMap} />
+          <ClaimTilesDiscover {...options} liveLivestreamsFirst livestreamMap={livestreamMap} />
           {(route || link) && (
             <Button
               className="claim-grid__title--secondary"

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -621,6 +621,19 @@
   }
 }
 
+.claim-preview__live {
+  .claim-preview__file-property-overlay {
+    opacity: 1; // The original 0.7 is not visible over bright thumbnails
+    color: var(--color-white-alt);
+    background-color: var(--color-live);
+  }
+
+  .file-properties {
+    font-weight: var(--font-weight-bold);
+    margin-top: 2px; // Even out bottom spacing due to all caps "LIVE".
+  }
+}
+
 .claim-link {
   @include font-sans;
   position: relative;

--- a/ui/scss/init/_color.scss
+++ b/ui/scss/init/_color.scss
@@ -13,6 +13,7 @@
   --color-cost: #ffd580;
   --color-focus: #93cff2;
   --color-notification: #f02849;
+  --color-live: #cc190f;
 
   --color-black: #111;
   --color-white: #fdfdfd;


### PR DESCRIPTION
## Issue
Closes #5841: [Show active live channels on homepage + categories](https://github.com/lbryio/lbry-desktop/issues/5841)

## Screenshots
- Original:
    - ![image](https://user-images.githubusercontent.com/64950861/116407360-47d0e300-a864-11eb-96f0-d640a09bd6fe.png)
- New:
    - ![image](https://user-images.githubusercontent.com/64950861/116407435-5a4b1c80-a864-11eb-9c58-eba2c67d0026.png)
- Extra (lbry tv):
    - ![image](https://user-images.githubusercontent.com/64950861/116408007-eeb57f00-a864-11eb-9e8c-2240c1254f45.png)

## Discussion
1. I understand there is already an "eye" icon version of the live marker.  We can change to that if that's is more desired, but I prefer "Live" as it is less cluttering without the numerical value.

## Changes
See commit messages for walk through.