### PR TITLE
RecommendedContent: prevent excessive render

### DIFF
--- a/ui/component/recommendedContent/view.jsx
+++ b/ui/component/recommendedContent/view.jsx
@@ -23,7 +23,7 @@ type Props = {
   claim: ?StreamClaim,
 };
 
-export default function RecommendedContent(props: Props) {
+export default React.memo<Props>(function RecommendedContent(props: Props) {
   const {
     uri,
     doFetchRecommendedContent,
@@ -121,4 +121,42 @@ export default function RecommendedContent(props: Props) {
       }
     />
   );
+}, areEqual);
+
+function areEqual(prevProps: Props, nextProps: Props) {
+  const a = prevProps;
+  const b = nextProps;
+
+  if (
+    a.uri !== b.uri ||
+    a.nextRecommendedUri !== b.nextRecommendedUri ||
+    a.isAuthenticated !== b.isAuthenticated ||
+    a.isSearching !== b.isSearching ||
+    a.mature !== b.mature ||
+    (a.recommendedContent && !b.recommendedContent) ||
+    (!a.recommendedContent && b.recommendedContent) ||
+    (a.claim && !b.claim) ||
+    (!a.claim && b.claim)
+  ) {
+    return false;
+  }
+
+  if (a.claim && b.claim && a.claim.claim_id !== b.claim.claim_id) {
+    return false;
+  }
+
+  if (a.recommendedContent && b.recommendedContent) {
+    if (a.recommendedContent.length !== b.recommendedContent.length) {
+      return false;
+    }
+
+    let i = a.recommendedContent.length;
+    while (i--) {
+      if (a.recommendedContent[i] !== b.recommendedContent[i]) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }


### PR DESCRIPTION
## Issue
When seeking on a video, RecommendedContent gets re-rendered, which causes the 20 ClaimPreviews to be re-rendered, several times. ClaimPreview has lots of children, plus it's constantly checking against the blacklist, among other things.

## Fix
The culprit seems to be the `recommendedContent` array -- the contents are actually the same.
Do a deep compare instead.

## Questions
- Is there a more elegant way to deep-compare?
- For `claim`, is comparing the `claim_id` sufficient?
- Not really sure why `SET_CONTENT_POSITION` would end up marking `makeSelectRecommendedContentForUri`.

## Results
Circled item indicates React activity when seeking a video. Reduced from (24ms * N) to (8ms).
- Before:
  - <img src="https://user-images.githubusercontent.com/64950861/123607933-e65fcd00-d830-11eb-8946-82b9862a74a3.png" width="400">
- After:
  - <img src="https://user-images.githubusercontent.com/64950861/123608212-2626b480-d831-11eb-845b-c407711ed988.png" width="400">

