### PR TITLE
Livestream-only query cleanup.

### DIFF
--- a/ui/component/claimTilesDiscover/view.jsx
+++ b/ui/component/claimTilesDiscover/view.jsx
@@ -6,14 +6,7 @@ import React from 'react';
 import { createNormalizedClaimSearchKey, MATURE_TAGS } from 'lbry-redux';
 import ClaimPreviewTile from 'component/claimPreviewTile';
 import { useHistory } from 'react-router';
-
-const getNoSourceOptions = (options) => {
-  const newOptions = Object.assign({}, options);
-  delete newOptions.has_source;
-  delete newOptions.stream_types;
-  newOptions.has_no_source = true;
-  return newOptions;
-};
+import { getLivestreamOnlyOptions } from 'util/search';
 
 /**
  * Updates 'uris' by adding and/or moving active livestreams to the front of
@@ -68,7 +61,7 @@ export function prioritizeActiveLivestreams(
 
   // 2. Now, repeat on the secondary search.
   if (options) {
-    const livestreamsOnlySearchCacheQuery = createNormalizedClaimSearchKey(getNoSourceOptions(options));
+    const livestreamsOnlySearchCacheQuery = createNormalizedClaimSearchKey(getLivestreamOnlyOptions(options));
     const livestreamsOnlyUris = claimSearchByQuery[livestreamsOnlySearchCacheQuery];
     if (livestreamsOnlyUris) {
       livestreamsOnlyUris.forEach((uri) => {
@@ -254,7 +247,7 @@ function ClaimTilesDiscover(props: Props) {
       doClaimSearch(searchOptions);
 
       if (liveLivestreamsFirst) {
-        doClaimSearch(getNoSourceOptions(searchOptions));
+        doClaimSearch(getLivestreamOnlyOptions(searchOptions));
       }
     }
   }, [doClaimSearch, shouldPerformSearch, optionsStringForEffect, liveLivestreamsFirst]);

--- a/ui/util/search.js
+++ b/ui/util/search.js
@@ -17,3 +17,19 @@ export function createNormalizedSearchKey(query: string) {
   }
   return normalizedQuery;
 }
+
+/**
+ * Returns the "livestream only" version of the given 'options'.
+ *
+ * Currently, the 'has_source' attribute is being used to identify livestreams.
+ *
+ * @param options
+ * @returns {*}
+ */
+export function getLivestreamOnlyOptions(options: any) {
+  const newOptions = Object.assign({}, options);
+  delete newOptions.has_source;
+  delete newOptions.stream_types;
+  newOptions.has_no_source = true;
+  return newOptions;
+}


### PR DESCRIPTION
This completes the change in c24c016e, covering ClaimListDiscover as well, in case it changes again in the future.
No functional change, just refactored the function so that both Tile and List uses the same code. 