### PR TITLE
Force video autoplay when a timestamp is present in URL

### DIFF
--- a/ui/component/fileRenderInitiator/view.jsx
+++ b/ui/component/fileRenderInitiator/view.jsx
@@ -46,7 +46,6 @@ export default function FileRenderInitiator(props: Props) {
     history,
     location,
     thumbnail,
-    autoplay,
     renderMode,
     hasCostInfo,
     costInfo,
@@ -54,6 +53,16 @@ export default function FileRenderInitiator(props: Props) {
     authenticated,
     videoTheaterMode,
   } = props;
+
+  // force autoplay if a timestamp is present
+  let autoplay = props.autoplay;
+  // get current url
+  const url = window.location.href;
+  // check if there is a time parameter, if so force autoplay
+  if (url.indexOf('t=')) {
+    autoplay = true;
+  }
+
   const cost = costInfo && costInfo.cost;
   const isFree = hasCostInfo && cost === 0;
   const fileStatus = fileInfo && fileInfo.status;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [X] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #5309 

## What is the current behavior?
A timestamped video will not autoplay if autoplay is turned off

## What is the new behavior?
Even if autoplay is turned off for the user, the video will autoplay if a timestamp is present

## Other information

I don't know if this is the best design in the world, perhaps it would be more appropriate have a React component hook into the Prop value to automatically pre-empt and change it, but it's a simple and working solution, really I'd like to talk to someone who is more familiar with the codebase and ask for their take but I can confirm this as a working solution.