### PR TITLE
Minor fix suggestion: Default to "TAB_BOOST" when supporting own claims

### DIFF
--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -149,10 +149,25 @@ function WalletSendTip(props: Props) {
 
   const [activeTab, setActiveTab] = React.useState(claimIsMine ? TAB_BOOST : TAB_LBC);
 
+  function setClaimTypeText() {
+    if (claim.value_type === 'stream') {
+      return __('Content'); 
+    } else if (claim.value_type === 'channel') {
+      return __('Channel');
+    } else if (claim.value_type === 'repost') {
+      return __('Repost');
+    } else if (claim.value_type === 'collection') {
+      return __('List');
+    }	else {
+      return __('Claim');
+    }
+  }
+  const claimTypeText = setClaimTypeText();
+
   let iconToUse, explainerText;
   if (activeTab === TAB_BOOST) {
     iconToUse = ICONS.LBC;
-    explainerText = __('This refundable boost will improve the discoverability of this content while active.');
+    explainerText = __('This refundable boost will improve the discoverability of this %claimTypeText% while active.', {claimTypeText});
   } else if (activeTab === TAB_FIAT) {
     iconToUse = ICONS.FINANCE;
     explainerText = __('Show this channel your appreciation by sending a donation of cash in USD.');
@@ -289,7 +304,7 @@ function WalletSendTip(props: Props) {
     const displayAmount = !isNan(tipAmount) ? tipAmount : '';
 
     if (activeTab === TAB_BOOST) {
-      return __('Boost This Content');
+      return (claimIsMine ?  __('Boost Your %claimTypeText%', {claimTypeText}) : __('Boost This %claimTypeText%', {claimTypeText}));
     } else if (activeTab === TAB_FIAT) {
       return __('Send a $%displayAmount% Tip', { displayAmount });
     } else if (activeTab === TAB_LBC) {
@@ -341,7 +356,7 @@ function WalletSendTip(props: Props) {
       ) : (
         // if there is lbc, the main tip/boost gui with the 3 tabs at the top
         <Card
-          title={<LbcSymbol postfix={claimIsMine ? __('Boost your content') : __('Support this content')} size={22} />}
+          title={<LbcSymbol postfix={claimIsMine ? __('Boost Your %claimTypeText%', {claimTypeText}) : __('Support This %claimTypeText%', {claimTypeText})} size={22} />}
           subtitle={
             <React.Fragment>
               {!claimIsMine && (

--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -147,7 +147,7 @@ function WalletSendTip(props: Props) {
   const noBalance = balance === 0;
   const tipAmount = useCustomTip ? customTipAmount : presetTipAmount;
 
-  const [activeTab, setActiveTab] = React.useState(TAB_LBC);
+  const [activeTab, setActiveTab] = React.useState(claimIsMine ? TAB_BOOST : TAB_LBC);
 
   let iconToUse, explainerText;
   if (activeTab === TAB_BOOST) {

--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -151,14 +151,14 @@ function WalletSendTip(props: Props) {
 
   function setClaimTypeText() {
     if (claim.value_type === 'stream') {
-      return __('Content'); 
+      return __('Content');
     } else if (claim.value_type === 'channel') {
       return __('Channel');
     } else if (claim.value_type === 'repost') {
       return __('Repost');
     } else if (claim.value_type === 'collection') {
       return __('List');
-    }	else {
+    } else {
       return __('Claim');
     }
   }


### PR DESCRIPTION
Someone mentioned about odysee.com showing "tip" related text when supporting **own** claims. Now it should default to "Boost" related text for **own** claims.

L167: Line not edited but not sure if "claimIsMine" is needed there any more.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:


## Fixes

Issue Number:

## What is the current behavior?
When supporting own channel ,app/site shows text about tipping.

## What is the new behavior?
When supporting own channel, app/site shows text about boosting.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
