### PR TITLE
Fix RSS icon not having a gap

### DIFF
--- a/ui/component/common/icon-custom.jsx
+++ b/ui/component/common/icon-custom.jsx
@@ -2299,21 +2299,9 @@ export const icons = {
       </g>
     </svg>
   ),
-  [ICONS.RSS]: (props: CustomProps) => (
-    <svg
-      viewBox="0 0 24 24"
-      width={props.size || '18'}
-      height={props.size || '18'}
-      xmlns="http://www.w3.org/2000/svg"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      stroke="currentColor"
-      fill="none"
-    >
-      <g>
-        <path d="M.75 19.497a3.75 3.75 0 107.5 0 3.75 3.75 0 10-7.5 0zM.75 8.844a11.328 11.328 0 0114.4 14.4M.75 1.113a18.777 18.777 0 0122.139 22.123" />
-      </g>
-    </svg>
+  [ICONS.RSS]: buildIcon(
+    <g>
+      <path d="M.75 19.497a3.75 3.75 0 107.5 0 3.75 3.75 0 10-7.5 0zM.75 8.844a11.328 11.328 0 0114.4 14.4M.75 1.113a18.777 18.777 0 0122.139 22.123" />
+    </g>
   ),
 };


### PR DESCRIPTION
@jessopb, is this the right fix?  What puzzles me is that if `buildIcon` is needed for props to be forwarded, then shouldn't all icons use it to avoid surprises?



![image](https://user-images.githubusercontent.com/64950861/124507993-902af500-de01-11eb-8489-0ef2e617c413.png)
