### PR TITLE
ChannelThumbnail fixes

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -21,6 +21,7 @@ type Props = {
   showDelayedMessage?: boolean,
   hideStakedIndicator?: boolean,
   xsmall?: boolean,
+  noOptimization?: boolean,
 };
 
 function ChannelThumbnail(props: Props) {
@@ -38,12 +39,14 @@ function ChannelThumbnail(props: Props) {
     isResolving,
     showDelayedMessage = false,
     hideStakedIndicator = false,
+    noOptimization,
   } = props;
   const [thumbError, setThumbError] = React.useState(false);
   const shouldResolve = claim === undefined;
   const thumbnail = rawThumbnail && rawThumbnail.trim().replace(/^http:\/\//i, 'https://');
   const thumbnailPreview = rawThumbnailPreview && rawThumbnailPreview.trim().replace(/^http:\/\//i, 'https://');
   const channelThumbnail = thumbnail || thumbnailPreview;
+  const isGif = channelThumbnail && channelThumbnail.endsWith('gif');
   const showThumb = (!obscure && !!thumbnail) || thumbnailPreview;
   // Generate a random color class based on the first letter of the channel name
   const { channelName } = parseURI(uri);
@@ -62,7 +65,7 @@ function ChannelThumbnail(props: Props) {
     }
   }, [doResolveUri, shouldResolve, uri]);
 
-  if (channelThumbnail && channelThumbnail.endsWith('gif') && !allowGifs) {
+  if (isGif && !allowGifs) {
     return (
       <FreezeframeWrapper src={channelThumbnail} className={classnames('channel-thumbnail', className)}>
         {!hideStakedIndicator && <ChannelStakedIndicator uri={uri} claim={claim} />}
@@ -72,8 +75,8 @@ function ChannelThumbnail(props: Props) {
 
   let url = channelThumbnail;
   // @if TARGET='web'
-  // Pass image urls through a compression proxy
-  if (thumbnail) {
+  // Pass image urls through a compression proxy, except for GIFs.
+  if (thumbnail && !noOptimization && !(isGif && allowGifs)) {
     url = getThumbnailCdnUrl({ thumbnail });
   }
   // @endif

--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -67,7 +67,7 @@ function ChannelThumbnail(props: Props) {
     }
   }, [doResolveUri, shouldResolve, uri]);
 
-  useLazyLoading(thumbnailRef, 0.25, [showThumb]);
+  useLazyLoading(thumbnailRef, 0.25, [showThumb, thumbError, channelThumbnail]);
 
   if (isGif && !allowGifs) {
     return (
@@ -99,7 +99,7 @@ function ChannelThumbnail(props: Props) {
           ref={thumbnailRef}
           alt={__('Channel profile picture')}
           className="channel-thumbnail__default"
-          src={!thumbError && url ? url : Gerbil}
+          data-src={!thumbError && url ? url : Gerbil}
           onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
         />
       )}
@@ -112,7 +112,7 @@ function ChannelThumbnail(props: Props) {
               ref={thumbnailRef}
               alt={__('Channel profile picture')}
               className="channel-thumbnail__custom"
-              src={!thumbError && url ? url : Gerbil}
+              data-src={!thumbError && url ? url : Gerbil}
               onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
             />
           )}

--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import Gerbil from './gerbil.png';
 import FreezeframeWrapper from 'component/fileThumbnail/FreezeframeWrapper';
 import ChannelStakedIndicator from 'component/channelStakedIndicator';
+import { getThumbnailCdnUrl } from 'util/thumbnail';
 
 type Props = {
   thumbnail: ?string,
@@ -69,6 +70,14 @@ function ChannelThumbnail(props: Props) {
     );
   }
 
+  let url = channelThumbnail;
+  // @if TARGET='web'
+  // Pass image urls through a compression proxy
+  if (thumbnail) {
+    url = getThumbnailCdnUrl({ thumbnail });
+  }
+  // @endif
+
   return (
     <div
       className={classnames('channel-thumbnail', className, {
@@ -82,7 +91,7 @@ function ChannelThumbnail(props: Props) {
         <img
           alt={__('Channel profile picture')}
           className="channel-thumbnail__default"
-          src={!thumbError && thumbnailPreview ? thumbnailPreview : Gerbil}
+          src={!thumbError && url ? url : Gerbil}
           onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
         />
       )}
@@ -94,7 +103,7 @@ function ChannelThumbnail(props: Props) {
             <img
               alt={__('Channel profile picture')}
               className="channel-thumbnail__custom"
-              src={!thumbError ? thumbnailPreview || thumbnail : Gerbil}
+              src={!thumbError && url ? url : Gerbil}
               onError={() => setThumbError(true)} // if thumb fails (including due to https replace, show gerbil.
             />
           )}

--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -6,6 +6,7 @@ import Gerbil from './gerbil.png';
 import FreezeframeWrapper from 'component/fileThumbnail/FreezeframeWrapper';
 import ChannelStakedIndicator from 'component/channelStakedIndicator';
 import { getThumbnailCdnUrl } from 'util/thumbnail';
+import useLazyLoading from 'effects/use-lazy-loading';
 
 type Props = {
   thumbnail: ?string,
@@ -48,6 +49,7 @@ function ChannelThumbnail(props: Props) {
   const channelThumbnail = thumbnail || thumbnailPreview;
   const isGif = channelThumbnail && channelThumbnail.endsWith('gif');
   const showThumb = (!obscure && !!thumbnail) || thumbnailPreview;
+  const thumbnailRef = React.useRef(null);
   // Generate a random color class based on the first letter of the channel name
   const { channelName } = parseURI(uri);
   let initializer;
@@ -64,6 +66,8 @@ function ChannelThumbnail(props: Props) {
       doResolveUri(uri);
     }
   }, [doResolveUri, shouldResolve, uri]);
+
+  useLazyLoading(thumbnailRef, 0.25, [showThumb]);
 
   if (isGif && !allowGifs) {
     return (
@@ -92,6 +96,7 @@ function ChannelThumbnail(props: Props) {
     >
       {!showThumb && (
         <img
+          ref={thumbnailRef}
           alt={__('Channel profile picture')}
           className="channel-thumbnail__default"
           src={!thumbError && url ? url : Gerbil}
@@ -104,6 +109,7 @@ function ChannelThumbnail(props: Props) {
             <div className="chanel-thumbnail--waiting">{__('This will be visible in a few minutes.')}</div>
           ) : (
             <img
+              ref={thumbnailRef}
               alt={__('Channel profile picture')}
               className="channel-thumbnail__custom"
               src={!thumbError && url ? url : Gerbil}

--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -168,7 +168,13 @@ function ChannelPage(props: Props) {
         </div>
         {cover && <img className={classnames('channel-cover__custom')} src={cover} />}
         <div className="channel__primary-info">
-          <ChannelThumbnail className="channel__thumbnail--channel-page" uri={uri} allowGifs hideStakedIndicator />
+          <ChannelThumbnail
+            className="channel__thumbnail--channel-page"
+            uri={uri}
+            allowGifs
+            hideStakedIndicator
+            noOptimization
+          />
           <h1 className="channel__title">
             {title || '@' + channelName}
             <ChannelStakedIndicator uri={uri} large />


### PR DESCRIPTION
# Disable optimization in Channel Page and for GIFs
- Closes #6067 `ChannelThumbnails: revisit image optimization`
- Better attempt for #5564 `Don't use optimized URLs on channel pages (profile/banner)`

### Notes
This is not the best/full solution yet, but it is better than what we have to today (one step in the right direction). The main page should load faster now.

Changes:
- Re-enabled optimization for `ChannelThumbnail`, but disable it for the avatar in Channel Page and also if it's a GIF.

### Remaining problem
Optimized channel thumbnail size is currently hardcoded to a lowest common denominator.  Filed as #6074 `Get exact optimized thumbnail sizes instead of hardcoded to lowest denominator`

# ChannelThumbnail: fix lazy-loading

- Closes #6066: `Revisit lazy-loading Channel thumbnails`.
- Properly fixes #5933: `Thumbnail lazy-load causes ChannelSelector icon to not update`.
    - Add effect-dependency on `channelThumbnail` and `thumbError`.
- Really perform the lazy-loading now.
    - `data-src` was not used, so it wasn't actually lazy loading previously.