### PR TITLE
Restore lost languages

### DIFF
--- a/ui/constants/supported_browser_languages.js
+++ b/ui/constants/supported_browser_languages.js
@@ -1,4 +1,5 @@
 const SUPPORTED_BROWSER_LANGUAGES = {
+  af: 'af',
   en: 'en',
   da: 'da',
   'zh-CN': 'zh-Hans',
@@ -9,11 +10,13 @@ const SUPPORTED_BROWSER_LANGUAGES = {
   nl: 'nl',
   no: 'no',
   fi: 'fi',
+  fil: 'fil',
   fr: 'fr',
   de: 'de',
   gu: 'gu',
   hi: 'hi',
   id: 'id',
+  ja: 'ja',
   jv: 'jv',
   it: 'it',
   ms: 'ms',
@@ -27,6 +30,7 @@ const SUPPORTED_BROWSER_LANGUAGES = {
   ru: 'ru',
   sr: 'sr',
   sk: 'sk',
+  th: 'th',
   ur: 'ur',
   ca: 'ca',
   es: 'es',
@@ -35,6 +39,7 @@ const SUPPORTED_BROWSER_LANGUAGES = {
   cs: 'cs',
   kn: 'kn',
   uk: 'uk',
+  vi: 'vi',
 };
 
 export default SUPPORTED_BROWSER_LANGUAGES;

--- a/ui/constants/supported_languages.js
+++ b/ui/constants/supported_languages.js
@@ -1,6 +1,7 @@
 import LANGUAGES from './languages';
 // supported_browser_languages
 const SUPPORTED_LANGUAGES = {
+  af: LANGUAGES.af[1],
   en: LANGUAGES.en[1],
   da: LANGUAGES.da[1],
   'zh-Hans': LANGUAGES['zh-Hans'][1],
@@ -9,11 +10,13 @@ const SUPPORTED_LANGUAGES = {
   nl: LANGUAGES.nl[1],
   no: LANGUAGES.no[1],
   fi: LANGUAGES.fi[1],
+  fil: LANGUAGES.fil[1],
   fr: LANGUAGES.fr[1],
   de: LANGUAGES.de[1],
   gu: LANGUAGES.gu[1],
   hi: LANGUAGES.hi[1],
   id: LANGUAGES.id[1],
+  ja: LANGUAGES.ja[1],
   jv: LANGUAGES.jv[1],
   it: LANGUAGES.it[1],
   ms: LANGUAGES.ms[1],
@@ -27,6 +30,7 @@ const SUPPORTED_LANGUAGES = {
   ru: LANGUAGES.ru[1],
   sr: LANGUAGES.sr[1],
   sk: LANGUAGES.sk[1],
+  th: LANGUAGES.th[1],
   ur: LANGUAGES.ur[1],
   ca: LANGUAGES.ca[1],
   es: LANGUAGES.es[1],
@@ -35,6 +39,7 @@ const SUPPORTED_LANGUAGES = {
   cs: LANGUAGES.cs[1],
   kn: LANGUAGES.kn[1],
   uk: LANGUAGES.uk[1],
+  vi: LANGUAGES.vi[1],
 };
 
 // Properties: language code (e.g. 'ja')


### PR DESCRIPTION
While looking at the next RC, I noticed the new languages were lost. I recall the new language PR included some refactoring which had to be reverted due to some webpack issue.

Re-add those languages in the old (non-refactored) method.
