### PR TITLE
Livestream: implement Pinned Comments

### DIFF
--- a/flow-typed/Comment.js
+++ b/flow-typed/Comment.js
@@ -38,6 +38,7 @@ declare type CommentsState = {
   topLevelTotalCommentsById: { [string]: number }, // ClaimID -> total top level comments in commentron.
   commentById: { [string]: Comment },
   linkedCommentAncestors: { [string]: Array<string> }, // {"linkedCommentId": ["parentId", "grandParentId", ...]}
+  pinnedCommentsById: {}, // ClaimId -> array of pinned comment IDs
   isLoading: boolean,
   isLoadingByParentId: { [string]: boolean },
   myComments: ?Set<string>,

--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -21,10 +21,22 @@ type Props = {
   stakedLevel: number,
   supportAmount: number,
   isFiat: boolean,
+  isPinned: boolean,
 };
 
 function LivestreamComment(props: Props) {
-  const { claim, uri, authorUri, message, commentIsMine, commentId, stakedLevel, supportAmount, isFiat } = props;
+  const {
+    claim,
+    uri,
+    authorUri,
+    message,
+    commentIsMine,
+    commentId,
+    stakedLevel,
+    supportAmount,
+    isFiat,
+    isPinned,
+  } = props;
   const [mouseIsHovering, setMouseHover] = React.useState(false);
   const commentByOwnerOfContent = claim && claim.signing_channel && claim.signing_channel.permanent_url === authorUri;
   const { claimName } = parseURI(authorUri);
@@ -57,6 +69,13 @@ function LivestreamComment(props: Props) {
             {claimName}
           </Button>
 
+          {isPinned && (
+            <span className="comment__pin">
+              <Icon icon={ICONS.PIN} size={14} />
+              {__('Pinned')}
+            </span>
+          )}
+
           <div className="livestream-comment__text">
             <MarkdownPreview content={message} promptLinks stakedLevel={stakedLevel} />
           </div>
@@ -78,6 +97,8 @@ function LivestreamComment(props: Props) {
             authorUri={authorUri}
             commentIsMine={commentIsMine}
             disableEdit
+            isTopLevel
+            isPinned={isPinned}
             disableRemove={supportAmount > 0}
           />
         </Menu>

--- a/ui/component/livestreamComments/index.js
+++ b/ui/component/livestreamComments/index.js
@@ -3,6 +3,7 @@ import { makeSelectClaimForUri, selectMyChannelClaims } from 'lbry-redux';
 import { doCommentSocketConnect, doCommentSocketDisconnect } from 'redux/actions/websocket';
 import { doCommentList, doSuperChatList } from 'redux/actions/comments';
 import {
+  selectPinnedCommentsById,
   makeSelectTopLevelCommentsForUri,
   selectIsFetchingComments,
   makeSelectSuperChatsForUri,
@@ -17,6 +18,7 @@ const select = (state, props) => ({
   superChats: makeSelectSuperChatsForUri(props.uri)(state),
   superChatsTotalAmount: makeSelectSuperChatTotalAmountForUri(props.uri)(state),
   myChannels: selectMyChannelClaims(state),
+  pinnedCommentsById: selectPinnedCommentsById(state),
 });
 
 export default connect(select, {

--- a/ui/component/livestreamComments/view.jsx
+++ b/ui/component/livestreamComments/view.jsx
@@ -23,6 +23,7 @@ type Props = {
   doSuperChatList: (string) => void,
   superChats: Array<Comment>,
   myChannels: ?Array<ChannelClaim>,
+  pinnedCommentsById: { [claimId: string]: Array<string> },
 };
 
 const VIEW_MODE_CHAT = 'view_chat';
@@ -43,6 +44,7 @@ export default function LivestreamComments(props: Props) {
     doSuperChatList,
     myChannels,
     superChats: superChatsByTipAmount,
+    pinnedCommentsById,
   } = props;
 
   let superChatsFiatAmount, superChatsTotalAmount;
@@ -57,6 +59,12 @@ export default function LivestreamComments(props: Props) {
 
   const discussionElement = document.querySelector('.livestream__comments');
   const commentElement = document.querySelector('.livestream-comment');
+
+  let pinnedComment;
+  const pinnedCommentIds = (claimId && pinnedCommentsById[claimId]) || [];
+  if (pinnedCommentIds.length > 0) {
+    pinnedComment = commentsByChronologicalOrder.find((c) => c.comment_id === pinnedCommentIds[0]);
+  }
 
   React.useEffect(() => {
     if (claimId) {
@@ -231,6 +239,22 @@ export default function LivestreamComments(props: Props) {
                   </Tooltip>
                 ))}
               </div>
+            </div>
+          )}
+
+          {pinnedComment && (
+            <div className="livestream-pinned__wrapper">
+              <LivestreamComment
+                key={pinnedComment.comment_id}
+                uri={uri}
+                authorUri={pinnedComment.channel_url}
+                commentId={pinnedComment.comment_id}
+                message={pinnedComment.comment}
+                supportAmount={pinnedComment.support_amount}
+                isFiat={pinnedComment.is_fiat}
+                isPinned={pinnedComment.is_pinned}
+                commentIsMine={pinnedComment.channel_id && isMyComment(pinnedComment.channel_id)}
+              />
             </div>
           )}
 

--- a/ui/redux/actions/websocket.js
+++ b/ui/redux/actions/websocket.js
@@ -110,6 +110,17 @@ export const doCommentSocketConnect = (uri, claimId) => (dispatch) => {
         data: { connected, claimId },
       });
     }
+    if (response.type === 'pinned') {
+      const pinnedComment = response.data.comment;
+      dispatch({
+        type: ACTIONS.COMMENT_PIN_COMPLETED,
+        data: {
+          pinnedComment: pinnedComment,
+          claimId,
+          unpin: !pinnedComment.is_pinned,
+        },
+      });
+    }
   });
 };
 

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -17,6 +17,7 @@ export const selectCommentsDisabledChannelIds = createSelector(
   (state) => state.commentsDisabledChannelIds
 );
 export const selectOthersReactsById = createSelector(selectState, (state) => state.othersReactsByCommentId);
+export const selectPinnedCommentsById = createSelector(selectState, (state) => state.pinnedCommentsById);
 
 export const selectModerationBlockList = createSelector(selectState, (state) =>
   state.moderationBlockList ? state.moderationBlockList.reverse() : []

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -217,6 +217,7 @@ $thumbnailWidthSmall: 1rem;
 
 .comment__pin {
   margin-left: var(--spacing-s);
+  font-size: var(--font-xsmall);
 
   .icon {
     padding-top: 1px;

--- a/ui/scss/component/_livestream.scss
+++ b/ui/scss/component/_livestream.scss
@@ -223,6 +223,27 @@ $discussion-header__height: 3rem;
   }
 }
 
+.livestream-pinned__wrapper {
+  flex-shrink: 0;
+  position: relative;
+  padding: var(--spacing-s) var(--spacing-xs);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--font-small);
+  background-color: var(--color-card-background-highlighted);
+  width: 100%;
+
+  .livestream-comment {
+    padding-top: var(--spacing-xs);
+    max-height: 6rem;
+    overflow-y: scroll;
+  }
+
+  @media (min-width: $breakpoint-small) {
+    padding: var(--spacing-xs);
+    width: var(--livestream-comments-width);
+  }
+}
+
 .livestream-superchat__amount-large {
   .credit-amount {
     display: flex;


### PR DESCRIPTION
## Issue
Fixes [#6420 Pinned Updates in SuperChats ](https://github.com/lbryio/lbry-desktop/issues/6420)

## Behavior
The top (latest) pinned comment will be displayed at the top of the livestream chat.  Only 1 pinned message will be displayed (same as other platforms).  When a comment is unpinned, the next pinned comment (if exists) will replace it's spot.

## Approach
- Livestream comments are retrieved from 2 ways:
    - From initial entry, `comment.List` is used to retrieved the chat.  Due to the recent pagination changes, the pinned comments will always be placed at the "top" (or in the chat GUI, the "bottom").
    - Subsequent messages will come via websocket. 
- We handle both cases by storing the pinned comment IDs in the reducer stage.

## Test
kp.odysee.com
