### PR TITLE
Clear out stale JS files during build

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -75,6 +75,12 @@ if (fs.existsSync(ROBOTS_TXT_PATH)) {
   });
 }
 
+// clear the dist folder of existing js files before compilation
+let regex = /^.*\.(json|js|map)$/;
+fs.readdirSync(`${DIST_ROOT}/public/`)
+  .filter(f => regex.test(f))
+  .map(f => fs.unlinkSync(`${DIST_ROOT}/public/` + f));
+
 let plugins = [
   new WriteFilePlugin(),
   new CopyWebpackPlugin(copyWebpackCommands),


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [X] Other - Please describe: Code improvement: deleting unused files that clog up disk

## Fixes

Issue Number:

## What is the current behavior?
Artifact JS files will be left after each build

## What is the new behavior?
Old JS files that aren't needed are deleted during build process. 

Could use some testing to make sure there are no bad side effects (aka if a build fails and there's no .JS file available which is the main possible bad scenario)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
