### PR TITLE
Fix logo size on firefox

### DIFF
--- a/ui/scss/component/_header.scss
+++ b/ui/scss/component/_header.scss
@@ -73,6 +73,8 @@
 
 .header__navigation-logo {
   height: var(--height-button);
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
   max-width: fit-content;
 }
 


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

From discord:
> Nikkei•プレーヤー#3
 — 
Today at 11:10 AM
Ah I see what you mean, If you're using mozilla based browser the odysee logo is pretty squished, In chrome based browser looks fine.



https://discord.com/channels/362322208485277697/363049604461232148/871424669075513375
