### PR TITLE
use standalone as the display instead of minimal-ui

### DIFF
--- a/web/static/pwa/manifest.json
+++ b/web/static/pwa/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Odysee",
   "theme_color": "#fa6164",
   "background_color": "#FAFAFA",
-  "display": "minimal-ui",
+  "display": "standalone",
   "description": "Launch your own channel | Watch and share videos",
   "scope": "/",
   "start_url": "/",


### PR DESCRIPTION
I had decided that `standalone` was probably the better `display` value for the pwa over `minimal-ui` but never ended up changing it in the code, here is a pull request to make that change

Here's documentation on the different display values and their corresponding look on mobile:
https://superpwa.com/doc/web-app-manifest-display-modes/

