### PR TITLE
Fix videos not switching when floating player is up

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -564,6 +564,12 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       // note: the poster prop seems to return null usually.
       if (poster) player.poster(poster);
 
+      // Update player source
+      player.src({
+        src: finalSource,
+        type: type,
+      });
+
       // set playsinline for mobile
       player.children_[0].setAttribute('playsinline', '');
 


### PR DESCRIPTION
## Issue
Closes #6278 Video doesn't switch when floating player is up

## Notes
Not sure why the double `src` call is needed, but it is.