### PR TITLE
Fix notification color.

### DIFF
--- a/ui/scss/component/_notification.scss
+++ b/ui/scss/component/_notification.scss
@@ -59,7 +59,7 @@ $contentMaxWidth: 60rem;
 }
 
 .notification__wrapper--unread {
-  background-color: #2d2d33;
+  background-color: var(--color-card-background-highlighted);
 
   &:hover {
     background-color: var(--color-button-secondary-bg);

--- a/ui/scss/themes/dark.scss
+++ b/ui/scss/themes/dark.scss
@@ -12,7 +12,7 @@
   // Structure
   --color-background: var(--color-gray-9);
   --color-background-overlay: #21252999;
-  --color-border: var(--color-gray-7);
+  --color-border: #333338;
   --color-card-background: var(--color-gray-8);
   --color-card-background-highlighted: var(--color-gray-7);
 


### PR DESCRIPTION
## Issue
Closes [#6196 Bright Theme is Broken](https://github.com/lbryio/lbry-desktop/issues/6196)

## Notes
I was trying to fix the problem of the border not visible in Desktop Dark because the highlight color was the same as the border color.  The approach didn't take Light and Odysee into account ... oops.

Round 2.

## Merge into odysee
- Odysee side:
   - take (restore) `background-color: var(--color-card-background-highlighted);`
   - ignore the change in border color (retain odysee color).
   