### PR TITLE
fix autoplay for transcoded files

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -234,10 +234,13 @@ function VideoViewer(props: Props) {
       Promise.race([playPromise, timeoutPromise]).catch((error) => {
         if (typeof error === 'object' && error.name && error.name === 'NotAllowedError') {
           // Autoplay disallowed by browser
+          player.play();
         }
 
+        // Autoplay failed
         if (PLAY_TIMEOUT_ERROR) {
-          // Autoplay failed
+          setIsLoading(false);
+          setIsPlaying(false);
         } else {
           setIsLoading(false);
           setIsPlaying(false);


### PR DESCRIPTION
Fixes issue where shouldPlay becomes undefined and will break autoplay if video is transcoded due to a new load request being started.

![image](https://user-images.githubusercontent.com/45262335/122966809-9ec3d780-d33e-11eb-8627-10916267aed3.png)
