### PR TITLE
Fix continuous reaction fetch in incognito

### DIFF
--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -130,7 +130,7 @@ function CommentList(props: Props) {
       } else {
         idsForReactionFetch = allCommentIds.filter((commentId) => {
           const key = activeChannelId ? `${commentId}:${activeChannelId}` : commentId;
-          return !othersReactsById[key] || !myReactsByCommentId[key];
+          return !othersReactsById[key] || (activeChannelId && !myReactsByCommentId[key]);
         });
       }
 


### PR DESCRIPTION
myReactions will never be filled in incognito. Also, it's probably enough to just check othersReactions, but for now, still do both when logged in.
