### PR TITLE
Open the sidebar by default

### DIFF
--- a/ui/component/page/view.jsx
+++ b/ui/component/page/view.jsx
@@ -12,7 +12,6 @@ import usePersistedState from 'effects/use-persisted-state';
 import { useHistory } from 'react-router';
 import { useIsMobile, useIsMediumScreen } from 'effects/use-screensize';
 import { parseURI } from 'lbry-redux';
-import { SIMPLE_SITE } from 'config';
 
 export const MAIN_CLASS = 'main';
 type Props = {
@@ -59,7 +58,7 @@ function Page(props: Props) {
   const {
     location: { pathname },
   } = useHistory();
-  const [sidebarOpen, setSidebarOpen] = usePersistedState('sidebar', !SIMPLE_SITE);
+  const [sidebarOpen, setSidebarOpen] = usePersistedState('sidebar', false);
   const isMediumScreen = useIsMediumScreen();
   const isMobile = useIsMobile();
 


### PR DESCRIPTION
## Issue
Closes [#6112 Side menu expanded by default unless collapsed by user](https://github.com/lbryio/lbry-desktop/issues/6112)

Changes won't appear in Odysee until merged.

## Notes
Did it in `master` to reduce diffs between `odysee`. 
`master` was already expanding by default.  It seemed like it was intentional to collapse it by default in Odysee back then.