### PR TITLE
Reuse BidHelpText for reposts

### DIFF
--- a/ui/component/repostCreate/view.jsx
+++ b/ui/component/repostCreate/view.jsx
@@ -15,6 +15,7 @@ import ClaimPreview from 'component/claimPreview';
 import { URL as SITE_URL, URL_LOCAL, URL_DEV } from 'config';
 import HelpLink from 'component/common/help-link';
 import WalletSpendableBalanceHelp from 'component/walletSpendableBalanceHelp';
+import BidHelpText from 'component/publishBid/bid-help-text';
 import Spinner from 'component/spinner';
 
 type Props = {
@@ -77,7 +78,6 @@ function RepostCreate(props: Props) {
 
   const [repostBid, setRepostBid] = React.useState(0.01);
   const [repostBidError, setRepostBidError] = React.useState(undefined);
-  const [takeoverAmount, setTakeoverAmount] = React.useState(0);
   const [enteredRepostName, setEnteredRepostName] = React.useState(defaultName);
   const [available, setAvailable] = React.useState(true);
   const [enteredContent, setEnteredContentUri] = React.useState(undefined);
@@ -189,10 +189,9 @@ function RepostCreate(props: Props) {
       : Number(passedRepostAmount) + 0.01;
 
     if (repostTakeoverAmount) {
-      setTakeoverAmount(Number(repostTakeoverAmount.toFixed(2)));
       setAutoRepostBid(repostTakeoverAmount);
     }
-  }, [setTakeoverAmount, enteredRepostAmount, passedRepostAmount]);
+  }, [enteredRepostAmount, passedRepostAmount]);
 
   // repost bid error
   React.useEffect(() => {
@@ -381,9 +380,11 @@ function RepostCreate(props: Props) {
                 error={repostBidError}
                 helper={
                   <>
-                    {__('Winning amount: %amount%', {
-                      amount: Number(takeoverAmount).toFixed(2),
-                    })}
+                    <BidHelpText
+                      uri={'lbry://' + enteredRepostName}
+                      amountNeededForTakeover={enteredRepostAmount}
+                      isResolvingUri={isResolvingEnteredRepost}
+                    />
                     <WalletSpendableBalanceHelp inline />
                   </>
                 }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/6802

## What is the current behavior?

When accessing the repost page, the message "Winning amount: n" is always displayed, no matter what bid is required to take over:

![image](https://user-images.githubusercontent.com/1719111/128571141-0b55b0f0-ca92-4272-a565-facd05b739dd.png)

## What is the new behavior?

The component `BidHelpText` is used to properly display the bid message.

![image](https://user-images.githubusercontent.com/1719111/128571376-610c65c1-fd23-4e6b-aaa8-79002752f8e9.png)

![image](https://user-images.githubusercontent.com/1719111/128571401-faaddd58-06ef-4852-a36e-43bd7bc62dfa.png)

![image](https://user-images.githubusercontent.com/1719111/128571422-4d250a86-ccfb-4412-b074-a6d0ed45f614.png)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
