### PR TITLE
Fix broken Block List due to surfacing of error

### DIFF
--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -537,7 +537,7 @@ export function doCommentModToggleBlock(channelUri: string, unblock: boolean = f
 
     const commentAction = unblock ? Comments.moderation_unblock : Comments.moderation_block;
 
-    return Promise.all(
+    return Promise.allSettled(
       channelSignatures.map((signatureData) =>
         commentAction({
           mod_channel_id: signatureData.claim_id,
@@ -601,7 +601,7 @@ export function doFetchModBlockedList() {
       }
     }
 
-    return Promise.all(
+    return Promise.allSettled(
       channelSignatures.map((signatureData) =>
         Comments.moderation_block_list({
           mod_channel_id: signatureData.claim_id,
@@ -611,7 +611,8 @@ export function doFetchModBlockedList() {
         })
       )
     )
-      .then((blockLists) => {
+      .then((res) => {
+        const blockLists = res.map((r) => r.value);
         let globalBlockList = [];
         blockLists
           .sort((a, b) => {


### PR DESCRIPTION
## Issue
The "Muted Words" PR elevated Comment-API errors so we can handle it (previously, it goes unnoticed). This broke the other Comment functions because the spammer mitigation might return an error, causing `Promise.all` to bail early.

## Fix
Changed to `Promise.allSettled` and reconstructed the results. This will make it equivalent to the code prior to the "Muted Words" PR.

## Potential issues
- [ ] ⚠️ `allSettled` is relatively new.  Safari, for example, requires version 13 (2019).  Should we polyfill?

----

@jessopb @tzarebczan, I had to bypass lint for this one.  Not sure how to add `allSettled` to lint.  Was trying to tweak the Bluebird file but didn't work -- not sure where else to tweak.