### PR TITLE
Rename default import/exports for clarity in text search (no functional change)

### DIFF
--- a/ui/component/channelContent/index.js
+++ b/ui/component/channelContent/index.js
@@ -14,7 +14,7 @@ import { withRouter } from 'react-router';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { makeSelectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
 
-import ChannelPage from './view';
+import ChannelContent from './view';
 
 const select = (state, props) => {
   const { search } = props.location;
@@ -37,4 +37,4 @@ const perform = (dispatch) => ({
   doResolveUris: (uris, returnCachedUris) => dispatch(doResolveUris(uris, returnCachedUris)),
 });
 
-export default withRouter(connect(select, perform)(ChannelPage));
+export default withRouter(connect(select, perform)(ChannelContent));

--- a/ui/component/channelEdit/index.js
+++ b/ui/component/channelEdit/index.js
@@ -17,7 +17,7 @@ import {
 } from 'lbry-redux';
 import { doOpenModal } from 'redux/actions/app';
 import { doUpdateBlockListForPublishedChannel } from 'redux/actions/comments';
-import ChannelPage from './view';
+import ChannelForm from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
@@ -52,4 +52,4 @@ const perform = (dispatch) => ({
   clearChannelErrors: () => dispatch(doClearChannelErrors()),
 });
 
-export default connect(select, perform)(ChannelPage);
+export default connect(select, perform)(ChannelForm);

--- a/ui/component/channelMuteButton/view.jsx
+++ b/ui/component/channelMuteButton/view.jsx
@@ -10,7 +10,7 @@ type Props = {
   doChannelUnmute: (string, boolean) => void,
 };
 
-function ChannelBlockButton(props: Props) {
+function ChannelMuteButton(props: Props) {
   const { uri, doChannelMute, doChannelUnmute, isMuted } = props;
 
   function handleClick() {
@@ -22,12 +22,8 @@ function ChannelBlockButton(props: Props) {
   }
 
   return (
-    <Button
-      button={isMuted ? 'alt' : 'secondary'}
-      label={isMuted ? __('Unmute') : __('Mute')}
-      onClick={handleClick}
-    />
+    <Button button={isMuted ? 'alt' : 'secondary'} label={isMuted ? __('Unmute') : __('Mute')} onClick={handleClick} />
   );
 }
 
-export default ChannelBlockButton;
+export default ChannelMuteButton;

--- a/ui/component/channelSelector/index.js
+++ b/ui/component/channelSelector/index.js
@@ -2,9 +2,9 @@ import { connect } from 'react-redux';
 import { selectMyChannelClaims } from 'lbry-redux';
 import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
 import { doSetActiveChannel, doSetIncognito } from 'redux/actions/app';
-import SelectChannel from './view';
+import ChannelSelector from './view';
 
-const select = state => ({
+const select = (state) => ({
   channels: selectMyChannelClaims(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   incognito: selectIncognito(state),
@@ -13,4 +13,4 @@ const select = state => ({
 export default connect(select, {
   doSetActiveChannel,
   doSetIncognito,
-})(SelectChannel);
+})(ChannelSelector);

--- a/ui/component/claimCollectionAddButton/index.js
+++ b/ui/component/claimCollectionAddButton/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { doOpenModal } from 'redux/actions/app';
-import PlaylistAddButton from './view';
+import CollectionAddButton from './view';
 import { makeSelectClaimForUri } from 'lbry-redux';
 
 const select = (state, props) => ({
@@ -9,4 +9,4 @@ const select = (state, props) => ({
 
 export default connect(select, {
   doOpenModal,
-})(PlaylistAddButton);
+})(CollectionAddButton);

--- a/ui/component/collectionEdit/index.js
+++ b/ui/component/collectionEdit/index.js
@@ -19,7 +19,7 @@ import {
 } from 'lbry-redux';
 import { doOpenModal } from 'redux/actions/app';
 
-import CollectionPage from './view';
+import CollectionForm from './view';
 import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
 
 const select = (state, props) => ({
@@ -50,4 +50,4 @@ const perform = (dispatch) => ({
   clearCollectionErrors: () => dispatch({ type: LBRY_REDUX_ACTIONS.CLEAR_COLLECTION_ERRORS }),
 });
 
-export default connect(select, perform)(CollectionPage);
+export default connect(select, perform)(CollectionForm);

--- a/ui/component/collectionMenuList/view.jsx
+++ b/ui/component/collectionMenuList/view.jsx
@@ -15,7 +15,7 @@ type Props = {
   collectionId: string,
 };
 
-function ClaimMenuList(props: Props) {
+function CollectionMenuList(props: Props) {
   const { inline = false, collectionId, collectionName, doOpenModal } = props;
 
   const { push } = useHistory();
@@ -65,4 +65,4 @@ function ClaimMenuList(props: Props) {
   );
 }
 
-export default ClaimMenuList;
+export default CollectionMenuList;

--- a/ui/component/collectionPreviewOverlay/view.jsx
+++ b/ui/component/collectionPreviewOverlay/view.jsx
@@ -14,7 +14,7 @@ type Props = {
   collectionItemUrls: Array<string>,
 };
 
-function CollectionPreviewTileOverlay(props: Props) {
+function CollectionPreviewOverlay(props: Props) {
   const { collectionItemUrls } = props;
 
   if (collectionItemUrls && collectionItemUrls.length > 0) {
@@ -39,4 +39,4 @@ function CollectionPreviewTileOverlay(props: Props) {
   return null;
 }
 
-export default withRouter(CollectionPreviewTileOverlay);
+export default withRouter(CollectionPreviewOverlay);

--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -22,7 +22,7 @@ type Props = {
   supportAmount: number,
 };
 
-function Comment(props: Props) {
+function LivestreamComment(props: Props) {
   const { claim, uri, authorUri, message, commentIsMine, commentId, stakedLevel, supportAmount } = props;
   const [mouseIsHovering, setMouseHover] = React.useState(false);
   const commentByOwnerOfContent = claim && claim.signing_channel && claim.signing_channel.permanent_url === authorUri;
@@ -85,4 +85,4 @@ function Comment(props: Props) {
   );
 }
 
-export default Comment;
+export default LivestreamComment;

--- a/ui/component/livestreamComments/index.js
+++ b/ui/component/livestreamComments/index.js
@@ -8,7 +8,7 @@ import {
   makeSelectSuperChatsForUri,
   makeSelectSuperChatTotalAmountForUri,
 } from 'redux/selectors/comments';
-import LivestreamFeed from './view';
+import LivestreamComments from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
@@ -24,4 +24,4 @@ export default connect(select, {
   doCommentSocketDisconnect,
   doCommentList,
   doSuperChatList,
-})(LivestreamFeed);
+})(LivestreamComments);

--- a/ui/component/livestreamList/index.js
+++ b/ui/component/livestreamList/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
-import LivestreamCurrent from './view';
+import LivestreamList from './view';
 
 const select = (state) => ({});
 
-export default connect(select)(LivestreamCurrent);
+export default connect(select)(LivestreamList);

--- a/ui/component/markdownLink/index.js
+++ b/ui/component/markdownLink/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import { doOpenModal } from 'redux/actions/app';
-import ExternalLink from './view';
+import MarkdownLink from './view';
 
 const select = () => ({});
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   openModal: (modal, props) => dispatch(doOpenModal(modal, props)),
 });
 
-export default connect(select, perform)(ExternalLink);
+export default connect(select, perform)(MarkdownLink);

--- a/ui/component/nagContinueFirstRun/index.js
+++ b/ui/component/nagContinueFirstRun/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
 import { SETTINGS } from 'lbry-redux';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
-import UserSignIn from './view';
+import NagContinueFirstRun from './view';
 
-const select = state => ({
+const select = (state) => ({
   followingAcknowledged: makeSelectClientSetting(SETTINGS.FOLLOWING_ACKNOWLEDGED)(state),
   firstRunStarted: makeSelectClientSetting(SETTINGS.FIRST_RUN_STARTED)(state),
 });
 
-export default connect(select)(UserSignIn);
+export default connect(select)(NagContinueFirstRun);

--- a/ui/component/notificationBubble/index.js
+++ b/ui/component/notificationBubble/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
 import { selectUnseenNotificationCount } from 'redux/selectors/notifications';
 import { selectUser } from 'redux/selectors/user';
-import NotificationBubble from './view';
+import NotificationHeaderButton from './view';
 
 const select = (state) => ({
   unseenCount: selectUnseenNotificationCount(state),
   user: selectUser(state),
 });
 
-export default connect(select)(NotificationBubble);
+export default connect(select)(NotificationHeaderButton);

--- a/ui/component/notificationContentChannelMenu/index.js
+++ b/ui/component/notificationContentChannelMenu/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { doChannelSubscribe } from 'redux/actions/subscriptions';
 import { doToast } from 'redux/actions/notifications';
 import { makeSelectNotificationsDisabled } from 'redux/selectors/subscriptions';
-import SubscribeButton from './view';
+import NotificationContentChannelMenu from './view';
 
 const select = (state, props) => ({
   notificationsDisabled: makeSelectNotificationsDisabled(props.uri)(state),
@@ -11,4 +11,4 @@ const select = (state, props) => ({
 export default connect(select, {
   doChannelSubscribe,
   doToast,
-})(SubscribeButton);
+})(NotificationContentChannelMenu);

--- a/ui/component/publishAdditionalOptions/index.js
+++ b/ui/component/publishAdditionalOptions/index.js
@@ -1,18 +1,18 @@
 import { connect } from 'react-redux';
 import { selectPublishFormValues, doUpdatePublishForm } from 'lbry-redux';
-import PublishPage from './view';
+import PublishAdditionalOptions from './view';
 import { selectUser, selectAccessToken } from 'redux/selectors/user';
 import { doFetchAccessToken } from 'redux/actions/user';
 
-const select = state => ({
+const select = (state) => ({
   ...selectPublishFormValues(state),
   accessToken: selectAccessToken(state),
   user: selectUser(state),
 });
 
-const perform = dispatch => ({
-  updatePublishForm: value => dispatch(doUpdatePublishForm(value)),
+const perform = (dispatch) => ({
+  updatePublishForm: (value) => dispatch(doUpdatePublishForm(value)),
   fetchAccessToken: () => dispatch(doFetchAccessToken()),
 });
 
-export default connect(select, perform)(PublishPage);
+export default connect(select, perform)(PublishAdditionalOptions);

--- a/ui/component/recommendedContent/index.js
+++ b/ui/component/recommendedContent/index.js
@@ -4,7 +4,7 @@ import { doFetchRecommendedContent } from 'redux/actions/search';
 import { makeSelectRecommendedContentForUri, selectIsSearching } from 'redux/selectors/search';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { makeSelectNextUnplayedRecommended } from 'redux/selectors/content';
-import RecommendedVideos from './view';
+import RecommendedContent from './view';
 
 const select = (state, props) => ({
   mature: makeSelectClaimIsNsfw(props.uri)(state),
@@ -19,4 +19,4 @@ const perform = (dispatch) => ({
   doFetchRecommendedContent: (uri, mature) => dispatch(doFetchRecommendedContent(uri, mature)),
 });
 
-export default connect(select, perform)(RecommendedVideos);
+export default connect(select, perform)(RecommendedContent);

--- a/ui/page/settingsAdvanced/index.js
+++ b/ui/page/settingsAdvanced/index.js
@@ -17,10 +17,10 @@ import {
   selectFindingFFmpeg,
 } from 'redux/selectors/settings';
 import { doWalletStatus, selectWalletIsEncrypted, SETTINGS } from 'lbry-redux';
-import SettingsPage from './view';
+import SettingsAdvancedPage from './view';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 
-const select = state => ({
+const select = (state) => ({
   daemonSettings: selectDaemonSettings(state),
   allowAnalytics: selectAllowAnalytics(state),
   isAuthenticated: selectUserVerifiedEmail(state),
@@ -34,18 +34,18 @@ const select = state => ({
   syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
 });
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   setDaemonSetting: (key, value) => dispatch(doSetDaemonSetting(key, value)),
-  clearDaemonSetting: key => dispatch(doClearDaemonSetting(key)),
+  clearDaemonSetting: (key) => dispatch(doClearDaemonSetting(key)),
   clearCache: () => dispatch(doClearCache()),
   setClientSetting: (key, value) => dispatch(doSetClientSetting(key, value)),
   encryptWallet: () => dispatch(doNotifyEncryptWallet()),
   decryptWallet: () => dispatch(doNotifyDecryptWallet()),
   updateWalletStatus: () => dispatch(doWalletStatus()),
-  confirmForgetPassword: modalProps => dispatch(doNotifyForgetPassword(modalProps)),
+  confirmForgetPassword: (modalProps) => dispatch(doNotifyForgetPassword(modalProps)),
   findFFmpeg: () => dispatch(doFindFFmpeg()),
   enterSettings: () => dispatch(doEnterSettingsPage()),
   exitSettings: () => dispatch(doExitSettingsPage()),
 });
 
-export default connect(select, perform)(SettingsPage);
+export default connect(select, perform)(SettingsAdvancedPage);

--- a/ui/page/settingsAdvanced/view.jsx
+++ b/ui/page/settingsAdvanced/view.jsx
@@ -38,7 +38,7 @@ type DaemonSettings = {
 
 type Props = {
   setDaemonSetting: (string, ?SetDaemonSettingArg) => void,
-  clearDaemonSetting: string => void,
+  clearDaemonSetting: (string) => void,
   setClientSetting: (string, SetDaemonSettingArg) => void,
   daemonSettings: DaemonSettings,
   isAuthenticated: boolean,
@@ -64,7 +64,7 @@ type State = {
   storedPassword: boolean,
 };
 
-class SettingsPage extends React.PureComponent<Props, State> {
+class SettingsAdvancedPage extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -98,7 +98,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
 
     if (isAuthenticated || !IS_WEB) {
       this.props.updateWalletStatus();
-      getPasswordFromCookie().then(p => {
+      getPasswordFromCookie().then((p) => {
         if (typeof p === 'string') {
           this.setState({ storedPassword: true });
         }
@@ -493,7 +493,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
                         onChange={this.onMaxConnectionsChange}
                         value={daemonSettings.max_connections_per_download}
                       >
-                        {connectionOptions.map(connectionOption => (
+                        {connectionOptions.map((connectionOption) => (
                           <option key={connectionOption} value={connectionOption}>
                             {connectionOption}
                           </option>
@@ -521,4 +521,4 @@ class SettingsPage extends React.PureComponent<Props, State> {
   }
 }
 
-export default SettingsPage;
+export default SettingsAdvancedPage;

--- a/ui/page/settingsNotifications/index.js
+++ b/ui/page/settingsNotifications/index.js
@@ -2,15 +2,15 @@ import { connect } from 'react-redux';
 import { doSetClientSetting } from 'redux/actions/settings';
 import { selectosNotificationsEnabled } from 'redux/selectors/settings';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
-import SettingsPage from './view';
+import NotificationSettingsPage from './view';
 
-const select = state => ({
+const select = (state) => ({
   osNotificationsEnabled: selectosNotificationsEnabled(state),
   isAuthenticated: Boolean(selectUserVerifiedEmail(state)),
 });
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   setClientSetting: (key, value) => dispatch(doSetClientSetting(key, value)),
 });
 
-export default connect(select, perform)(SettingsPage);
+export default connect(select, perform)(NotificationSettingsPage);

--- a/ui/page/settingsStripeCard/index.js
+++ b/ui/page/settingsStripeCard/index.js
@@ -3,16 +3,16 @@ import { doSetClientSetting } from 'redux/actions/settings';
 import { selectosNotificationsEnabled } from 'redux/selectors/settings';
 import { selectUserVerifiedEmail, selectUserEmail } from 'redux/selectors/user';
 
-import SettingsPage from './view';
+import SettingsStripeCard from './view';
 
-const select = state => ({
+const select = (state) => ({
   osNotificationsEnabled: selectosNotificationsEnabled(state),
   isAuthenticated: Boolean(selectUserVerifiedEmail(state)),
   email: selectUserEmail(state),
 });
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   setClientSetting: (key, value) => dispatch(doSetClientSetting(key, value)),
 });
 
-export default connect(select, perform)(SettingsPage);
+export default connect(select, perform)(SettingsStripeCard);

--- a/ui/page/settingsStripeCard/view.jsx
+++ b/ui/page/settingsStripeCard/view.jsx
@@ -35,7 +35,7 @@ if (STRIPE_PUBLIC_KEY.indexOf('pk_live') > -1) {
 //   scriptFailedToLoad: boolean,
 // };
 
-class CardVerify extends React.Component<Props, State> {
+class SettingsStripeCard extends React.Component<Props, State> {
   constructor(props) {
     // :Props
     super(props);
@@ -472,6 +472,6 @@ class CardVerify extends React.Component<Props, State> {
   }
 }
 
-export default CardVerify;
+export default SettingsStripeCard;
 /* eslint-enable no-undef */
 /* eslint-enable react/prop-types */


### PR DESCRIPTION
I believe it was just due to copy/pasting from another file and not renaming it.
