### PR TITLE
Odysee: fix missing '--color-help-warning-bg' for Dark

### DIFF
--- a/ui/scss/init/_gui.scss
+++ b/ui/scss/init/_gui.scss
@@ -286,7 +286,6 @@ textarea {
 .help--warning {
   @extend .help;
   padding: var(--spacing-s);
-  color: var(--color-black);
   border-radius: var(--border-radius);
   background-color: var(--color-help-warning-bg);
   color: var(--color-help-warning-text);

--- a/ui/scss/themes/dark.scss
+++ b/ui/scss/themes/dark.scss
@@ -24,6 +24,7 @@
   --color-blockquote: var(--color-gray-5);
   --color-blockquote-bg: var(--color-card-background-highlighted);
   --color-help-warning-text: var(--color-white-alt);
+  --color-help-warning-bg: #fbbf2450;
 
   // Tags (words)
   --color-tag-words: var(--color-text);


### PR DESCRIPTION
Probably got lost in a rebase