### PR TITLE
clear stale js files on nonprod environments

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -77,6 +77,15 @@ if (fs.existsSync(CUSTOM_OG_PATH)) {
   });
 }
 
+// clear the dist folder of existing js files before compilation
+let regex = /^.*\.(json|js|map)$/;
+// only run on nonprod environments to avoid side effects on prod
+if (!isProduction) {
+  fs.readdirSync(`${DIST_ROOT}/public/`)
+    .filter(f => regex.test(f))
+    .map(f => fs.unlinkSync(`${DIST_ROOT}/public/` + f));
+}
+
 const ROBOTS_TXT_PATH = `${CUSTOM_ROOT}/robots.txt`;
 if (fs.existsSync(ROBOTS_TXT_PATH)) {
   copyWebpackCommands.push({


### PR DESCRIPTION
The old JS clearing functionality but only run when it's not on prod

Useful for development to avoid a buildup of JS files in the dist/public folder