### PR TITLE
Restore "Use better icon for "Copy Link"" -- lost in a merge.

### DIFF
--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -394,6 +394,13 @@ function ClaimMenuList(props: Props) {
         )}
         <hr className="menu__separator" />
 
+        <MenuItem className="comment__menu-option" onSelect={handleCopyLink}>
+          <div className="menu__link">
+            <Icon aria-hidden icon={ICONS.COPY_LINK} />
+            {__('Copy Link')}
+          </div>
+        </MenuItem>
+
         {isChannelPage && IS_WEB && rssUrl && (
           <MenuItem className="comment__menu-option" onSelect={handleCopyRssLink}>
             <div className="menu__link">
@@ -402,13 +409,6 @@ function ClaimMenuList(props: Props) {
             </div>
           </MenuItem>
         )}
-
-        <MenuItem className="comment__menu-option" onSelect={handleCopyLink}>
-          <div className="menu__link">
-            <Icon aria-hidden icon={ICONS.SHARE} />
-            {__('Copy Link')}
-          </div>
-        </MenuItem>
 
         {!claimIsMine && !isMyCollection && (
           <MenuItem className="comment__menu-option" onSelect={handleReportContent}>


### PR DESCRIPTION
b164a5d1 accidentally nulled the changed.

While at it, moved the "Copy RSS" button below "Copy Link" -- I think that looks better.