### PR TITLE
[+redux] Define default value for 'thumbnailError'

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#41ef1117e55231ab70fbda18b77c674d62ea9578",
+    "lbry-redux": "lbryio/lbry-redux#3b853b6ddd1e55ca8e9f184e0d8c2702b68ddb3c",
     "lbryinc": "lbryio/lbryinc#8f9a58bfc8312a65614fd7327661cdcc502c4e59",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#3b853b6ddd1e55ca8e9f184e0d8c2702b68ddb3c",
+    "lbry-redux": "lbryio/lbry-redux#6fc11454eb1b8f9e323c234669880721f12664ee",
     "lbryinc": "lbryio/lbryinc#8f9a58bfc8312a65614fd7327661cdcc502c4e59",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6951,9 +6951,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#41ef1117e55231ab70fbda18b77c674d62ea9578:
+lbry-redux@lbryio/lbry-redux#3b853b6ddd1e55ca8e9f184e0d8c2702b68ddb3c:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/41ef1117e55231ab70fbda18b77c674d62ea9578"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/3b853b6ddd1e55ca8e9f184e0d8c2702b68ddb3c"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6951,9 +6951,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#3b853b6ddd1e55ca8e9f184e0d8c2702b68ddb3c:
+lbry-redux@lbryio/lbry-redux#6fc11454eb1b8f9e323c234669880721f12664ee:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/3b853b6ddd1e55ca8e9f184e0d8c2702b68ddb3c"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/6fc11454eb1b8f9e323c234669880721f12664ee"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
## Issue
Closes #6044 "thumbnail is invalid" not reset with new thumbnail upload 
Requires lbry-redux update.

## Change
Defining a default value will cover both CLEAR_PUBLISH and DO_PREPARE_EDIT