### PR TITLE
Moderation: resolve chan name or URL instead of using Lighthouse.

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1911,6 +1911,7 @@
   "Enabling a minimum amount to hyperchat will force all TIPPED comments to have this value in order to be shown. This still allows regular comments to be posted.": "Enabling a minimum amount to hyperchat will force all TIPPED comments to have this value in order to be shown. This still allows regular comments to be posted.",
   "Settings unavailable for this channel": "Settings unavailable for this channel",
   "This channel isn't staking enough LBRY Credits to enable Creator Settings.": "This channel isn't staking enough LBRY Credits to enable Creator Settings.",
+  "Not a channel (prefix with \"@\", or enter the channel URL)": "Not a channel (prefix with \"@\", or enter the channel URL)",
   "We apologize for this inconvenience, but have added this additional step to prevent abuse. Users on VPN or shared connections will continue to see this message and are not eligible for Rewards.": "We apologize for this inconvenience, but have added this additional step to prevent abuse. Users on VPN or shared connections will continue to see this message and are not eligible for Rewards.",
   "Help LBRY Save Crypto": "Help LBRY Save Crypto",
   "The US government is attempting to destroy the cryptocurrency industry. Can you help?": "The US government is attempting to destroy the cryptocurrency industry. Can you help?",
@@ -1994,5 +1995,6 @@
   "Item added to Watch Later": "Item added to Watch Later",
   "Your publish is being confirmed and will be live soon": "Your publish is being confirmed and will be live soon",
   "Clear Edits": "Clear Edits",
+  "Something not quite right..": "Something not quite right..",
   "--end--": "--end--"
 }

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -78,6 +78,7 @@ type Props = {
   isCollectionMine: boolean,
   collectionUris: Array<Collection>,
   collectionIndex?: number,
+  disableNavigation?: boolean,
 };
 
 const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
@@ -134,6 +135,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     editCollection,
     isCollectionMine,
     collectionUris,
+    disableNavigation,
   } = props;
   const isRepost = claim && claim.repost_channel_url;
   const WrapperElement = wrapperElement || 'li';
@@ -214,7 +216,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
       onClick(e);
     }
 
-    if (claim && !pending) {
+    if (claim && !pending && !disableNavigation) {
       history.push(navigateUrl);
     }
   }
@@ -423,7 +425,9 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
             )}
           </div>
         </div>
-        {!hideMenu && <ClaimMenuList uri={uri} collectionId={collectionId} channelUri={channelUri} isRepost={isRepost} />}
+        {!hideMenu && (
+          <ClaimMenuList uri={uri} collectionId={collectionId} channelUri={channelUri} isRepost={isRepost} />
+        )}
       </>
     </WrapperElement>
   );

--- a/ui/util/search.js
+++ b/ui/util/search.js
@@ -1,5 +1,8 @@
 // @flow
 
+import { isNameValid, isURIValid, normalizeURI, parseURI } from 'lbry-redux';
+import { URL as SITE_URL, URL_LOCAL, URL_DEV } from 'config';
+
 export function createNormalizedSearchKey(query: string) {
   const FROM = '&from=';
 
@@ -32,4 +35,71 @@ export function getLivestreamOnlyOptions(options: any) {
   delete newOptions.stream_types;
   newOptions.has_no_source = true;
   return newOptions;
+}
+
+/**
+ * getUriForSearchTerm
+ * @param term
+ * @returns {string[]|*[]|(string|string)[]}
+ */
+export function getUriForSearchTerm(term: string) {
+  const WEB_DEV_PREFIX = `${URL_DEV}/`;
+  const WEB_LOCAL_PREFIX = `${URL_LOCAL}/`;
+  const WEB_PROD_PREFIX = `${SITE_URL}/`;
+  const ODYSEE_PREFIX = `https://odysee.com/`;
+  const includesLbryTvProd = term.includes(WEB_PROD_PREFIX);
+  const includesOdysee = term.includes(ODYSEE_PREFIX);
+  const includesLbryTvLocal = term.includes(WEB_LOCAL_PREFIX);
+  const includesLbryTvDev = term.includes(WEB_DEV_PREFIX);
+  const wasCopiedFromWeb = includesLbryTvDev || includesLbryTvLocal || includesLbryTvProd || includesOdysee;
+  const isLbryUrl = term.startsWith('lbry://') && term !== 'lbry://';
+  const error = '';
+
+  const addLbryIfNot = (term) => {
+    return term.startsWith('lbry://') ? term : `lbry://${term}`;
+  };
+
+  if (wasCopiedFromWeb) {
+    let prefix = WEB_PROD_PREFIX;
+    if (includesLbryTvLocal) prefix = WEB_LOCAL_PREFIX;
+    if (includesLbryTvDev) prefix = WEB_DEV_PREFIX;
+    if (includesOdysee) prefix = ODYSEE_PREFIX;
+
+    let query = (term && term.slice(prefix.length).replace(/:/g, '#')) || '';
+    try {
+      const lbryUrl = `lbry://${query}`;
+      parseURI(lbryUrl);
+      return [lbryUrl, null];
+    } catch (e) {
+      return [query, 'error'];
+    }
+  }
+
+  if (!isLbryUrl) {
+    if (term.startsWith('@')) {
+      if (isNameValid(term.slice(1))) {
+        return [term, null];
+      } else {
+        return [term, error];
+      }
+    }
+    return [addLbryIfNot(term), null];
+  } else {
+    try {
+      const isValid = isURIValid(term);
+      if (isValid) {
+        let uri;
+        try {
+          uri = normalizeURI(term);
+        } catch (e) {
+          return [term, null];
+        }
+        return [uri, null];
+      } else {
+        return [term, null];
+      }
+    } catch (e) {
+      return [term, 'error'];
+    }
+  }
 }


### PR DESCRIPTION
While Lighthouse allows looser searching like "Tom from LBRY", it doesn't show the expected results when direct channel name with partial ID is entered to disambiguate.  Instead of having 2 ways of searching/validating, stick with the one that works (using `resolveUri` on the search term).
