### PR TITLE
Swap: populate 'status' from 'btc/swap' response instead of waiting for first websocket input.

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1786,7 +1786,7 @@
   "Remove %address%?": "Remove %address%?",
   "This process cannot be reversed.": "This process cannot be reversed.",
   "View transaction": "View transaction",
-  "Send (USE COPY BUTTON, ENSURE EXACT AMOUNT IS SENT!)": "Send (USE COPY BUTTON, ENSURE EXACT AMOUNT IS SENT!)",
+  "Use the copy button to ensure the EXACT amount is sent!": "Use the copy button to ensure the EXACT amount is sent!",
   "Amount copied.": "Amount copied.",
   "Copy transaction ID": "Copy transaction ID",
   "Transaction ID copied.": "Transaction ID copied.",

--- a/ui/component/walletSwap/view.jsx
+++ b/ui/component/walletSwap/view.jsx
@@ -301,16 +301,25 @@ function WalletSwap(props: Props) {
         const btcAmount = response.Charge.data.pricing['bitcoin'].amount;
         const rate = response.Exchange.rate;
 
-        const swap = {
+        const timeline = response.Charge.data.timeline;
+        const lastTimeline = timeline[timeline.length - 1];
+
+        const newSwap = {
           chargeCode: response.Exchange.charge_code,
           coins: Object.keys(response.Charge.data.addresses),
           sendAddresses: response.Charge.data.addresses,
           sendAmounts: response.Charge.data.pricing,
           lbcAmount: (btcAmount * BTC_SATOSHIS) / rate,
+          status: {
+            status: lastTimeline.status,
+            receiptCurrency: lastTimeline.payment.value.currency,
+            receiptTxid: lastTimeline.payment.transaction_id,
+            lbcTxid: response.Exchange.lbc_txid || '',
+          },
         };
 
-        setSwap({ ...swap });
-        addCoinSwap({ ...swap });
+        setSwap({ ...newSwap });
+        addCoinSwap({ ...newSwap });
       })
       .catch((err) => {
         setNag({ msg: err === INTERNAL_APIS_DOWN ? NAG_SWAP_CALL_FAILED : err.message, type: 'error' });

--- a/ui/component/walletSwap/view.jsx
+++ b/ui/component/walletSwap/view.jsx
@@ -541,7 +541,7 @@ function WalletSwap(props: Props) {
               {getGap()}
             </>
           )}
-          <div className="confirm__label">{__('Send (USE COPY BUTTON, ENSURE EXACT AMOUNT IS SENT!)')}</div>
+          <div className="confirm__label">{__('Send')}</div>
           <CopyableText
             primaryButton
             copyable={getCoinSendAmountStr(coin)}
@@ -554,6 +554,7 @@ function WalletSwap(props: Props) {
               }
             }}
           />
+          <div className="help">{__('Use the copy button to ensure the EXACT amount is sent!')}</div>
           {getGap()}
           <div className="confirm__label">{__('To')}</div>
           <CopyableText primaryButton copyable={getCoinAddress(coin)} snackMessage={__('Address copied.')} />


### PR DESCRIPTION
## Issue
Closes #5975: [swap stop at processing even though response comes through](https://github.com/lbryio/lbry-desktop/issues/5975)

## Notes
Occasionally, the first websocket message doesn't come through (seems like the commerce didn't send?). There's really no need to wait for one more 'status=NEW' message to ensure the right data is being populated (was being over-cautious to get the amount right).