### PR TITLE
Notification: further handle "missed_out" + other tweaks

### DIFF
--- a/ui/component/notification/view.jsx
+++ b/ui/component/notification/view.jsx
@@ -42,6 +42,9 @@ export default function Notification(props: Props) {
     case NOTIFICATIONS.DAILY_WATCH_REMIND:
       notificationTarget = `/$/${PAGES.CHANNELS_FOLLOWING}`;
       break;
+    case NOTIFICATIONS.MISSED_OUT:
+      notificationTarget = `/$/${PAGES.REWARDS_VERIFY}?redirect=/$/${PAGES.REWARDS}`;
+      break;
     default:
       notificationTarget = notification_parameters.device.target;
   }
@@ -80,6 +83,7 @@ export default function Notification(props: Props) {
       break;
     case NOTIFICATIONS.DAILY_WATCH_AVAILABLE:
     case NOTIFICATIONS.DAILY_WATCH_REMIND:
+    case NOTIFICATIONS.MISSED_OUT:
       icon = <Icon icon={ICONS.LBC} sectionIcon />;
       break;
     default:

--- a/ui/component/notification/view.jsx
+++ b/ui/component/notification/view.jsx
@@ -145,11 +145,16 @@ export default function Notification(props: Props) {
                   <div className="notification__title">
                     <LbcMessage>{notification_parameters.device.title}</LbcMessage>
                   </div>
-                  <div className="notification__text mobile-hidden">{commentText}</div>
+                  <div title={commentText} className="notification__text mobile-hidden">
+                    {commentText}
+                  </div>
                 </>
               ) : (
                 <>
-                  <div className="notification__text">
+                  <div
+                    title={notification_parameters.device.text.replace(/\sLBC/g, ' Credits')}
+                    className="notification__text"
+                  >
                     <LbcMessage>{notification_parameters.device.text}</LbcMessage>
                   </div>
                 </>

--- a/ui/constants/notifications.js
+++ b/ui/constants/notifications.js
@@ -1,6 +1,7 @@
 export const NOTIFICATION_CREATOR_SUBSCRIBER = 'creator_subscriber';
 export const NOTIFICATION_COMMENT = 'comment';
 export const NOTIFICATION_REPLY = 'comment-reply';
+export const MISSED_OUT = 'missed_out';
 export const DAILY_WATCH_AVAILABLE = 'daily_watch_available';
 export const DAILY_WATCH_REMIND = 'daily_watch_remind';
 export const NEW_CONTENT = 'new_content';


### PR DESCRIPTION
## Issue
Closes #6021: `Notifications: Missed Out`

## Test
kp.odysee.com

![image](https://user-images.githubusercontent.com/64950861/117950379-b4101400-b345-11eb-850c-8489f13dde9d.png)

## Changes
See full commit messages for details.

Addition notes:  the tooltip change doesn't really help Mobile, but maybe we'll add "press-and-hold" for tooltips one day.