### PR TITLE
Fix CLS in `Recommended` section

### DIFF
--- a/ui/component/claimPreview/claim-preview-loading.jsx
+++ b/ui/component/claimPreview/claim-preview-loading.jsx
@@ -14,6 +14,7 @@ function ClaimPreviewLoading(props: Props) {
       className={classnames('claim-preview__wrapper', {
         'claim-preview__wrapper--channel': isChannel && type !== 'inline',
         'claim-preview__wrapper--inline': type === 'inline',
+        'claim-preview__wrapper--small': type === 'small',
       })}
     >
       <div className={classnames('claim-preview', { 'claim-preview--large': type === 'large' })}>

--- a/ui/scss/component/_ads.scss
+++ b/ui/scss/component/_ads.scss
@@ -33,6 +33,10 @@
     min-width: 15rem;
   }
 
+  .ads__injected-video {
+    aspect-ratio: 16 / 9;
+  }
+
   .avp-p-gui {
     z-index: 1 !important;
   }

--- a/web/component/ads/view.jsx
+++ b/web/component/ads/view.jsx
@@ -82,7 +82,7 @@ function Ads(props: Props) {
 
   const videoAd = (
     <div className="ads__claim-item">
-      <div id="62d1eb10-e362-4873-99ed-c64a4052b43b" />
+      <div id="62d1eb10-e362-4873-99ed-c64a4052b43b" className="ads__injected-video" />
       <div
         className={classnames('ads__claim-text', {
           'ads__claim-text--small': small,


### PR DESCRIPTION
## Issue
<img src="https://user-images.githubusercontent.com/64950861/126734774-1ea8f96c-447b-48c5-9681-c5d7a6914e7a.png" width="400">

[#6068 Fix "Cumulative Layout Shift" for Core Web Vitals ](https://github.com/lbryio/lbry-desktop/issues/6068)
[#6057 Investigate low Core Web Vitals score from google ](https://github.com/lbryio/lbry-desktop/issues/6057)

## Changes
- Fix wrapper-size mismatch between "loading" vs "loaded" state.
- Reserved space for video ads by assuming a 16:9 aspect ratio. 
  - When the ad is injection, the margin changed a bit. Not sure where that is coming from, but the impact is small on the score.