### PR TITLE
Fix: OG messed up if `$"` is in title

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -23,13 +23,17 @@ const { getJsBundleId } = require('../bundle-id.js');
 const jsBundleId = getJsBundleId();
 
 function insertToHead(fullHtml, htmlToInsert) {
-  return fullHtml.replace(
-    /<!-- VARIABLE_HEAD_BEGIN -->.*<!-- VARIABLE_HEAD_END -->/s,
-    `
-      ${htmlToInsert || buildOgMetadata()}
-      <script src="/public/ui-${jsBundleId}.js" async></script>
-    `
-  );
+  const beginStr = '<!-- VARIABLE_HEAD_BEGIN -->';
+  const finalStr = '<!-- VARIABLE_HEAD_END -->';
+
+  const beginIndex = fullHtml.indexOf(beginStr);
+  const finalIndex = fullHtml.indexOf(finalStr);
+
+  if (beginIndex > -1 && finalIndex > -1 && finalIndex > beginIndex) {
+    return `${fullHtml.slice(0, beginIndex)}${
+      htmlToInsert || buildOgMetadata()
+    }<script src="/public/ui-${jsBundleId}.js" async></script>${fullHtml.slice(finalIndex + finalStr.length)}`;
+  }
 }
 
 function truncateDescription(description) {


### PR DESCRIPTION
## Issue
Closes [#5951: OG messed up if `$"` is in title](https://github.com/lbryio/lbry-desktop/issues/5951)

To replicate: `web:dev-server` with CQ credentials, then open the link mentioned in the issue.

The replacement string would contain `...$&quot...`. The character `$&` has special meaning in `replace`, so the output was messed up.

## Approach
Use a direct slice approach. A bit less elegant.

