### PR TITLE
Front-page lazy-load fixes and improvements

### DIFF
--- a/ui/component/common/wait-until-on-page.jsx
+++ b/ui/component/common/wait-until-on-page.jsx
@@ -62,7 +62,11 @@ export default function WaitUntilOnPage(props: Props) {
 
     if (ref && ref.current && !shouldRender) {
       window.addEventListener('scroll', handleDisplayingRef);
-      return () => window.removeEventListener('scroll', handleDisplayingRef);
+      window.addEventListener('resize', handleDisplayingRef);
+      return () => {
+        window.removeEventListener('scroll', handleDisplayingRef);
+        window.removeEventListener('resize', handleDisplayingRef);
+      };
     }
   }, [ref, setShouldRender, shouldRender, shouldElementRender]);
 

--- a/ui/component/common/wait-until-on-page.jsx
+++ b/ui/component/common/wait-until-on-page.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import debounce from 'util/debounce';
 
-const DEBOUNCE_SCROLL_HANDLER_MS = 25;
+const DEBOUNCE_SCROLL_HANDLER_MS = 50;
 
 type Props = {
   children: any,
@@ -14,33 +14,48 @@ export default function WaitUntilOnPage(props: Props) {
   const ref = React.useRef();
   const [shouldRender, setShouldRender] = React.useState(false);
 
-  React.useEffect(() => {
-    const handleDisplayingRef = debounce((e) => {
-      const element = ref && ref.current;
-      if (element) {
-        const bounding = element.getBoundingClientRect();
-        if (
-          bounding.bottom >= 0 &&
-          bounding.right >= 0 &&
-          // $FlowFixMe
-          bounding.top <= (window.innerHeight || document.documentElement.clientHeight) &&
-          // $FlowFixMe
-          bounding.left <= (window.innerWidth || document.documentElement.clientWidth)
-        ) {
-          setShouldRender(true);
-        }
+  const shouldElementRender = React.useCallback((ref) => {
+    const element = ref && ref.current;
+    if (element) {
+      const bounding = element.getBoundingClientRect();
+      if (
+        bounding.width > 0 &&
+        bounding.height > 0 &&
+        bounding.bottom >= 0 &&
+        bounding.right >= 0 &&
+        // $FlowFixMe
+        bounding.top <= (window.innerHeight || document.documentElement.clientHeight) &&
+        // $FlowFixMe
+        bounding.left <= (window.innerWidth || document.documentElement.clientWidth)
+      ) {
+        return true;
       }
+    }
+    return false;
+  }, []);
 
-      if (element && !shouldRender) {
-        window.addEventListener('scroll', handleDisplayingRef);
-        return () => window.removeEventListener('scroll', handleDisplayingRef);
+  // Handles "element is already in viewport when mounted".
+  React.useEffect(() => {
+    setTimeout(() => {
+      if (!shouldRender && shouldElementRender(ref)) {
+        setShouldRender(true);
+      }
+    }, 500);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Handles "element scrolled into viewport".
+  React.useEffect(() => {
+    const handleDisplayingRef = debounce(() => {
+      if (shouldElementRender(ref)) {
+        setShouldRender(true);
       }
     }, DEBOUNCE_SCROLL_HANDLER_MS);
 
-    if (ref) {
-      handleDisplayingRef();
+    if (ref && ref.current && !shouldRender) {
+      window.addEventListener('scroll', handleDisplayingRef);
+      return () => window.removeEventListener('scroll', handleDisplayingRef);
     }
-  }, [ref, setShouldRender, shouldRender]);
+  }, [ref, setShouldRender, shouldRender, shouldElementRender]);
 
   const render = props.skipWait || shouldRender;
 

--- a/ui/component/common/wait-until-on-page.jsx
+++ b/ui/component/common/wait-until-on-page.jsx
@@ -8,31 +8,40 @@ type Props = {
   children: any,
   skipWait?: boolean,
   placeholder?: any,
+  yOffset?: number,
 };
 
 export default function WaitUntilOnPage(props: Props) {
+  const { yOffset } = props;
   const ref = React.useRef();
   const [shouldRender, setShouldRender] = React.useState(false);
 
-  const shouldElementRender = React.useCallback((ref) => {
-    const element = ref && ref.current;
-    if (element) {
-      const bounding = element.getBoundingClientRect();
-      if (
-        bounding.width > 0 &&
-        bounding.height > 0 &&
-        bounding.bottom >= 0 &&
-        bounding.right >= 0 &&
+  const shouldElementRender = React.useCallback(
+    (ref) => {
+      const element = ref && ref.current;
+      if (element) {
+        const bounding = element.getBoundingClientRect();
         // $FlowFixMe
-        bounding.top <= (window.innerHeight || document.documentElement.clientHeight) &&
+        const windowH = window.innerHeight || document.documentElement.clientHeight;
         // $FlowFixMe
-        bounding.left <= (window.innerWidth || document.documentElement.clientWidth)
-      ) {
-        return true;
+        const windowW = window.innerWidth || document.documentElement.clientWidth;
+
+        const isApproachingViewport = yOffset && bounding.top < windowH + yOffset;
+        const isInViewport = // also covers "element is larger than viewport".
+          bounding.width > 0 &&
+          bounding.height > 0 &&
+          bounding.bottom >= 0 &&
+          bounding.right >= 0 &&
+          bounding.top <= windowH &&
+          bounding.left <= windowW;
+
+        return isInViewport || isApproachingViewport;
       }
-    }
-    return false;
-  }, []);
+
+      return false;
+    },
+    [yOffset]
+  );
 
   // Handles "element is already in viewport when mounted".
   React.useEffect(() => {

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -63,7 +63,7 @@ function HomePage(props: Props) {
 
         {index === 0 && <>{claimTiles}</>}
         {index !== 0 && (
-          <WaitUntilOnPage name={title} placeholder={tilePlaceholder}>
+          <WaitUntilOnPage name={title} placeholder={tilePlaceholder} yOffset={800}>
             {claimTiles}
           </WaitUntilOnPage>
         )}


### PR DESCRIPTION
See commit messages for complete walkthrough.

## Issues
- `WaitUntilOnPage` never unregisters scroll-callback, and was also registering on every update.
- Run `claim_search` when category is approaching the viewport.
- `WaitUntilOnPage` was not responding to window-resize or zoom changes, so it could stay hidden until a scroll event happens.