### PR TITLE
Fix invisible snack in Odysee Light Theme

### DIFF
--- a/ui/scss/themes/light.scss
+++ b/ui/scss/themes/light.scss
@@ -138,7 +138,6 @@
   --color-view-icon: var(--color-secondary);
 
   // Snack
-  --color-snack-bg: var(--color-success);
   --color-snack: var(--color-white);
   --color-snack-bg-error: var(--color-danger);
   --color-snack-upgrade: var(--color-tertiary);


### PR DESCRIPTION
The snack bar on Odysee Light is currently invisible due to the undefined `--color-success`.  
Followed `master`'s version of using `--color-primary` from the base theme for Light mode.