### PR TITLE
Don't reset content language on edit [+redux]

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "imagesloaded": "^4.1.4",
     "json-loader": "^0.5.4",
     "lbry-format": "https://github.com/lbryio/lbry-format.git",
-    "lbry-redux": "lbryio/lbry-redux#d298c00f2463859c57a1ffa0f83b092a197eadac",
+    "lbry-redux": "lbryio/lbry-redux#166c3b28322764447c0ee8ba8b43b5a957cf031a",
     "lbryinc": "lbryio/lbryinc#8f9a58bfc8312a65614fd7327661cdcc502c4e59",
     "lint-staged": "^7.0.2",
     "localforage": "^1.7.1",

--- a/ui/component/publishAdditionalOptions/view.jsx
+++ b/ui/component/publishAdditionalOptions/view.jsx
@@ -161,7 +161,7 @@ function PublishAdditionalOptions(props: Props) {
                   type="select"
                   name="content_language"
                   value={language}
-                  onChange={(event) => updatePublishForm({ language: event.target.value })}
+                  onChange={(event) => updatePublishForm({ languages: [event.target.value] })}
                 >
                   {sortLanguageMap(SUPPORTED_LANGUAGES).map(([langKey, langName]) => (
                     <option key={langKey} value={langKey}>

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "koa-logger": "^3.2.1",
     "koa-send": "^5.0.0",
     "koa-static": "^5.0.0",
-    "lbry-redux": "lbryio/lbry-redux#ecfcc95bebbdbe303b3ea065134457a5e168fb89",
+    "lbry-redux": "lbryio/lbry-redux#166c3b28322764447c0ee8ba8b43b5a957cf031a",
     "lbryinc": "lbryio/lbryinc#8f9a58bfc8312a65614fd7327661cdcc502c4e59",
     "mysql": "^2.17.1",
     "node-fetch": "^2.6.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3331,9 +3331,9 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-lbry-redux@lbryio/lbry-redux#ecfcc95bebbdbe303b3ea065134457a5e168fb89:
+lbry-redux@lbryio/lbry-redux#166c3b28322764447c0ee8ba8b43b5a957cf031a:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/ecfcc95bebbdbe303b3ea065134457a5e168fb89"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/166c3b28322764447c0ee8ba8b43b5a957cf031a"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6970,9 +6970,9 @@ lazy-val@^1.0.4:
     yargs "^13.2.2"
     zstd-codec "^0.1.1"
 
-lbry-redux@lbryio/lbry-redux#d298c00f2463859c57a1ffa0f83b092a197eadac:
+lbry-redux@lbryio/lbry-redux#166c3b28322764447c0ee8ba8b43b5a957cf031a:
   version "0.0.1"
-  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/d298c00f2463859c57a1ffa0f83b092a197eadac"
+  resolved "https://codeload.github.com/lbryio/lbry-redux/tar.gz/166c3b28322764447c0ee8ba8b43b5a957cf031a"
   dependencies:
     proxy-polyfill "0.1.6"
     reselect "^3.0.0"


### PR DESCRIPTION
[Continuation of lbryio/lbry-redux/pull/414]

## Issue

Publish page tries to set the upload language to the user langauge, and it does so on edit and overwrites the existing value.
Closes #6132

## Change

selectPublishFormValues was trying to return "language" from formValues but would always return false, and set the language as default instead, should return "languages" instead.

