### PR TITLE
Reset file input on publishing when accessing since it can be restored to previous value.

### DIFF
--- a/ui/component/publishForm/view.jsx
+++ b/ui/component/publishForm/view.jsx
@@ -532,6 +532,15 @@ function PublishForm(props: Props) {
     }
   }, [autoSwitchMode, editingURI, fileMimeType, myClaimForUri, mode, setMode, setAutoSwitchMode]);
 
+  // When accessing to publishing, make sure to reset file input attributes
+  // since we can't restore from previous user selection (like we do
+  // with other properties such as name, title, etc.) for security reasons.
+  useEffect(() => {
+    if (mode === PUBLISH_MODES.FILE) {
+      updatePublishForm({ filePath: '', fileDur: 0, fileSize: 0 });
+    }
+  }, [mode, updatePublishForm]);
+
   if (publishing) {
     return (
       <div className="main--empty">


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/6679

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

1 - Enter publish
2 - Select a file
3 - Complete all fields to publish a file
4 - Reload
5 - Go back to publish

The publish form can be submitted even though the file couldn't be restored.

## What is the new behavior?

The file input gets always reset since it can't be restored.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Type & Checklist

<details><summary>PR Type...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

</details>

<!---------------------------------------------------------------------------->

<details><summary>PR Checklist...</summary>

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
