### PR TITLE
Beautify/elaborate comment spam-check message

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1452,6 +1452,7 @@
   "Unable to comment. This channel has blocked you.": "Unable to comment. This channel has blocked you.",
   "Unable to comment. Your channel has been blocked by an admin.": "Unable to comment. Your channel has been blocked by an admin.",
   "Unable to comment. The content owner has disabled comments.": "Unable to comment. The content owner has disabled comments.",
+  "Please do not spam.": "Please do not spam.",
   "Slow mode is on. Please wait up to %value% seconds before commenting again.": "Slow mode is on. Please wait up to %value% seconds before commenting again.",
   "The comment contains contents that are blocked by %author%": "The comment contains contents that are blocked by %author%",
   "Your channel is still being setup, try again in a few moments.": "Your channel is still being setup, try again in a few moments.",

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -348,6 +348,9 @@ export function doCommentCreate(
             case 'comments are disabled by the creator':
               toastMessage = __('Unable to comment. The content owner has disabled comments.');
               break;
+            case 'duplicate comment!':
+              toastMessage = __('Please do not spam.');
+              break;
             default:
               const BLOCKED_WORDS_ERR_MSG = 'the comment contents are blocked by';
               const SLOW_MODE_PARTIAL_ERR_MSG = 'Slow mode is on. Please wait at most';


### PR DESCRIPTION
Feel free to change the text.  Currently, we are showing "Unable to create comment".  Neither that nor "duplicate comment!" looks polished.