### PR TITLE
Remove console.log

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -497,7 +497,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   }
 
   function detectFileType() {
-    console.log(`Detecting file type via pre-fetch...`);
     return new Promise(async (res, rej) => {
       try {
         const response = await fetch(source, { method: 'HEAD', cache: 'no-store' });
@@ -514,8 +513,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
           finalSource = response.url;
         }
 
-        console.log(`File type is: ${finalType}`);
-
         // Modify video source in options
         videoJsOptions.sources = [
           {
@@ -526,7 +523,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
         return res(videoJsOptions);
       } catch (error) {
-        console.error(`Failed to pre-fetch video!`);
         return rej(error);
       }
     });

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -436,7 +436,6 @@ export function doCommentCreate(
       ...(environment ? { environment } : {}), // add environment for stripe if it exists
     })
       .then((result: CommentCreateResponse) => {
-        console.log(result);
         dispatch({
           type: ACTIONS.COMMENT_CREATE_COMPLETED,
           data: {
@@ -449,7 +448,6 @@ export function doCommentCreate(
         return result;
       })
       .catch((error) => {
-        console.log(error);
         dispatch({
           type: ACTIONS.COMMENT_CREATE_FAILED,
           data: error,


### PR DESCRIPTION
Seems like lint is being bypassed recently?

Reviewing just in case this was intentional, but it's messy in production and interferes with developer's own logging locally.