### PR TITLE
Fix missing "currrent/remaining time" control is mobile

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -497,7 +497,7 @@ video::-internal-media-controls-overlay-cast-button {
   // --- Unhide desired components per layout ---
   &.vjs-layout-x-small {
     .vjs-playback-rate {
-      display: inherit;
+      display: flex !important;
     }
   }
 
@@ -506,7 +506,7 @@ video::-internal-media-controls-overlay-cast-button {
     .vjs-time-divider,
     .vjs-duration,
     .vjs-playback-rate {
-      display: inherit;
+      display: flex !important;
     }
   }
 


### PR DESCRIPTION
## Issue
Closes #6447

## Root-cause
`https://github.com/videojs/video.js/pull/7098`

videojs was recently upgraded.

## Change
Override videojs default theme of hiding the time control in smaller layouts.
