### PR TITLE
Fix muted-words now returning null instead of ""

### DIFF
--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -1390,7 +1390,9 @@ export const doFetchCreatorSettings = (channelClaimIds: Array<string> = []) => {
           const channelId = channelSignatures[i].claim_id;
           settingsByChannelId[channelId] = settings[i];
 
-          settingsByChannelId[channelId].words = settingsByChannelId[channelId].words.split(',');
+          if (settings[i].words) {
+            settingsByChannelId[channelId].words = settings[i].words.split(',');
+          }
 
           delete settingsByChannelId[channelId].channel_name;
           delete settingsByChannelId[channelId].channel_id;

--- a/ui/redux/reducers/comments.js
+++ b/ui/redux/reducers/comments.js
@@ -986,6 +986,11 @@ export default handleActions(
       fetchingSettings: false,
     }),
     [ACTIONS.COMMENT_FETCH_SETTINGS_COMPLETED]: (state: CommentsState, action: any) => {
+      // TODO: This is incorrect, as it could make 'settingsByChannelId' store
+      // only 1 channel with other channel's data purged. It works for now
+      // because the GUI only shows 1 channel's setting at a time, and *always*
+      // re-fetches to get latest data before displaying. Either rename this to
+      // 'activeChannelCreatorSettings', or append the new data properly.
       return {
         ...state,
         settingsByChannelId: action.data,


### PR DESCRIPTION
## Issue
Creating Settings suddenly start to stop loading correctly for some of my channels.

## Change
`settings.List` now returns null instead of empty array. Double-checked the Commentron repo and this is indeed the case.

Updated the code to handle null.