### PR TITLE
Skip thumbnail fetch if autoplay is ON

### DIFF
--- a/ui/component/fileRenderInitiator/view.jsx
+++ b/ui/component/fileRenderInitiator/view.jsx
@@ -127,7 +127,7 @@ export default function FileRenderInitiator(props: Props) {
   return (
     <div
       onClick={disabled ? undefined : shouldRedirect ? doAuthRedirect : viewFile}
-      style={thumbnail && !obscurePreview ? { backgroundImage: `url("${thumbnail}")` } : {}}
+      style={thumbnail && !obscurePreview && !autoplay ? { backgroundImage: `url("${thumbnail}")` } : {}}
       className={classnames('content__cover', {
         'content__cover--disabled': disabled,
         'content__cover--theater-mode': videoTheaterMode,


### PR DESCRIPTION
It's useful to show the thumbnail as the player's backdrop when Video Autoplay is OFF, but it's a wasted fetch when it's ON because the videojs component will be blocking it.

Although it's the same image as the ClaimPreview, this one will be in full size, so a fetch will always happen.

Aside: videojs handles the backdrop for the audio and embed case, so this change won't affect those items.
```
  <VideoJs
    poster={isAudio || (embedded && !autoplayIfEmbedded) ? thumbnail : ''}
  />
```

Future: for "mobile + autoplay=OFF", we should consider using the optimized thumbnail. 6074 should help.
