### PR TITLE
use video js viewer for ios and add playsinline

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -75,7 +75,6 @@ const VIDEO_JS_OPTIONS: VideoJSOptions = {
   responsive: true,
   controls: true,
   html5: {
-    nativeControlsForTouch: IS_IOS,
     hls: {
       overrideNative: !videojs.browser.IS_ANY_SAFARI,
     },

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -578,6 +578,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         type: type,
       });
 
+      // set playsinline for mobile
+      player.children_[0].setAttribute('playsinline', '');
+
       // Add quality selector to player
       player.hlsQualitySelector({
         displayCurrentQuality: true,

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -348,12 +348,6 @@
   width: 100%;
 }
 
-.video-js-parent--ios {
-  .vjs-control-bar {
-    display: none;
-  }
-}
-
 // By default no video js play button
 .vjs-big-play-button {
   display: none;


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #5737

## What is the current behavior?
Uses ios native player (no styling, can't change speed, auto fullscreen)

## What is the new behavior?
Use videojs stylized frontend, also use playsinline to view video without auto full screen

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
