### PR TITLE
Don't display CC button via videojs settings

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -200,6 +200,11 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       eventTracking: true,
       overlay: OVERLAY.OVERLAY_DATA,
     },
+    // fixes problem of errant CC button showing up on iOS
+    // TODO: find the source of why the button recently began to show up on iOS
+    controlBar: {
+      subsCapsButton: false,
+    },
   };
 
   const tapToUnmuteRef = useRef();


### PR DESCRIPTION
## PR Checklist

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #6233 

## What is the current behavior?
Errant CC button shows up on iOS Safari

## What is the new behavior?
Errant CC button no longer shows up

## Other information
Address issue:
https://github.com/lbryio/lbry-desktop/issues/6233

I can confirm the CC button began to show up only on more recent versions of master. May warrant further investigation as to what caused that to start appearing, this is a working hotfix to stop users from being confused.