### PR TITLE
Fix time to start metric

### DIFF
--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -197,11 +197,6 @@ const analytics: Analytics = {
     }
   },
 
-  videoFetchDuration: (source, duration) => {
-    sendPromMetric('time_to_fetch', duration);
-    sendMatomoEvent('Media', 'TimeToFetch', source, duration);
-  },
-
   videoStartEvent: (claimId, duration) => {
     sendPromMetric('time_to_start', duration);
     sendMatomoEvent('Media', 'TimeToStart', claimId, duration);

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -152,15 +152,15 @@ function VideoViewer(props: Props) {
   }
 
   function doTrackingFirstPlay(e: Event, data: any) {
-    let timeToStartInMs = data.secondsToLoad * 1000;
+    let timeToStart = data.secondsToLoad;
 
     if (desktopPlayStartTime !== undefined) {
       const differenceToAdd = Date.now() - desktopPlayStartTime;
-      timeToStartInMs += differenceToAdd;
+      timeToStart += differenceToAdd;
     }
     analytics.playerStartedEvent(embedded);
-    analytics.videoStartEvent(claimId, timeToStartInMs);
-    doAnalyticsView(uri, timeToStartInMs).then(() => {
+    analytics.videoStartEvent(claimId, timeToStart);
+    doAnalyticsView(uri, timeToStart).then(() => {
       claimRewards();
     });
   }


### PR DESCRIPTION
Time to start is multiplied by 1000, which was supposed to be a division if we're trying to get milliseconds, but metrics endpoint expects seconds anyway so there is no need for it.