### PR TITLE
Fix "invalid thumbnail" error behaviour

### DIFF
--- a/ui/component/publishForm/view.jsx
+++ b/ui/component/publishForm/view.jsx
@@ -230,7 +230,8 @@ function PublishForm(props: Props) {
     !bidError &&
     !emptyPostError &&
     !thumbnailError &&
-    !(uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS);
+    !(uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS) &&
+    !(uploadThumbnailStatus === THUMBNAIL_STATUSES.READY);
 
   const isOverwritingExistingClaim = !editingURI && myClaimForUri;
 

--- a/ui/component/publishFormErrors/view.jsx
+++ b/ui/component/publishFormErrors/view.jsx
@@ -35,6 +35,7 @@ function PublishFormErrors(props: Props) {
   // If there is an error it will be presented as an inline error as well
 
   const isUploadingThumbnail = uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS;
+  const isReadyToSelectThumbnail = uploadThumbnailStatus === THUMBNAIL_STATUSES.READY;
 
   return (
     <div className="error__text">
@@ -45,7 +46,7 @@ function PublishFormErrors(props: Props) {
       {!bid && <div>{__('A deposit amount is required')}</div>}
       {bidError && <div>{__('Please check your deposit amount.')}</div>}
       {isUploadingThumbnail && <div>{__('Please wait for thumbnail to finish uploading')}</div>}
-      {!isUploadingThumbnail && !thumbnail && (
+      {!isUploadingThumbnail && (!thumbnail || isReadyToSelectThumbnail) && (
         <div>{__('A thumbnail is required. Please upload or provide an image URL above.')}</div>
       )}
       {thumbnailError && <div>{__('Thumbnail is invalid.')}</div>}

--- a/ui/component/selectThumbnail/view.jsx
+++ b/ui/component/selectThumbnail/view.jsx
@@ -112,7 +112,9 @@ class SelectThumbnail extends React.PureComponent<Props> {
                 <Button
                   button="link"
                   label={__('Use thumbnail upload tool')}
-                  onClick={() => updatePublishForm({ uploadThumbnailStatus: THUMBNAIL_STATUSES.READY })}
+                  onClick={() =>
+                    updatePublishForm({ uploadThumbnailStatus: THUMBNAIL_STATUSES.READY, thumbnailError: false })
+                  }
                 />
               </div>
             </div>


### PR DESCRIPTION
	modified:   selectThumbnail/view.jsx
	Fix issue with "invalid thumbnail"
	
	
	modified:   publishForm/view.jsx
	Prevent upload of publish when in thumbnail upload tool. As there isn't thumbnail yet.


	modified:   publishFormErrors/view.jsx
	Show "A thumbnail is required. Please upload or provide an image
	URL above." error when user is in thumbnail upload tool.

	
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:
#6044 

## What is the current behavior?
When entering invalid URL for thumbnail, an "Invalid thumbnail" error appears.
"Invalid thumbnail" error didn't get cleared when **a valid thumbnail was uploaded**, which prevented the upload of the publish.
Only way to clear error was to clear thumbnail URL or enter a valid URL to an image.

## What is the new behavior?
When entering invalid URL for thumbnail, an "Invalid thumbnail" error appears.
Error is cleared when user switches to "thumbnail upload tool".  
"A thumbnail is required...." error is shown instead, until thumbnail is successfully uploaded, or if user switches back to entering URL for thumbnail.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
