### PR TITLE
Creator: Enable "min tips" and "min hyperchat"

### DIFF
--- a/flow-typed/Comment.js
+++ b/flow-typed/Comment.js
@@ -58,7 +58,6 @@ declare type CommentsState = {
   blockingByUri: {},
   unBlockingByUri: {},
   togglingForDelegatorMap: {[string]: Array<string>}, // {"blockedUri": ["delegatorUri1", ""delegatorUri2", ...]}
-  commentsDisabledChannelIds: Array<string>,
   settingsByChannelId: { [string]: PerChannelSettings }, // ChannelID -> settings
   fetchingSettings: boolean,
   fetchingBlockedWords: boolean,
@@ -222,10 +221,20 @@ declare type ModerationAmIParams = {
 };
 
 declare type SettingsParams = {
-  channel_name: string,
+  channel_name?: string,
   channel_id: string,
-  signature: string,
-  signing_ts: string,
+  signature?: string,
+  signing_ts?: string,
+};
+
+declare type SettingsResponse = {
+  words?: string,
+  comments_enabled: boolean,
+  min_tip_amount_comment: number,
+  min_tip_amount_super_chat: number,
+  slow_mode_min_gap: number,
+  curse_jar_amount: number,
+  filters_enabled?: boolean,
 };
 
 declare type UpdateSettingsParams = {

--- a/ui/comments.js
+++ b/ui/comments.js
@@ -34,6 +34,7 @@ const Comments = {
   setting_unblock_word: (params: BlockWordParams) => fetchCommentsApi('setting.UnBlockWord', params),
   setting_list_blocked_words: (params: SettingsParams) => fetchCommentsApi('setting.ListBlockedWords', params),
   setting_update: (params: UpdateSettingsParams) => fetchCommentsApi('setting.Update', params),
+  setting_get: (params: SettingsParams) => fetchCommentsApi('setting.Get', params),
   super_list: (params: SuperListParams) => fetchCommentsApi('comment.SuperChatList', params),
 };
 

--- a/ui/component/commentCreate/index.js
+++ b/ui/component/commentCreate/index.js
@@ -7,30 +7,42 @@ import {
   doSendTip,
 } from 'lbry-redux';
 import { doOpenModal, doSetActiveChannel } from 'redux/actions/app';
-import { doCommentCreate } from 'redux/actions/comments';
+import { doCommentCreate, doFetchCreatorSettings } from 'redux/actions/comments';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
-import { makeSelectCommentsDisabledForUri } from 'redux/selectors/comments';
+import { selectSettingsByChannelId } from 'redux/selectors/comments';
 import { CommentCreate } from './view';
 import { doToast } from 'redux/actions/notifications';
 
 const select = (state, props) => ({
   commentingEnabled: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
-  commentsDisabledBySettings: makeSelectCommentsDisabledForUri(props.uri)(state),
   claim: makeSelectClaimForUri(props.uri)(state),
   channels: selectMyChannelClaims(state),
   isFetchingChannels: selectFetchingMyChannels(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  settingsByChannelId: selectSettingsByChannelId(state),
 });
 
 const perform = (dispatch, ownProps) => ({
   createComment: (comment, claimId, parentId, txid, payment_intent_id, environment) =>
-    dispatch(doCommentCreate(comment, claimId, parentId, ownProps.uri, ownProps.livestream, txid, payment_intent_id, environment)),
+    dispatch(
+      doCommentCreate(
+        comment,
+        claimId,
+        parentId,
+        ownProps.uri,
+        ownProps.livestream,
+        txid,
+        payment_intent_id,
+        environment
+      )
+    ),
   openModal: (modal, props) => dispatch(doOpenModal(modal, props)),
   setActiveChannel: (claimId) => dispatch(doSetActiveChannel(claimId)),
   sendTip: (params, callback, errorCallback) => dispatch(doSendTip(params, false, callback, errorCallback, false)),
   doToast: (options) => dispatch(doToast(options)),
+  doFetchCreatorSettings: (channelClaimId) => dispatch(doFetchCreatorSettings(channelClaimId)),
 });
 
 export default connect(select, perform)(CommentCreate);

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -6,6 +6,7 @@ import * as ICONS from 'constants/icons';
 import React from 'react';
 import classnames from 'classnames';
 import { FormField, Form } from 'component/common/form';
+import Icon from 'component/common/icon';
 import Button from 'component/button';
 import SelectChannel from 'component/selectChannel';
 import usePersistedState from 'effects/use-persisted-state';
@@ -14,10 +15,11 @@ import { useHistory } from 'react-router';
 import WalletTipAmountSelector from 'component/walletTipAmountSelector';
 import CreditAmount from 'component/common/credit-amount';
 import ChannelThumbnail from 'component/channelThumbnail';
+import I18nMessage from 'component/i18nMessage';
 import UriIndicator from 'component/uriIndicator';
 import Empty from 'component/common/empty';
-import { Lbryio } from 'lbryinc';
 import { getChannelIdFromClaim } from 'util/claim';
+import { Lbryio } from 'lbryinc';
 
 let stripeEnvironment = 'test';
 // if the key contains pk_live it's a live key
@@ -50,7 +52,7 @@ type Props = {
   sendTip: ({}, (any) => void, (any) => void) => void,
   doToast: ({ message: string }) => void,
   disabled: boolean,
-  doFetchCreatorSettings: (channelId: string) => void,
+  doFetchCreatorSettings: (channelId: string) => Promise<any>,
   settingsByChannelId: { [channelId: string]: PerChannelSettings },
 };
 
@@ -97,6 +99,38 @@ export function CommentCreate(props: Props) {
   const [shouldDisableReviewButton, setShouldDisableReviewButton] = React.useState();
   const channelId = getChannelIdFromClaim(claim);
   const channelSettings = channelId ? settingsByChannelId[channelId] : undefined;
+  const minSuper = (channelSettings && channelSettings.min_tip_amount_super_chat) || 0;
+  const minTip = (channelSettings && channelSettings.min_tip_amount_comment) || 0;
+  const minAmount = minTip || minSuper || 0;
+  const minAmountMet = minAmount === 0 || tipAmount >= minAmount;
+
+  const minAmountRef = React.useRef(minAmount);
+  minAmountRef.current = minAmount;
+
+  const MinAmountNotice = minAmount ? (
+    <div className="help--notice comment--min-amount-notice">
+      <I18nMessage tokens={{ lbc: <CreditAmount noFormat amount={minAmount} /> }}>
+        {minTip ? 'Comment min: %lbc%' : minSuper ? 'HyperChat min: %lbc%' : ''}
+      </I18nMessage>
+      <Icon
+        customTooltipText={
+          minTip
+            ? __('This channel requires a minimum tip for each comment.')
+            : minSuper
+            ? __('This channel requires a minimum amount for HyperChats to be visible.')
+            : ''
+        }
+        className="icon--help"
+        icon={ICONS.HELP}
+        tooltip
+        size={16}
+      />
+    </div>
+  ) : null;
+
+  // **************************************************************************
+  // Functions
+  // **************************************************************************
 
   function handleCommentChange(event) {
     let commentValue;
@@ -136,12 +170,43 @@ export function CommentCreate(props: Props) {
       return;
     }
 
+    if (!channelId) {
+      doToast({
+        message: __('Unable to verify channel settings. Try refreshing the page.'),
+        isError: true,
+      });
+      return;
+    }
+
     // if comment post didn't work, but tip was already made, try again to create comment
     if (commentFailure && tipAmount === successTip.tipAmount) {
       handleCreateComment(successTip.txid);
       return;
     } else {
       setSuccessTip({ txid: undefined, tipAmount: undefined });
+    }
+
+    // !! Beware of stale closure when editing the then-block, including doSubmitTip().
+    doFetchCreatorSettings(channelId).then(() => {
+      const lockedMinAmount = minAmount; // value during closure.
+      const currentMinAmount = minAmountRef.current; // value from latest doFetchCreatorSettings().
+
+      if (lockedMinAmount !== currentMinAmount) {
+        doToast({
+          message: __('The creator just updated the minimum setting. Please revise or double-check your tip amount.'),
+          isError: true,
+        });
+        setIsReviewingSupportComment(false);
+        return;
+      }
+
+      doSubmitTip();
+    });
+  }
+
+  function doSubmitTip() {
+    if (!activeChannelClaim) {
+      return;
     }
 
     const params = {
@@ -273,6 +338,12 @@ export function CommentCreate(props: Props) {
       .catch(() => {
         setIsSubmitting(false);
         setCommentFailure(true);
+
+        if (channelId) {
+          // It could be that the creator added a minimum tip setting.
+          // Manually update for now until a websocket msg is available.
+          doFetchCreatorSettings(channelId);
+        }
       });
   }
 
@@ -280,11 +351,20 @@ export function CommentCreate(props: Props) {
     setAdvancedEditor(!advancedEditor);
   }
 
+  // **************************************************************************
+  // Effects
+  // **************************************************************************
+
+  // Fetch channel constraints if not already.
   React.useEffect(() => {
     if (!channelSettings && channelId) {
       doFetchCreatorSettings(channelId);
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // **************************************************************************
+  // Render
+  // **************************************************************************
 
   if (channelSettings && !channelSettings.comments_enabled) {
     return <Empty padded text={__('This channel has disabled comments on their page.')} />;
@@ -342,7 +422,7 @@ export function CommentCreate(props: Props) {
           <Button
             autoFocus
             button="primary"
-            disabled={disabled}
+            disabled={disabled || !minAmountMet}
             label={
               isSubmitting
                 ? __('Sending...')
@@ -358,6 +438,7 @@ export function CommentCreate(props: Props) {
             label={__('Cancel')}
             onClick={() => setIsReviewingSupportComment(false)}
           />
+          {MinAmountNotice}
         </div>
       </div>
     );
@@ -411,7 +492,7 @@ export function CommentCreate(props: Props) {
         {isSupportComment ? (
           <>
             <Button
-              disabled={disabled || tipError || shouldDisableReviewButton}
+              disabled={disabled || tipError || shouldDisableReviewButton || !minAmountMet}
               type="button"
               button="primary"
               icon={activeTab === TAB_LBC ? ICONS.LBC : ICONS.FINANCE}
@@ -423,22 +504,24 @@ export function CommentCreate(props: Props) {
           </>
         ) : (
           <>
-            <Button
-              ref={buttonRef}
-              button="primary"
-              disabled={disabled}
-              type="submit"
-              label={
-                isReply
-                  ? isSubmitting
-                    ? __('Replying...')
-                    : __('Reply')
-                  : isSubmitting
-                  ? __('Commenting...')
-                  : __('Comment --[button to submit something]--')
-              }
-              requiresAuth={IS_WEB}
-            />
+            {(!minTip || claimIsMine) && (
+              <Button
+                ref={buttonRef}
+                button="primary"
+                disabled={disabled}
+                type="submit"
+                label={
+                  isReply
+                    ? isSubmitting
+                      ? __('Replying...')
+                      : __('Reply')
+                    : isSubmitting
+                    ? __('Commenting...')
+                    : __('Comment --[button to submit something]--')
+                }
+                requiresAuth={IS_WEB}
+              />
+            )}
             {!claimIsMine && (
               <Button
                 disabled={disabled}
@@ -463,7 +546,7 @@ export function CommentCreate(props: Props) {
                 }}
               />
             )}
-            {isReply && (
+            {isReply && !minTip && (
               <Button
                 button="link"
                 label={__('Cancel')}
@@ -476,6 +559,7 @@ export function CommentCreate(props: Props) {
             )}
           </>
         )}
+        {MinAmountNotice}
       </div>
     </Form>
   );

--- a/ui/component/commentsList/index.js
+++ b/ui/component/commentsList/index.js
@@ -1,5 +1,10 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimIsMine, selectFetchingMyChannels, selectMyChannelClaims } from 'lbry-redux';
+import {
+  makeSelectClaimForUri,
+  makeSelectClaimIsMine,
+  selectFetchingMyChannels,
+  selectMyChannelClaims,
+} from 'lbry-redux';
 import {
   makeSelectTopLevelCommentsForUri,
   makeSelectTopLevelTotalPagesForUri,
@@ -7,12 +12,11 @@ import {
   selectIsFetchingReacts,
   makeSelectTotalCommentsCountForUri,
   selectOthersReactsById,
-  makeSelectCommentsDisabledForUri,
   selectMyReactionsByCommentId,
   makeSelectCommentIdsForUri,
+  selectSettingsByChannelId,
 } from 'redux/selectors/comments';
 import { doCommentReset, doCommentList, doCommentById, doCommentReactList } from 'redux/actions/comments';
-import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
 import CommentsList from './view';
 
@@ -24,12 +28,12 @@ const select = (state, props) => {
     topLevelComments: makeSelectTopLevelCommentsForUri(props.uri)(state),
     topLevelTotalPages: makeSelectTopLevelTotalPagesForUri(props.uri)(state),
     totalComments: makeSelectTotalCommentsCountForUri(props.uri)(state),
+    claim: makeSelectClaimForUri(props.uri)(state),
     claimIsMine: makeSelectClaimIsMine(props.uri)(state),
     isFetchingComments: selectIsFetchingComments(state),
     isFetchingReacts: selectIsFetchingReacts(state),
-    commentingEnabled: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
-    commentsDisabledBySettings: makeSelectCommentsDisabledForUri(props.uri)(state),
     fetchingChannels: selectFetchingMyChannels(state),
+    settingsByChannelId: selectSettingsByChannelId(state),
     myReactsByCommentId: selectMyReactionsByCommentId(state),
     othersReactsById: selectOthersReactsById(state),
     activeChannelId: activeChannelClaim && activeChannelClaim.claim_id,

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -14,6 +14,7 @@ import { ENABLE_COMMENT_REACTIONS } from 'config';
 import Empty from 'component/common/empty';
 import debounce from 'util/debounce';
 import { useIsMobile } from 'effects/use-screensize';
+import { getChannelIdFromClaim } from 'util/claim';
 
 const DEBOUNCE_SCROLL_HANDLER_MS = 200;
 
@@ -29,12 +30,12 @@ type Props = {
   allCommentIds: any,
   topLevelComments: Array<Comment>,
   topLevelTotalPages: number,
-  commentsDisabledBySettings: boolean,
   fetchTopLevelComments: (string, number, number, number) => void,
   fetchComment: (string) => void,
   fetchReacts: (Array<string>) => Promise<any>,
   resetComments: (string) => void,
   uri: string,
+  claim: ?Claim,
   claimIsMine: boolean,
   myChannels: ?Array<ChannelClaim>,
   isFetchingComments: boolean,
@@ -45,6 +46,7 @@ type Props = {
   myReactsByCommentId: ?{ [string]: Array<string> }, // "CommentId:MyChannelId" -> reaction array (note the ID concatenation)
   othersReactsById: ?{ [string]: { [REACTION_TYPES.LIKE | REACTION_TYPES.DISLIKE]: number } },
   activeChannelId: ?string,
+  settingsByChannelId: { [channelId: string]: PerChannelSettings },
 };
 
 function CommentList(props: Props) {
@@ -57,7 +59,7 @@ function CommentList(props: Props) {
     uri,
     topLevelComments,
     topLevelTotalPages,
-    commentsDisabledBySettings,
+    claim,
     claimIsMine,
     myChannels,
     isFetchingComments,
@@ -68,6 +70,7 @@ function CommentList(props: Props) {
     myReactsByCommentId,
     othersReactsById,
     activeChannelId,
+    settingsByChannelId,
   } = props;
 
   const commentRef = React.useRef();
@@ -78,6 +81,8 @@ function CommentList(props: Props) {
   const isMobile = useIsMobile();
   const [expandedComments, setExpandedComments] = React.useState(!isMobile);
   const totalFetchedComments = allCommentIds ? allCommentIds.length : 0;
+  const channelId = getChannelIdFromClaim(claim);
+  const channelSettings = channelId ? settingsByChannelId[channelId] : undefined;
 
   // Display comments immediately if not fetching reactions
   // If not, wait to show comments until reactions are fetched
@@ -279,7 +284,7 @@ function CommentList(props: Props) {
         <>
           <CommentCreate uri={uri} />
 
-          {!commentsDisabledBySettings && !isFetchingComments && hasNoComments && (
+          {channelSettings && channelSettings.comments_enabled && !isFetchingComments && hasNoComments && (
             <Empty padded text={__('That was pretty deep. What do you think?')} />
           )}
 

--- a/ui/page/settingsCreator/index.js
+++ b/ui/page/settingsCreator/index.js
@@ -29,7 +29,7 @@ const select = (state) => ({
 const perform = (dispatch) => ({
   commentBlockWords: (channelClaim, words) => dispatch(doCommentBlockWords(channelClaim, words)),
   commentUnblockWords: (channelClaim, words) => dispatch(doCommentUnblockWords(channelClaim, words)),
-  fetchCreatorSettings: (channelClaimIds) => dispatch(doFetchCreatorSettings(channelClaimIds)),
+  fetchCreatorSettings: (channelClaimId) => dispatch(doFetchCreatorSettings(channelClaimId)),
   updateCreatorSettings: (channelClaim, settings) => dispatch(doUpdateCreatorSettings(channelClaim, settings)),
   commentModAddDelegate: (modChanId, modChanName, creatorChannelClaim) =>
     dispatch(doCommentModAddDelegate(modChanId, modChanName, creatorChannelClaim)),

--- a/ui/page/settingsCreator/view.jsx
+++ b/ui/page/settingsCreator/view.jsx
@@ -344,15 +344,25 @@ export default function SettingsCreatorPage(props: Props) {
                   label={
                     <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>Minimum %lbc% tip amount for hyperchats</I18nMessage>
                   }
-                  helper={__(
-                    'Enabling a minimum amount to hyperchat will force all TIPPED comments to have this value in order to be shown. This still allows regular comments to be posted.'
-                  )}
+                  helper={
+                    <>
+                      {__(
+                        'Enabling a minimum amount to hyperchat will force all TIPPED comments to have this value in order to be shown. This still allows regular comments to be posted.'
+                      )}
+                      {minTipAmountComment !== 0 && (
+                        <p className="help--inline">
+                          <em>{__('(This settings is not applicable if all comments require a tip.)')}</em>
+                        </p>
+                      )}
+                    </>
+                  }
                   className="form-field--price-amount"
                   min={0}
                   step="any"
                   type="number"
                   placeholder="1"
                   value={minTipAmountSuperChat}
+                  disabled={minTipAmountComment !== 0}
                   onChange={(e) => setSettings({ min_tip_amount_super_chat: parseFloat(e.target.value) })}
                 />
               </>

--- a/ui/page/settingsCreator/view.jsx
+++ b/ui/page/settingsCreator/view.jsx
@@ -15,7 +15,9 @@ import { getUriForSearchTerm } from 'util/search';
 
 const DEBOUNCE_REFRESH_MS = 1000;
 
-const FEATURE_IS_READY = false;
+const LBC_MAX = 21000000;
+const LBC_MIN = 0;
+const LBC_STEP = 1.0;
 
 type Props = {
   activeChannelClaim: ChannelClaim,
@@ -297,47 +299,46 @@ export default function SettingsCreatorPage(props: Props) {
               </div>
             }
           />
-          {FEATURE_IS_READY && (
-            <Card
-              title={__('Tip')}
-              actions={
-                <>
-                  <FormField
-                    name="min_tip_amount_comment"
-                    label={
-                      <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>Minimum %lbc% tip amount for comments</I18nMessage>
-                    }
-                    helper={__(
-                      'Enabling a minimum amount to comment will force all comments, including livestreams, to have tips associated with them. This can help prevent spam.'
-                    )}
-                    className="form-field--price-amount"
-                    min={0}
-                    step="any"
-                    type="number"
-                    placeholder="1"
-                    value={minTipAmountComment}
-                    onChange={(e) => setSettings({ min_tip_amount_comment: parseFloat(e.target.value) })}
-                  />
-                  <FormField
-                    name="min_tip_amount_super_chat"
-                    label={
-                      <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>Minimum %lbc% tip amount for hyperchats</I18nMessage>
-                    }
-                    helper={__(
-                      'Enabling a minimum amount to hyperchat will force all TIPPED comments to have this value in order to be shown. This still allows regular comments to be posted.'
-                    )}
-                    className="form-field--price-amount"
-                    min={0}
-                    step="any"
-                    type="number"
-                    placeholder="1"
-                    value={minTipAmountSuperChat}
-                    onChange={(e) => setSettings({ min_tip_amount_super_chat: parseFloat(e.target.value) })}
-                  />
-                </>
-              }
-            />
-          )}
+          <Card
+            title={__('Tip')}
+            actions={
+              <>
+                <FormField
+                  name="min_tip_amount_comment"
+                  label={
+                    <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>Minimum %lbc% tip amount for comments</I18nMessage>
+                  }
+                  helper={__(
+                    'Enabling a minimum amount to comment will force all comments, including livestreams, to have tips associated with them. This can help prevent spam.'
+                  )}
+                  className="form-field--price-amount"
+                  max={LBC_MAX}
+                  min={LBC_MIN}
+                  step={LBC_STEP}
+                  type="number"
+                  placeholder="3.14"
+                  value={minTipAmountComment}
+                  onChange={(e) => setSettings({ min_tip_amount_comment: parseFloat(e.target.value) })}
+                />
+                <FormField
+                  name="min_tip_amount_super_chat"
+                  label={
+                    <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>Minimum %lbc% tip amount for hyperchats</I18nMessage>
+                  }
+                  helper={__(
+                    'Enabling a minimum amount to hyperchat will force all TIPPED comments to have this value in order to be shown. This still allows regular comments to be posted.'
+                  )}
+                  className="form-field--price-amount"
+                  min={0}
+                  step="any"
+                  type="number"
+                  placeholder="1"
+                  value={minTipAmountSuperChat}
+                  onChange={(e) => setSettings({ min_tip_amount_super_chat: parseFloat(e.target.value) })}
+                />
+              </>
+            }
+          />
           <Card
             title={__('Delegation')}
             className="card--enable-overflow"

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -1429,15 +1429,6 @@ export const doUpdateCreatorSettings = (channelClaim: ChannelClaim, settings: Pe
       return;
     }
 
-    const BTC_SATOSHIS = 100000000;
-
-    if (settings.min_tip_amount_comment !== undefined) {
-      settings.min_tip_amount_comment *= BTC_SATOSHIS;
-    }
-    if (settings.min_tip_amount_super_chat !== undefined) {
-      settings.min_tip_amount_super_chat *= BTC_SATOSHIS;
-    }
-
     return Comments.setting_update({
       channel_name: channelClaim.name,
       channel_id: channelClaim.claim_id,

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -104,7 +104,7 @@ export function doCommentList(
             totalFilteredItems: total_filtered_items,
             totalPages: total_pages,
             claimId: claimId,
-            authorClaimId: authorChannelClaim ? authorChannelClaim.claim_id : undefined,
+            commenterClaimId: authorChannelClaim ? authorChannelClaim.claim_id : undefined,
             uri: uri,
           },
         });
@@ -1357,7 +1357,7 @@ export function doFetchCommentModAmIList(channelClaim: ChannelClaim) {
   };
 }
 
-export const doFetchCreatorSettings = (channelClaimIds: Array<string> = []) => {
+export const doFetchCreatorSettings = (channelId: string) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
     const myChannels = selectMyChannelClaims(state);
@@ -1366,84 +1366,49 @@ export const doFetchCreatorSettings = (channelClaimIds: Array<string> = []) => {
       type: ACTIONS.COMMENT_FETCH_SETTINGS_STARTED,
     });
 
-    let channelSignatures = [];
+    let signedName;
+
     if (myChannels) {
-      for (const channelClaim of myChannels) {
-        if (channelClaimIds.length !== 0 && !channelClaimIds.includes(channelClaim.claim_id)) {
-          continue;
-        }
-
-        try {
-          const channelSignature = await Lbry.channel_sign({
-            channel_id: channelClaim.claim_id,
-            hexdata: toHex(channelClaim.name),
-          });
-
-          channelSignatures.push({ ...channelSignature, claim_id: channelClaim.claim_id, name: channelClaim.name });
-        } catch (e) {}
+      const index = myChannels.findIndex((myChannel) => myChannel.claim_id === channelId);
+      if (index > -1) {
+        signedName = await channelSignName(channelId, myChannels[index].name);
       }
     }
 
-    return Promise.all(
-      channelSignatures.map((signatureData) =>
-        Comments.setting_list({
-          channel_name: signatureData.name,
-          channel_id: signatureData.claim_id,
-          signature: signatureData.signature,
-          signing_ts: signatureData.signing_ts,
-        })
-      )
-    )
-      .then((settings) => {
-        const settingsByChannelId = {};
+    const cmd = signedName ? Comments.setting_list : Comments.setting_get;
 
-        for (let i = 0; i < channelSignatures.length; ++i) {
-          const channelId = channelSignatures[i].claim_id;
-          settingsByChannelId[channelId] = settings[i];
-
-          if (settings[i].words) {
-            settingsByChannelId[channelId].words = settings[i].words.split(',');
-          }
-
-          delete settingsByChannelId[channelId].channel_name;
-          delete settingsByChannelId[channelId].channel_id;
-          delete settingsByChannelId[channelId].signature;
-          delete settingsByChannelId[channelId].signing_ts;
-        }
-
+    return cmd({
+      channel_id: channelId,
+      channel_name: (signedName && signedName.name) || undefined,
+      signature: (signedName && signedName.signature) || undefined,
+      signing_ts: (signedName && signedName.signing_ts) || undefined,
+    })
+      .then((response: SettingsResponse) => {
         dispatch({
           type: ACTIONS.COMMENT_FETCH_SETTINGS_COMPLETED,
-          data: settingsByChannelId,
+          data: {
+            channelId: channelId,
+            settings: response,
+            partialUpdate: !signedName,
+          },
         });
       })
       .catch((err) => {
-        // TODO: Use error codes when available.
-        // TODO: The "validation is disallowed" thing ideally should just be a
-        //       success case that returns a null setting, instead of an error.
-        //       As we are using 'Promise.all', if one channel fails, everyone
-        //       fails. This forces us to remove the batch functionality of this
-        //       function. However, since this "validation is disallowed" thing
-        //       is potentially a temporary one to handle spammers, I retained
-        //       the batch functionality for now.
         if (err.message === 'validation is disallowed for non controlling channels') {
-          const settingsByChannelId = {};
-          for (let i = 0; i < channelSignatures.length; ++i) {
-            const channelId = channelSignatures[i].claim_id;
-            // 'undefined' means "fetching or have not fetched";
-            // 'null' means "feature not available for this channel";
-            settingsByChannelId[channelId] = null;
-          }
-
           dispatch({
             type: ACTIONS.COMMENT_FETCH_SETTINGS_COMPLETED,
-            data: settingsByChannelId,
+            data: {
+              channelId: channelId,
+              settings: null,
+              partialUpdate: !signedName,
+            },
           });
-          return;
+        } else {
+          devToast(dispatch, `Creator: ${err}`);
+          dispatch({
+            type: ACTIONS.COMMENT_FETCH_SETTINGS_FAILED,
+          });
         }
-
-        dispatch({
-          type: ACTIONS.COMMENT_FETCH_SETTINGS_FAILED,
-        });
       });
   };
 };
@@ -1454,7 +1419,7 @@ export const doFetchCreatorSettings = (channelClaimIds: Array<string> = []) => {
  *
  * @param channelClaim
  * @param settings
- * @returns {function(Dispatch, GetState): Promise<R>|Promise<unknown>|*}
+ * @returns {function(Dispatch, GetState): any}
  */
 export const doUpdateCreatorSettings = (channelClaim: ChannelClaim, settings: PerChannelSettings) => {
   return async (dispatch: Dispatch, getState: GetState) => {

--- a/ui/redux/reducers/comments.js
+++ b/ui/redux/reducers/comments.js
@@ -4,8 +4,6 @@ import { handleActions } from 'util/redux-utils';
 import { BLOCK_LEVEL } from 'constants/comment';
 import { isURIEqual } from 'lbry-redux';
 
-const BTC_SATOSHIS = 100000000;
-
 const defaultState: CommentsState = {
   commentById: {}, // commentId -> Comment
   byId: {}, // ClaimID -> list of fetched comment IDs.
@@ -1022,11 +1020,6 @@ export default handleActions(
           settingsByChannelId[channelId].words = settings.words.split(',');
         }
       }
-
-      // Both partial and full update will always include these,
-      // so safe to always re-compute without accidentally double-converting.
-      settingsByChannelId[channelId].min_tip_amount_comment /= BTC_SATOSHIS;
-      settingsByChannelId[channelId].min_tip_amount_super_chat /= BTC_SATOSHIS;
 
       return {
         ...state,

--- a/ui/redux/reducers/comments.js
+++ b/ui/redux/reducers/comments.js
@@ -1023,9 +1023,22 @@ export default handleActions(
       // because the GUI only shows 1 channel's setting at a time, and *always*
       // re-fetches to get latest data before displaying. Either rename this to
       // 'activeChannelCreatorSettings', or append the new data properly.
+      const settingsByChannelId = Object.assign({}, action.data);
+      const BTC_SATOSHIS = 100000000;
+
+      const channelIds = Object.keys(settingsByChannelId);
+      channelIds.forEach((ci) => {
+        if (settingsByChannelId[ci].min_tip_amount_comment) {
+          settingsByChannelId[ci].min_tip_amount_comment /= BTC_SATOSHIS;
+        }
+        if (settingsByChannelId[ci].min_tip_amount_super_chat) {
+          settingsByChannelId[ci].min_tip_amount_super_chat /= BTC_SATOSHIS;
+        }
+      });
+
       return {
         ...state,
-        settingsByChannelId: action.data,
+        settingsByChannelId,
         fetchingSettings: false,
       };
     },

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { selectBlacklistedOutpointMap, selectFilteredOutpointMap } from 'lbryinc';
-import { selectClaimsById, isClaimNsfw, selectMyActiveClaims, makeSelectClaimForUri } from 'lbry-redux';
+import { selectClaimsById, isClaimNsfw, selectMyActiveClaims } from 'lbry-redux';
 
 const selectState = (state) => state.comments || {};
 
@@ -12,10 +12,6 @@ export const selectIsFetchingComments = createSelector(selectState, (state) => s
 export const selectIsFetchingCommentsByParentId = createSelector(selectState, (state) => state.isLoadingByParentId);
 export const selectIsPostingComment = createSelector(selectState, (state) => state.isCommenting);
 export const selectIsFetchingReacts = createSelector(selectState, (state) => state.isFetchingReacts);
-export const selectCommentsDisabledChannelIds = createSelector(
-  selectState,
-  (state) => state.commentsDisabledChannelIds
-);
 export const selectOthersReactsById = createSelector(selectState, (state) => state.othersReactsByCommentId);
 export const selectPinnedCommentsById = createSelector(selectState, (state) => state.pinnedCommentsById);
 
@@ -425,16 +421,4 @@ export const makeSelectSuperChatTotalAmountForUri = (uri: string) =>
     }
 
     return superChatData.totalAmount;
-  });
-
-export const makeSelectCommentsDisabledForUri = (uri: string) =>
-  createSelector(selectCommentsDisabledChannelIds, makeSelectClaimForUri(uri), (commentsDisabledChannelIds, claim) => {
-    const channelClaim = !claim
-      ? null
-      : claim.value_type === 'channel'
-      ? claim
-      : claim.signing_channel && claim.is_channel_signature_valid
-      ? claim.signing_channel
-      : null;
-    return channelClaim && channelClaim.claim_id && commentsDisabledChannelIds.includes(channelClaim.claim_id);
   });

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -438,3 +438,9 @@ $thumbnailWidthSmall: 1rem;
 .comment--blocked {
   opacity: 0.5;
 }
+
+.comment--min-amount-notice {
+  .icon {
+    margin-bottom: -3px; // TODO fix few instances of these (find "-2px")
+  }
+}

--- a/ui/util/claim.js
+++ b/ui/util/claim.js
@@ -1,0 +1,11 @@
+// @flow
+
+export function getChannelIdFromClaim(claim: ?Claim) {
+  if (claim) {
+    if (claim.value_type === 'channel') {
+      return claim.claim_id;
+    } else if (claim.signing_channel) {
+      return claim.signing_channel.claim_id;
+    }
+  }
+}


### PR DESCRIPTION
## Issue
Closes #6119 (min tips)

## Test
jimbo.lbry.tv (⚠️ different test instance from usual -- troublesome to merge with existing PRs multiple times).

## General description of changes
- "Creator Settings" page now include a "Min Tip" and "Min Hyper Chat" amount setting.
- An advisory text will be displayed beside the comment-create submission button to indicate the minimum amount.  For livestreams, and additional bubble will appear to describe the min hyper chat amount.

## Concerns
- How does fiat-comments come into play?
- There is no mechanism to avoid mismatched payment.  I tried to handle it as much as possible, as describe in the Notion post.