### PR TITLE
Move 'Download' and 'Report Content' into overflow menu.

### DIFF
--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -7,12 +7,13 @@ import {
   selectMyChannelClaims,
   makeSelectClaimIsStreamPlaceholder,
   makeSelectTagInClaimOrChannelForUri,
+  makeSelectStreamingUrlForUri,
 } from 'lbry-redux';
 import { DISABLE_COMMENTS_TAG } from 'constants/tags';
 import { makeSelectCostInfoForUri } from 'lbryinc';
-import { doSetPlayingUri } from 'redux/actions/content';
+import { doSetPlayingUri, doPlayUri } from 'redux/actions/content';
 import { doToast } from 'redux/actions/notifications';
-import { doOpenModal, doSetActiveChannel, doSetIncognito } from 'redux/actions/app';
+import { doOpenModal, doSetActiveChannel, doSetIncognito, doAnalyticsView } from 'redux/actions/app';
 import fs from 'fs';
 import FileActions from './view';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
@@ -26,6 +27,7 @@ const select = (state, props) => ({
   myChannels: selectMyChannelClaims(state),
   isLivestreamClaim: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
   reactionsDisabled: makeSelectTagInClaimOrChannelForUri(props.uri, DISABLE_COMMENTS_TAG)(state),
+  streamingUrl: makeSelectStreamingUrlForUri(props.uri)(state),
 });
 
 const perform = (dispatch) => ({
@@ -42,6 +44,7 @@ const perform = (dispatch) => ({
   },
   clearPlayingUri: () => dispatch(doSetPlayingUri({ uri: null })),
   doToast: (options) => dispatch(doToast(options)),
+  download: (uri) => dispatch(doPlayUri(uri, false, true, () => dispatch(doAnalyticsView(uri)))),
 });
 
 export default connect(select, perform)(FileActions);

--- a/ui/component/fileDownloadLink/view.jsx
+++ b/ui/component/fileDownloadLink/view.jsx
@@ -3,6 +3,7 @@ import * as ICONS from 'constants/icons';
 import * as MODALS from 'constants/modal_types';
 import React, { useState } from 'react';
 import Button from 'component/button';
+import { webDownloadClaim } from 'util/downloadClaim';
 
 type Props = {
   uri: string,
@@ -46,16 +47,7 @@ function FileDownloadLink(props: Props) {
   // @if TARGET='web'
   React.useEffect(() => {
     if (didClickDownloadButton && streamingUrl) {
-      let element = document.createElement('a');
-      element.setAttribute('href', `${streamingUrl}?download=true`);
-      element.setAttribute('download', fileName);
-      element.style.display = 'none';
-      // $FlowFixMe
-      document.body.appendChild(element);
-      element.click();
-      // $FlowFixMe
-      document.body.removeChild(element);
-
+      webDownloadClaim(streamingUrl, fileName);
       setDidClickDownloadButton(false);
     }
   }, [streamingUrl, didClickDownloadButton, fileName]);

--- a/ui/util/downloadClaim.js
+++ b/ui/util/downloadClaim.js
@@ -1,0 +1,13 @@
+export function webDownloadClaim(streamingUrl, fileName) {
+  // @if TARGET='web'
+  let element = document.createElement('a');
+  element.setAttribute('href', `${streamingUrl}?download=true`);
+  element.setAttribute('download', fileName);
+  element.style.display = 'none';
+  // $FlowFixMe
+  document.body.appendChild(element);
+  element.click();
+  // $FlowFixMe
+  document.body.removeChild(element);
+  // @endif
+}


### PR DESCRIPTION
## Issue
Closes [#6236 Add context menu to file page](https://github.com/lbryio/lbry-desktop/issues/6236)

## Notes
The download button actually handles a lot of things -- generating 'streamingUrl', differences between Web and Desktop, download progress for Desktop, etc.  A simpler fix would be to put something else (maybe "Share") into the overflow menu instead.

Anyway, went ahead to do it per 6236, but retained the item for Desktop since we need a progress label.