### PR TITLE
Optimized `getDefaultKnownTags` || update `web.package.json`

### DIFF
--- a/ui/redux/reducers/tags.js
+++ b/ui/redux/reducers/tags.js
@@ -4,13 +4,10 @@ import { ACTIONS as LBRY_REDUX_ACTIONS, DEFAULT_KNOWN_TAGS, DEFAULT_FOLLOWED_TAG
 import { handleActions } from 'util/redux-utils';
 
 function getDefaultKnownTags() {
-  return DEFAULT_FOLLOWED_TAGS.concat(DEFAULT_KNOWN_TAGS).reduce(
-    (tagsMap, tag) => ({
-      ...tagsMap,
-      [tag]: { name: tag },
-    }),
-    {}
-  );
+  return DEFAULT_FOLLOWED_TAGS.concat(DEFAULT_KNOWN_TAGS).reduce((tagsMap, tag) => {
+    tagsMap[tag] = { name: tag };
+    return tagsMap;
+  }, {});
 }
 
 const defaultState: TagState = {
@@ -27,7 +24,7 @@ export default handleActions(
       let newFollowedTags = followedTags.slice();
 
       if (newFollowedTags.includes(name)) {
-        newFollowedTags = newFollowedTags.filter(tag => tag !== name);
+        newFollowedTags = newFollowedTags.filter((tag) => tag !== name);
       } else {
         newFollowedTags.push(name);
       }
@@ -57,7 +54,7 @@ export default handleActions(
 
       let newKnownTags = { ...knownTags };
       delete newKnownTags[name];
-      const newFollowedTags = followedTags.filter(tag => tag !== name);
+      const newFollowedTags = followedTags.filter((tag) => tag !== name);
 
       return {
         ...state,

--- a/web/package.json
+++ b/web/package.json
@@ -31,8 +31,8 @@
     "koa-logger": "^3.2.1",
     "koa-send": "^5.0.0",
     "koa-static": "^5.0.0",
-    "lbry-redux": "lbryio/lbry-redux#c107d9cc4c4b2cc31f182f196ab6a033aefe976e",
-    "lbryinc": "lbryio/lbryinc#6a52f8026cdc7cd56d200fb5c46f852e0139bbeb",
+    "lbry-redux": "lbryio/lbry-redux#ecfcc95bebbdbe303b3ea065134457a5e168fb89",
+    "lbryinc": "lbryio/lbryinc#8f9a58bfc8312a65614fd7327661cdcc502c4e59",
     "mysql": "^2.17.1",
     "node-fetch": "^2.6.1",
     "uuid": "^8.3.0"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3331,17 +3331,17 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-lbry-redux@lbryio/lbry-redux#c107d9cc4c4b2cc31f182f196ab6a033aefe976e:
+lbry-redux@lbryio/lbry-redux#ecfcc95bebbdbe303b3ea065134457a5e168fb89:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/c107d9cc4c4b2cc31f182f196ab6a033aefe976e"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/ecfcc95bebbdbe303b3ea065134457a5e168fb89"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"
-    uuid "^3.3.2"
+    uuid "^8.3.1"
 
-lbryinc@lbryio/lbryinc#6a52f8026cdc7cd56d200fb5c46f852e0139bbeb:
+lbryinc@lbryio/lbryinc#8f9a58bfc8312a65614fd7327661cdcc502c4e59:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/6a52f8026cdc7cd56d200fb5c46f852e0139bbeb"
+  resolved "https://codeload.github.com/lbryio/lbryinc/tar.gz/8f9a58bfc8312a65614fd7327661cdcc502c4e59"
   dependencies:
     reselect "^3.0.0"
 
@@ -5420,6 +5420,11 @@ uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
+
+uuid@^8.3.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
1. Update `web.package.json` to point to the latest `lbry-redux` and `lbryinc` (discussed in Slack)
    - It's odd that things have been working fine without the correct reference.  Hopefully this doesn't cause more issues that it tries to fix.
2. Optimized `getDefaultKnownTags`
    - Requires `web.package.json` to point to the right dependencies.
