### PR TITLE
Livestream comment delete/edit fix

### DIFF
--- a/ui/component/commentMenuList/view.jsx
+++ b/ui/component/commentMenuList/view.jsx
@@ -24,6 +24,7 @@ type Props = {
   commentModBlock: (string) => void,
   playingUri: ?PlayingUri,
   disableEdit?: boolean,
+  disableRemove?: boolean,
 };
 
 function CommentMenuList(props: Props) {
@@ -45,6 +46,7 @@ function CommentMenuList(props: Props) {
     commentModBlock,
     playingUri,
     disableEdit,
+    disableRemove,
   } = props;
   const activeChannelIsCreator = activeChannelClaim && activeChannelClaim.permanent_url === contentChannelPermanentUrl;
 
@@ -83,7 +85,8 @@ function CommentMenuList(props: Props) {
         </MenuItem>
       )}
 
-      {activeChannelClaim &&
+      {!disableRemove &&
+        activeChannelClaim &&
         (activeChannelClaim.permanent_url === authorUri ||
           activeChannelClaim.permanent_url === contentChannelPermanentUrl) && (
           <MenuItem className="comment__menu-option" onSelect={handleDeleteComment}>

--- a/ui/component/commentMenuList/view.jsx
+++ b/ui/component/commentMenuList/view.jsx
@@ -23,6 +23,7 @@ type Props = {
   isTopLevel: boolean,
   commentModBlock: (string) => void,
   playingUri: ?PlayingUri,
+  disableEdit?: boolean,
 };
 
 function CommentMenuList(props: Props) {
@@ -43,6 +44,7 @@ function CommentMenuList(props: Props) {
     fetchComments,
     commentModBlock,
     playingUri,
+    disableEdit,
   } = props;
   const activeChannelIsCreator = activeChannelClaim && activeChannelClaim.permanent_url === contentChannelPermanentUrl;
 
@@ -92,7 +94,7 @@ function CommentMenuList(props: Props) {
           </MenuItem>
         )}
 
-      {commentIsMine && activeChannelClaim && activeChannelClaim.permanent_url === authorUri && (
+      {commentIsMine && activeChannelClaim && activeChannelClaim.permanent_url === authorUri && !disableEdit && (
         <MenuItem className="comment__menu-option menu__link" onSelect={handleEditComment}>
           <Icon aria-hidden icon={ICONS.EDIT} />
           {__('Edit')}

--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -74,6 +74,7 @@ function Comment(props: Props) {
             authorUri={authorUri}
             commentIsMine={commentIsMine}
             disableEdit
+            disableRemove={supportAmount > 0}
           />
         </Menu>
       </div>

--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -68,7 +68,13 @@ function Comment(props: Props) {
               icon={ICONS.MORE_VERTICAL}
             />
           </MenuButton>
-          <CommentMenuList uri={uri} commentId={commentId} authorUri={authorUri} commentIsMine={commentIsMine} />
+          <CommentMenuList
+            uri={uri}
+            commentId={commentId}
+            authorUri={authorUri}
+            commentIsMine={commentIsMine}
+            disableEdit
+          />
         </Menu>
       </div>
     </li>

--- a/ui/component/livestreamComments/index.js
+++ b/ui/component/livestreamComments/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri } from 'lbry-redux';
+import { makeSelectClaimForUri, selectMyChannelClaims } from 'lbry-redux';
 import { doCommentSocketConnect, doCommentSocketDisconnect } from 'redux/actions/websocket';
 import { doCommentList, doSuperChatList } from 'redux/actions/comments';
 import {
@@ -16,6 +16,7 @@ const select = (state, props) => ({
   fetchingComments: selectIsFetchingComments(state),
   superChats: makeSelectSuperChatsForUri(props.uri)(state),
   superChatsTotalAmount: makeSelectSuperChatTotalAmountForUri(props.uri)(state),
+  myChannels: selectMyChannelClaims(state),
 });
 
 export default connect(select, {

--- a/ui/component/livestreamComments/view.jsx
+++ b/ui/component/livestreamComments/view.jsx
@@ -23,6 +23,7 @@ type Props = {
   doSuperChatList: (string) => void,
   superChats: Array<Comment>,
   superChatsTotalAmount: number,
+  myChannels: ?Array<ChannelClaim>,
 };
 
 const VIEW_MODE_CHAT = 'view_chat';
@@ -41,6 +42,7 @@ export default function LivestreamComments(props: Props) {
     doSuperChatList,
     superChats,
     superChatsTotalAmount,
+    myChannels,
   } = props;
   const commentsRef = React.createRef();
   const hasScrolledComments = React.useRef();
@@ -49,6 +51,18 @@ export default function LivestreamComments(props: Props) {
   const claimId = claim && claim.claim_id;
   const commentsLength = comments && comments.length;
   const commentsToDisplay = viewMode === VIEW_MODE_CHAT ? comments : superChats;
+
+  // todo: implement comment_list --mine in SDK so redux can grab with selectCommentIsMine
+  function isMyComment(channelId: string) {
+    if (myChannels != null && channelId != null) {
+      for (let i = 0; i < myChannels.length; i++) {
+        if (myChannels[i].claim_id === channelId) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   React.useEffect(() => {
     if (claimId) {
@@ -177,6 +191,7 @@ export default function LivestreamComments(props: Props) {
                   commentId={comment.comment_id}
                   message={comment.comment}
                   supportAmount={comment.support_amount}
+                  commentIsMine={comment.channel_id && isMyComment(comment.channel_id)}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Issue
- Closes #5832: can't remove own comments in live stream mode (if you have multiple channels?)
    - Looks like it was just missing `commentIsMine` for the new component
    - Indirectly fixes "Block | Mute" appearing for own comment.
- Disable editing livestream comments.
    - It doesn't do anything at the moment anyway.
- Disable deleting hyperchats 
    - The "total tipped" will get deducted when hyperchats are deleted, which doesn't make sense (doesn't reflect actual total that the creator received).