### PR TITLE
Improve cache for hashed js files

### DIFF
--- a/web/middleware/cache-control.js
+++ b/web/middleware/cache-control.js
@@ -25,7 +25,9 @@ async function redirectMiddleware(ctx, next) {
     request: { url },
   } = ctx;
 
-  if (STATIC_ASSET_PATHS.includes(url) || (url.startsWith('/public/ui-') && url.endsWith('.js'))) {
+  const HASHED_JS_REGEX = /^\/public\/.*[a-fA-F0-9]{12}\.js$/i;
+
+  if (STATIC_ASSET_PATHS.includes(url) || HASHED_JS_REGEX.test(url)) {
     ctx.set('Cache-Control', `public, max-age=${SIX_MONTHS_IN_SECONDS}`);
   }
 


### PR DESCRIPTION
Cache any js file residing in `/public` that ends with a 12-character hash.  12 is the shortest among webpack-split files.

## Test
![image](https://user-images.githubusercontent.com/64950861/126300512-60c59702-a016-498d-94e8-a41bcd92c074.png)

