### PR TITLE
Fix channel-selector thumbnail not updating

### DIFF
--- a/ui/component/optimizedImage/view.jsx
+++ b/ui/component/optimizedImage/view.jsx
@@ -89,7 +89,9 @@ function OptimizedImage(props: Props) {
     } else {
       setOptimizedSrc(src);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    // We only want to run this on (1) initial mount and (2) 'src' change. Nothing else.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [src]);
 
   if (!src) {
     return null;


### PR DESCRIPTION
Recently changed to `<OptimizedImg>`, which was assuming the `src` never changes.

dejavu ... we also hit this issue when implementing the `IntersectionObserver` lazy-loading.