### PR TITLE
dont display cc button via videojs settings

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -201,7 +201,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       overlay: OVERLAY.OVERLAY_DATA,
     },
     // fixes problem of errant CC button showing up on iOS
-    // TODO: find the source of why the button recently began to show up on iOS
+    // the true fix here is to fix the m3u8 file, see: https://github.com/lbryio/lbry-desktop/pull/6315
     controlBar: {
       subsCapsButton: false,
     },

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -200,6 +200,11 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       eventTracking: true,
       overlay: OVERLAY.OVERLAY_DATA,
     },
+    // fixes problem of errant CC button showing up on iOS
+    // TODO: find the source of why the button recently began to show up on iOS
+    controlBar: {
+      subsCapsButton: false,
+    },
   };
 
   const tapToUnmuteRef = useRef();


### PR DESCRIPTION
Per this PR: https://github.com/lbryio/lbry-desktop/pull/6315/

It was determined that the CC button showing up errantly was being caused by the m3u8 spec requiring explicit disabling of captions when there are multiple video tracks in latest iOS versions.

So the true fix of this is the backend to include the CLOSED-CAPTIONS=NONE in the proper tag in the m3u8 file (documented by Xander in the linked PR above).

Though disabling closed captioning by default will cause an issue whereby people who stream with live captions to livestreaming will have that temporarily disabled, the jarring effect of this CC popping up on all transcoded videos on iOS, that this will affect/confuse a lot more viewers than those who will be affected by the disabling of live captions on livestreams,  we will turn this off by default and then the backend team can help us turn on livestream captions by including CLOSED-CAPTIONS=NONE in the m3u8 files for transcoded videos.

