### PR TITLE
Posts: restore "Tip unlock | Claim details" component

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1867,6 +1867,7 @@
   "Help LBRY Save Crypto": "Help LBRY Save Crypto",
   "The US government is attempting to destroy the cryptocurrency industry. Can you help?": "The US government is attempting to destroy the cryptocurrency industry. Can you help?",
   "Learn more and sign petition": "Learn more and sign petition",
+  "View claim details": "View claim details",
   "Publishing...": "Publishing...",
   "Collection": "Collection",
   "Fetch transaction data for export": "Fetch transaction data for export",

--- a/ui/component/common/icon-custom.jsx
+++ b/ui/component/common/icon-custom.jsx
@@ -385,6 +385,13 @@ export const icons = {
       <line x1="12" y1="16" x2="12" y2="16" />
     </g>
   ),
+  [ICONS.INFO]: buildIcon(
+    <g>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="8" />
+      <line x1="12" y1="12" x2="12" y2="16" />
+    </g>
+  ),
   [ICONS.UNLOCK]: buildIcon(
     <g>
       <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />

--- a/ui/component/postViewer/index.js
+++ b/ui/component/postViewer/index.js
@@ -1,9 +1,13 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri } from 'lbry-redux';
+import { makeSelectClaimForUri, makeSelectClaimIsMine } from 'lbry-redux';
 import PostViewer from './view';
+import { doOpenModal } from 'redux/actions/app';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
+  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
 });
 
-export default connect(select)(PostViewer);
+export default connect(select, {
+  doOpenModal,
+})(PostViewer);

--- a/ui/constants/icons.js
+++ b/ui/constants/icons.js
@@ -6,6 +6,7 @@
 export const REWARDS = 'Award';
 export const LOCAL = 'Folder';
 export const ALERT = 'AlertCircle';
+export const INFO = 'InfoCircle';
 export const COPY = 'Clipboard';
 export const ARROW_LEFT = 'ChevronLeft';
 export const ARROW_RIGHT = 'ChevronRight';

--- a/ui/scss/component/_post.scss
+++ b/ui/scss/component/_post.scss
@@ -70,6 +70,32 @@
   }
 }
 
+.post__info--expanded {
+  margin-bottom: var(--spacing-s);
+}
+
+.post__info--grouped {
+  .button--link {
+    margin-right: var(--spacing-s);
+  }
+
+  .dim {
+    color: var(--color-text-subtitle);
+    stroke: var(--color-text-subtitle);
+  }
+}
+
+.post__info--credit-details {
+  @include font-sans;
+  margin-top: var(--spacing-l);
+  margin-bottom: var(--spacing-l);
+  width: 75%;
+
+  .tag {
+    margin-top: 0;
+  }
+}
+
 .post__date {
   display: block;
   margin-top: var(--spacing-s);


### PR DESCRIPTION
## Issue
Closes #5882: `tip unlock + claim id detials missing from markdown posts view`

## Test
kp.odysee.com

## Notes
The easiest solution would be to put `FileDescription` into posts, but I think that goes against the clean up of the Post layout, where the focus should be on the content. The faded style of the File Details section will be too distracting, plus we don't want the File Description anyway.

Fixed by:
- Make the existing "LBC amount" clickable to show credit details. An additional padlock will appear to the right if the content is yours and you have tips to unlock.
- Add an "info" icon to the left to show file details.

These "link" buttons are usually lit, but I dimmed it in this case to make them stand out less. Again, focusing on Post content instead of buttons.

![image](https://user-images.githubusercontent.com/64950861/117912310-dbe58480-b311-11eb-879e-5d1176a99183.png)

