### PR TITLE
Handle comment + tip failure, don't re-support

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -62,6 +62,8 @@ export function CommentCreate(props: Props) {
     location: { pathname },
   } = useHistory();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [commentFailure, setCommentFailure] = React.useState(false);
+  const [successTip, setSuccessTip] = React.useState({ txid: undefined, tipAmount: undefined });
   const { claim_id: claimId } = claim;
   const [isSupportComment, setIsSupportComment] = React.useState();
   const [isReviewingSupportComment, setIsReviewingSupportComment] = React.useState();
@@ -120,6 +122,13 @@ export function CommentCreate(props: Props) {
       return;
     }
 
+    if (commentFailure && tipAmount === successTip.tipAmount) {
+      handleCreateComment(successTip.txid);
+      return;
+    } else {
+      setSuccessTip({ txid: undefined, tipAmount: undefined });
+    }
+
     const params = {
       amount: tipAmount,
       claim_id: claimId,
@@ -135,6 +144,7 @@ export function CommentCreate(props: Props) {
         setTimeout(() => {
           handleCreateComment(txid);
         }, 1500);
+        setSuccessTip({ txid, tipAmount });
       },
       () => {
         setIsSubmitting(false);
@@ -153,6 +163,7 @@ export function CommentCreate(props: Props) {
           setLastCommentTime(Date.now());
           setIsReviewingSupportComment(false);
           setIsSupportComment(false);
+          setCommentFailure(false);
           justCommented.push(res.comment_id);
 
           if (onDoneReplying) {
@@ -162,6 +173,7 @@ export function CommentCreate(props: Props) {
       })
       .catch(() => {
         setIsSubmitting(false);
+        setCommentFailure(true);
       });
   }
 
@@ -212,7 +224,7 @@ export function CommentCreate(props: Props) {
             autoFocus
             button="primary"
             disabled={disabled}
-            label={isSubmitting ? __('Sending...') : __('Send')}
+            label={isSubmitting ? __('Sending...') : (commentFailure && tipAmount === successTip.tipAmount) ? __('Re-submit') : __('Send')}
             onClick={handleSupportComment}
           />
           <Button button="link" label={__('Cancel')} onClick={() => setIsReviewingSupportComment(false)} />


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: Closes #6063

## What is the new behavior?

In case of failed comment, allows to re-submit the previous tip, without having to send another tip

![](https://i.postimg.cc/k5TYRDj9/image.png)
![](https://i.postimg.cc/8k2K62bF/image.png)
![](https://i.postimg.cc/FsxyH8CX/image.png)
_(tried to comment twice, first tip failed, re-submitted without tipping twice)_