### PR TITLE
Pick wunderbar-debouncing fixes to odysee

### DIFF
--- a/ui/component/wunderbarSuggestion/index.js
+++ b/ui/component/wunderbarSuggestion/index.js
@@ -1,9 +1,10 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri } from 'lbry-redux';
+import { makeSelectClaimForUri, makeSelectIsUriResolving } from 'lbry-redux';
 import WunderbarSuggestion from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
+  isResolvingUri: makeSelectIsUriResolving(props.uri)(state),
 });
 
 export default connect(select)(WunderbarSuggestion);

--- a/ui/component/wunderbarSuggestion/view.jsx
+++ b/ui/component/wunderbarSuggestion/view.jsx
@@ -10,10 +10,21 @@ import ClaimProperties from 'component/claimProperties';
 type Props = {
   claim: ?Claim,
   uri: string,
+  isResolvingUri: boolean,
 };
 
 export default function WunderbarSuggestion(props: Props) {
-  const { claim, uri } = props;
+  const { claim, uri, isResolvingUri } = props;
+
+  if (isResolvingUri) {
+    return (
+      <ComboboxOption value={uri}>
+        <div className="wunderbar__suggestion">
+          <div className="media__thumb media__thumb--resolving" />
+        </div>
+      </ComboboxOption>
+    );
+  }
 
   if (!claim) {
     return null;

--- a/ui/component/wunderbarSuggestions/view.jsx
+++ b/ui/component/wunderbarSuggestions/view.jsx
@@ -18,6 +18,7 @@ import { useHistory } from 'react-router';
 import { formatLbryUrlForWeb } from 'util/url';
 import Yrbl from 'component/yrbl';
 import { SEARCH_OPTIONS } from 'constants/search';
+import Spinner from 'component/spinner';
 
 const LBRY_PROTOCOL = 'lbry://';
 const WEB_DEV_PREFIX = `${URL_DEV}/`;
@@ -94,6 +95,9 @@ export default function WunderBarSuggestions(props: Props) {
   if (channelUrlForTopTest) {
     topUrisToTest.push(uriFromQuery);
   }
+
+  const isTyping = debouncedTerm !== term;
+  const showPlaceholder = isTyping || loading;
 
   function handleSelect(value) {
     if (!value) {
@@ -297,7 +301,7 @@ export default function WunderBarSuggestions(props: Props) {
             value={term}
           />
 
-          {isFocused && results && results.length > 0 && (
+          {isFocused && (
             <ComboboxPopover
               portal={false}
               className={classnames('wunderbar__suggestions', { 'wunderbar__suggestions--mobile': isMobile })}
@@ -306,9 +310,12 @@ export default function WunderBarSuggestions(props: Props) {
                 {uriFromQueryIsValid && !noTopSuggestion ? <WunderbarTopSuggestion query={nameFromQuery} /> : null}
 
                 <div className="wunderbar__label">{__('Search Results')}</div>
-                {results.slice(0, term.length < LIGHTHOUSE_MIN_CHARACTERS ? 0 : isMobile ? 20 : 5).map((uri) => (
-                  <WunderbarSuggestion key={uri} uri={uri} />
-                ))}
+
+                {showPlaceholder && term.length > LIGHTHOUSE_MIN_CHARACTERS ? <Spinner type="small" /> : null}
+
+                {!showPlaceholder && results
+                  ? results.slice(0, isMobile ? 20 : 5).map((uri) => <WunderbarSuggestion key={uri} uri={uri} />)
+                  : null}
 
                 {!noBottomLinks && (
                   <div className="wunderbar__bottom-links">

--- a/ui/effects/use-lighthouse.js
+++ b/ui/effects/use-lighthouse.js
@@ -7,15 +7,15 @@ import useThrottle from './use-throttle';
 
 export default function useLighthouse(
   query: string,
-  showMature?: boolean,
-  size?: number = 5,
-  additionalOptions: any = {}
+  showMature: boolean,
+  size: number = 5,
+  additionalOptions: any = {},
+  throttleMs: number = 500
 ) {
-  const THROTTLE_MS = 1000;
   const [results, setResults] = React.useState();
   const [loading, setLoading] = React.useState();
   const queryString = query ? getSearchQueryString(query, { nsfw: showMature, size, ...additionalOptions }) : '';
-  const throttledQuery = useThrottle(queryString, THROTTLE_MS);
+  const throttledQuery = useThrottle(queryString, throttleMs);
 
   React.useEffect(() => {
     if (throttledQuery) {


### PR DESCRIPTION
This cherry-picks the wunderbar-debouncing PR from `master` to `odysee`

## What for?
- Resolve conflict -- Assuming we'll collapse odysee first before rebasing to master, this PR will help reduce the amount of conflicts (there was a recent attempt to adjust the throttle in odysee as well).
- Bring over the changes to odysee early to lighten up Lighthouse, without having to rebase to master.  I assume we don't want to bring in 'code-split' yet until it's proven ok in lbry.tv.
