### PR TITLE
Bump up notification content width to show more text

### DIFF
--- a/ui/scss/component/_notification.scss
+++ b/ui/scss/component/_notification.scss
@@ -1,5 +1,5 @@
 $thumbnailWidth: 4rem;
-$contentMaxWidth: 35rem;
+$contentMaxWidth: 60rem;
 
 .notifications__empty {
   background-color: var(--color-card-background);


### PR DESCRIPTION
## Issue
Closes [#6056 Extend notificaiton text to show more characters](https://github.com/lbryio/lbry-desktop/issues/6056)

## Notes
Looking at the code and comments, I couldn't figure out what was the reason for adding the width constraint (just in case this breaks something).

My guesses:
- Try not to make the rhs thumbnail too far apart from the lhs thumbnail.
- Try not to make the rhs thumbnail misaligned due to dynamic width of the "xx days ago" string on the far right.

## Changes:
Extended the width as much as possible, while retaining some gap before the "xx days ago" string and "unread dot" so that thumbnails stay align in the general case.

The components still reflows nicely (as it did previously) per window-size.
