### PR TITLE
Reload when auth token mismatch is detected

### DIFF
--- a/ui/redux/actions/sync.js
+++ b/ui/redux/actions/sync.js
@@ -3,9 +3,10 @@ import { Lbryio } from 'lbryinc';
 import { SETTINGS, Lbry, doWalletEncrypt, doWalletDecrypt } from 'lbry-redux';
 import { selectGetSyncIsPending, selectSetSyncIsPending, selectSyncIsLocked } from 'redux/selectors/sync';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
-import { getSavedPassword } from 'util/saved-passwords';
+import { getSavedPassword, getAuthToken } from 'util/saved-passwords';
 import { doAnalyticsTagSync, doHandleSyncComplete } from 'redux/actions/app';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
+import { X_LBRY_AUTH_TOKEN } from 'constants/token';
 
 let syncTimer = null;
 const SYNC_INTERVAL = 1000 * 60 * 5; // 5 minutes
@@ -147,6 +148,17 @@ export function doGetSync(passedPassword, callback) {
       callback(error, hasNewData);
     }
   }
+
+  // @if TARGET='web'
+  const xAuth =
+    Lbry.getApiRequestHeaders() && Object.keys(Lbry.getApiRequestHeaders()).includes(X_LBRY_AUTH_TOKEN)
+      ? Lbry.getApiRequestHeaders()[X_LBRY_AUTH_TOKEN]
+      : '';
+  if (xAuth && xAuth !== getAuthToken()) {
+    window.location.reload();
+    return;
+  }
+  // @endif
 
   return (dispatch) => {
     dispatch({


### PR DESCRIPTION
## Tickets
- Closes [#5504 Signing out of account causes page to break in other tabs](https://github.com/lbryio/lbry-desktop/issues/5504)
- Closes [#6829 merged accounts - force log out / fail sync when x-auth-token and cookie auth token are different](https://github.com/lbryio/lbry-desktop/issues/6829)

## Steps to replicate
1. Login to odysee with account-A.
2. Open another tab, and split both tabs on the screen.
3. Logout from the 1st tab. Do not activate (focus) the 2nd tab.
4. On the 1st tab, login with account-B.
5. Activate (focus) the 2nd tab. The wallet would have been merged, and we are still logged in as account-A.

## Approach
Reload when the LBRY API token no longer matches the auth token.

## Concerns
- Will there be valid scenarios where the API token can be different?