### PR TITLE
remove words like "revoke" and "claim" from abandon modal

### DIFF
--- a/ui/modal/modalRemoveFile/view.jsx
+++ b/ui/modal/modalRemoveFile/view.jsx
@@ -32,7 +32,7 @@ function ModalRemoveFile(props: Props) {
         title={__('Remove File')}
         subtitle={
           <I18nMessage tokens={{ title: <cite>{`"${title}"`}</cite> }}>
-            Are you sure you'd like to remove %title% from LBRY?
+            Are you sure you'd like to remove %title%?
           </I18nMessage>
         }
         body={
@@ -55,7 +55,7 @@ function ModalRemoveFile(props: Props) {
                     <I18nMessage
                       tokens={{ lbc: <LbcSymbol prefix={__('reclaim %amount%', { amount: claim.amount })} /> }}
                     >
-                      Abandon on blockchain (%lbc%)
+                      Remove from blockchain (%lbc%)
                     </I18nMessage>
                   }
                   type="checkbox"
@@ -63,7 +63,7 @@ function ModalRemoveFile(props: Props) {
                   onChange={() => setAbandonChecked(!abandonChecked)}
                 />
                 {abandonChecked === true && (
-                  <p className="help error__text">{__('This action is permanent and cannot be undone.')}</p>
+                  <p className="help error__text">{__('This action is permanent and cannot be undone')}</p>
                 )}
 
                 {/* @if TARGET='app' */}
@@ -86,7 +86,7 @@ function ModalRemoveFile(props: Props) {
               <Button
                 button="primary"
                 label={isAbandoning ? __('Removing...') : __('OK')}
-                disabled={isAbandoning}
+                disabled={isAbandoning || !(deleteChecked || abandonChecked)}
                 onClick={() => deleteFile(uri, deleteChecked, claimIsMine ? abandonChecked : false)}
               />
               <Button button="link" label={__('Cancel')} onClick={closeModal} />

--- a/ui/modal/modalRevokeClaim/view.jsx
+++ b/ui/modal/modalRevokeClaim/view.jsx
@@ -34,22 +34,24 @@ export default function ModalRevokeClaim(props: Props) {
 
   function getButtonLabel(type: string, isSupport: boolean) {
     if (isSupport && type === txnTypes.SUPPORT) {
-      return __('Confirm Support Revoke');
+      return __('Confirm Support Removal');
     } else if (type === txnTypes.SUPPORT) {
       return __('Confirm Tip Unlock');
+    } else if (type === txnTypes.CHANNEL) {
+      return __('Confirm Channel Removal');
     }
-    return __('Confirm Claim Revoke');
+    return __('Confirm Removal');
   }
 
   function getMsgBody(type: string, isSupport: boolean, name: string) {
     if (isSupport && type === txnTypes.SUPPORT) {
       return (
         <React.Fragment>
-          <p>{__('Are you sure you want to remove this support?')}</p>
+          <p>{__('Are you sure you want to remove this boost?')}</p>
           <p>
             <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>
-              These Credits are permanently yours and can be removed at any time. Removing this support will reduce the
-              claim's discoverability and return the %lbc% to your spendable balance.
+              These Credits are permanently yours and this boost can be removed at any time. Removing this boost will reduce 
+              discoverability and return %lbc% to your spendable balance.
             </I18nMessage>
           </p>
         </React.Fragment>
@@ -60,7 +62,7 @@ export default function ModalRevokeClaim(props: Props) {
           <p>{__('Are you sure you want to unlock these Credits?')}</p>
           <p>
             {__(
-              'These Credits are permanently yours and can be unlocked at any time. Unlocking them allows you to spend them, but can hurt the performance of your content in lookups and search results. It is recommended you leave tips locked until you need or want to spend them.'
+              'These Credits are permanently yours and can be unlocked at any time. Unlocking them allows you to spend them, but reduces discoverability of your content in lookups and search results. It is recommended you leave Credits locked until you need or want to spend them.'
             )}
           </p>
         </React.Fragment>
@@ -70,10 +72,10 @@ export default function ModalRevokeClaim(props: Props) {
         <React.Fragment>
           <p>
             {__(
-              "You're about to permanently delete a channel. Content published under this channel will be orphaned and their signing channel invalid. Content sync programs using this channel will fail."
+              "This will permanently remove your channel. Content published under this channel will be orphaned."
             )}
           </p>
-          <p>{__('Are you sure? Type %name% to confirm that you wish to delete the channel.', { name })}</p>
+          <p>{__('Are you sure? Type %name% to confirm that you wish to remove the channel.', { name })}</p>
           <FormField type={'text'} onChange={e => setChannelName(e.target.value)} />
         </React.Fragment>
       );
@@ -81,11 +83,11 @@ export default function ModalRevokeClaim(props: Props) {
 
     return (
       <React.Fragment>
-        <p>{__('Are you sure you want to revoke this claim?')}</p>
+        <p>{__('Are you sure you want to remove this?')}</p>
         <p>
           <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>
             This will prevent others from resolving and accessing the content you published. It will return the %lbc% to
-            your spendable balance, less a small transaction fee.
+            your spendable balance.
           </I18nMessage>
         </p>
         <p className="help error__text"> {__('FINAL WARNING: This action is permanent and cannot be undone.')}</p>

--- a/ui/modal/modalRevokeClaim/view.jsx
+++ b/ui/modal/modalRevokeClaim/view.jsx
@@ -50,8 +50,8 @@ export default function ModalRevokeClaim(props: Props) {
           <p>{__('Are you sure you want to remove this boost?')}</p>
           <p>
             <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>
-              These Credits are permanently yours and this boost can be removed at any time. Removing this boost will reduce 
-              discoverability and return %lbc% to your spendable balance.
+              These Credits are permanently yours and this boost can be removed at any time. Removing this boost will
+              reduce discoverability and return %lbc% to your spendable balance.
             </I18nMessage>
           </p>
         </React.Fragment>
@@ -71,12 +71,10 @@ export default function ModalRevokeClaim(props: Props) {
       return (
         <React.Fragment>
           <p>
-            {__(
-              "This will permanently remove your channel. Content published under this channel will be orphaned."
-            )}
+            {__('This will permanently remove your channel. Content published under this channel will be orphaned.')}
           </p>
           <p>{__('Are you sure? Type %name% to confirm that you wish to remove the channel.', { name })}</p>
-          <FormField type={'text'} onChange={e => setChannelName(e.target.value)} />
+          <FormField type={'text'} onChange={(e) => setChannelName(e.target.value)} />
         </React.Fragment>
       );
     }


### PR DESCRIPTION
I edited this on GitHub and didn't run it