### PR TITLE
fix div being stretched by comment section

### DIFF
--- a/ui/scss/component/_main.scss
+++ b/ui/scss/component/_main.scss
@@ -87,6 +87,7 @@
 
     > :first-child {
       flex: 1;
+      max-width: 100%;
     }
 
     @media (min-width: $breakpoint-medium) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #5680 

## What is the current behavior?
On iOS (and probably other mobile devices) the secondary content section gets stretched. Check #5680 for more information

## What is the new behavior?
No longer is stretched by the comment section

## Other information
