### PR TITLE
Preload fonts properly with 'crossorigin'

### DIFF
--- a/static/index-web.html
+++ b/static/index-web.html
@@ -7,12 +7,12 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <link rel="icon" type="image/png" href="/public/favicon.png" />
 
-    <link rel="preload" href="/public/font/v1/300.woff" as="font" type="font/woff" />
-    <link rel="preload" href="/public/font/v1/300i.woff" as="font" type="font/woff" />
-    <link rel="preload" href="/public/font/v1/400.woff" as="font" type="font/woff" />
-    <link rel="preload" href="/public/font/v1/400i.woff" as="font" type="font/woff" />
-    <link rel="preload" href="/public/font/v1/700.woff" as="font" type="font/woff" />
-    <link rel="preload" href="/public/font/v1/700i.woff" as="font" type="font/woff" />
+    <link rel="preload" href="/public/font/v1/300.woff" as="font" type="font/woff" crossorigin />
+    <link rel="preload" href="/public/font/v1/300i.woff" as="font" type="font/woff" crossorigin />
+    <link rel="preload" href="/public/font/v1/400.woff" as="font" type="font/woff" crossorigin />
+    <link rel="preload" href="/public/font/v1/400i.woff" as="font" type="font/woff" crossorigin />
+    <link rel="preload" href="/public/font/v1/700.woff" as="font" type="font/woff" crossorigin />
+    <link rel="preload" href="/public/font/v1/700i.woff" as="font" type="font/woff" crossorigin />
 
     <style>
       @font-face {


### PR DESCRIPTION
We probably don't need to preload fonts (it will reduce browser warnings), since it wasn't working all this while.

But it's probably there to address something (perhaps to handle OG better?), so do it right by setting the proper flags.
https://stackoverflow.com/questions/1330825/preloading-font-face-fonts/46830425#comment87712868_46830425

## Before
Font is re-fetched
<img src="https://user-images.githubusercontent.com/64950861/126203677-9a3e6985-62a2-4a22-82d3-4edd6fdcc2d9.png" width="400">

## After
<img src="https://user-images.githubusercontent.com/64950861/126203721-afa74405-8026-4b0f-89cc-666c40b8c6a5.png" width="400">
