### PR TITLE
Set 'activeChannel' before entering Dashboard

### DIFF
--- a/ui/page/channels/index.js
+++ b/ui/page/channels/index.js
@@ -5,18 +5,20 @@ import {
   doFetchChannelListMine,
   selectFetchingMyChannels,
 } from 'lbry-redux';
+import { doSetActiveChannel } from 'redux/actions/app';
 import { selectYoutubeChannels } from 'redux/selectors/user';
 import ChannelsPage from './view';
 
-const select = state => ({
+const select = (state) => ({
   channelUrls: selectMyChannelUrls(state),
   channels: selectMyChannelClaims(state),
   fetchingChannels: selectFetchingMyChannels(state),
   youtubeChannels: selectYoutubeChannels(state),
 });
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   fetchChannelListMine: () => dispatch(doFetchChannelListMine()),
+  doSetActiveChannel: (claimId) => dispatch(doSetActiveChannel(claimId)),
 });
 
 export default connect(select, perform)(ChannelsPage);

--- a/ui/page/channels/view.jsx
+++ b/ui/page/channels/view.jsx
@@ -11,6 +11,7 @@ import Yrbl from 'component/yrbl';
 import LbcSymbol from 'component/common/lbc-symbol';
 import * as PAGES from 'constants/pages';
 import HelpLink from 'component/common/help-link';
+import { useHistory } from 'react-router';
 
 type Props = {
   channels: Array<ChannelClaim>,
@@ -18,13 +19,15 @@ type Props = {
   fetchChannelListMine: () => void,
   fetchingChannels: boolean,
   youtubeChannels: ?Array<any>,
+  doSetActiveChannel: (string) => void,
 };
 
 export default function ChannelsPage(props: Props) {
-  const { channels, channelUrls, fetchChannelListMine, fetchingChannels, youtubeChannels } = props;
+  const { channels, channelUrls, fetchChannelListMine, fetchingChannels, youtubeChannels, doSetActiveChannel } = props;
   const [rewardData, setRewardData] = React.useState();
   const hasYoutubeChannels = youtubeChannels && Boolean(youtubeChannels.length);
   const hasPendingChannels = channels && channels.some((channel) => channel.confirmations < 0);
+  const { push } = useHistory();
 
   useEffect(() => {
     fetchChannelListMine();
@@ -62,7 +65,10 @@ export default function ChannelsPage(props: Props) {
                     button="alt"
                     icon={ICONS.ANALYTICS}
                     label={__('Analytics')}
-                    navigate={`/$/${PAGES.CREATOR_DASHBOARD}?channel=${encodeURIComponent(claim.canonical_url)}`}
+                    onClick={() => {
+                      doSetActiveChannel(claim.claim_id);
+                      push(`/$/${PAGES.CREATOR_DASHBOARD}`);
+                    }}
                   />
                 </div>
               );


### PR DESCRIPTION
## Issue
Closes [#6237: Analytics button from Channels page doesn't open analytics to right channel](https://github.com/lbryio/lbry-desktop/issues/6237)

## Notes
I assume we have changed to the `activeChannel` method, so we are dropping the direct URL support.  Saves us the need to update the URL when user changes from the selector after entering the page.