### PR TITLE
Improve logic for own comments showing first

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -35,7 +35,7 @@ type Props = {
   toast: (string) => void,
   claimIsMine: boolean,
   sendTip: ({}, (any) => void, (any) => void) => void,
-  setjustCommented: (boolean) => void,
+  justCommented: Array<string>,
 };
 
 export function CommentCreate(props: Props) {
@@ -54,7 +54,7 @@ export function CommentCreate(props: Props) {
     toast,
     claimIsMine,
     sendTip,
-    setjustCommented,
+    justCommented,
   } = props;
   const buttonref: ElementRef<any> = React.useRef();
   const {
@@ -153,7 +153,7 @@ export function CommentCreate(props: Props) {
           setLastCommentTime(Date.now());
           setIsReviewingSupportComment(false);
           setIsSupportComment(false);
-          setjustCommented(true);
+          justCommented.push(res.comment_id);
 
           if (onDoneReplying) {
             onDoneReplying();

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -58,7 +58,7 @@ function CommentList(props: Props) {
   const [readyToDisplayComments, setReadyToDisplayComments] = React.useState(
     Boolean(reactionsById) || !ENABLE_COMMENT_REACTIONS
   );
-  const [justCommented, setjustCommented] = React.useState(false);
+  const [justCommented] = React.useState([]);
   const linkedCommentId = linkedComment && linkedComment.comment_id;
   const hasNoComments = !totalComments;
   const moreBelow = totalComments - end > 0;
@@ -210,7 +210,7 @@ function CommentList(props: Props) {
       }
       actions={
         <>
-          <CommentCreate uri={uri} setjustCommented={setjustCommented} />
+          <CommentCreate uri={uri} justCommented={justCommented} />
 
           {!isFetchingComments && hasNoComments && (
             <Empty padded text={__('That was pretty deep. What do you think?')} />

--- a/ui/util/comments.js
+++ b/ui/util/comments.js
@@ -9,8 +9,8 @@ type SortProps = {
   comments: ?Array<Comment>,
   reactionsById: {},
   sort: string,
-  isMyComment: string => boolean,
-  justCommented: boolean,
+  isMyComment: (string) => boolean,
+  justCommented: Array<string>,
 };
 
 export function sortComments(sortProps: SortProps): Array<Comment> {
@@ -29,12 +29,12 @@ export function sortComments(sortProps: SortProps): Array<Comment> {
 
     const aIsMine = isMyComment(a.channel_id);
     const bIsMine = isMyComment(b.channel_id);
-    const aIsMyRecent = a.comment_id === comments[0].comment_id;
-    const bIsMyRecent = b.comment_id === comments[0].comment_id;
+    const aIsMyRecent = justCommented.includes(a.comment_id);
+    const bIsMyRecent = justCommented.includes(b.comment_id);
 
-    if (aIsMine && justCommented && aIsMyRecent) {
+    if (aIsMine && justCommented.length && aIsMyRecent) {
       return -1;
-    } else if (bIsMine && justCommented && bIsMyRecent) {
+    } else if (bIsMine && justCommented.length && bIsMyRecent) {
       return 1;
     }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: A fix from (#5939)

## What is the current behavior?

I just noticed when you add multiple comments they replace each other at the top:

![](https://i.postimg.cc/rsx2xkR9/image.png) ![](https://i.postimg.cc/XYV6Gtjw/image.png)

## What is the new behavior?

Improved the logic so that all show up:

![](https://i.postimg.cc/BbgNdYr0/image.png)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
