### PR TITLE
Re-enable "file download" in Odysee

### DIFF
--- a/ui/component/fileActions/view.jsx
+++ b/ui/component/fileActions/view.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { SIMPLE_SITE, SITE_NAME, ENABLE_FILE_REACTIONS } from 'config';
+import { SITE_NAME, ENABLE_FILE_REACTIONS } from 'config';
 import * as PAGES from 'constants/pages';
 import * as MODALS from 'constants/modal_types';
 import * as ICONS from 'constants/icons';
@@ -109,7 +109,7 @@ function FileActions(props: Props) {
 
   const rhsSection = (
     <>
-      {!SIMPLE_SITE && <FileDownloadLink uri={uri} />}
+      <FileDownloadLink uri={uri} />
 
       {claimIsMine && (
         <Button


### PR DESCRIPTION
## Issue
Closes [#6167 Make downloading more intuitive / obvious in web mode](https://github.com/lbryio/lbry-desktop/issues/6167)

## ??
- Hidden for SIMPLE_SITE in e10647b5, but not sure why.  Did we have an important reason to block?

## Notes
- Requires odysee merge for the changes to be live.