### PR TITLE
Fix currently active playing item on playlist

### DIFF
--- a/ui/component/collectionContentSidebar/index.js
+++ b/ui/component/collectionContentSidebar/index.js
@@ -7,9 +7,14 @@ import {
   makeSelectClaimForUri,
   makeSelectClaimIsMine,
 } from 'lbry-redux';
+import {
+  selectPlayingUri,
+} from 'redux/selectors/content';
 
 const select = (state, props) => {
-  const claim = makeSelectClaimForUri(props.uri)(state);
+  const playingUri = selectPlayingUri(state);
+  const playingUrl = playingUri && playingUri.uri;
+  const claim = makeSelectClaimForUri(playingUrl)(state);
   const url = claim && claim.permanent_url;
 
   return {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## What is the current behavior?

Right now the list will show the selected file as "active", not the currently playing one

## What is the new behavior?

Even if the playing item is floating, it will remain as active, until another file starts playing:
[![Anima-o.gif](https://i.postimg.cc/zfvrL4YJ/Anima-o.gif)](https://postimg.cc/xXw7hxd7)