### PR TITLE
Restore "Autoplay media files" behavior

### DIFF
--- a/ui/component/fileRenderInitiator/view.jsx
+++ b/ui/component/fileRenderInitiator/view.jsx
@@ -59,7 +59,7 @@ export default function FileRenderInitiator(props: Props) {
   // get current url
   const url = window.location.href;
   // check if there is a time parameter, if so force autoplay
-  if (url.indexOf('t=')) {
+  if (url.indexOf('t=') > -1) {
     autoplay = true;
   }
 


### PR DESCRIPTION
## Issue
Closes #6078 `"Autoplay media files = disable" is broken`

`if (-1)` is "truthy"
