### PR TITLE
"Scroll to recent" button improvements

### DIFF
--- a/ui/component/livestreamComments/view.jsx
+++ b/ui/component/livestreamComments/view.jsx
@@ -9,6 +9,7 @@ import UriIndicator from 'component/uriIndicator';
 import CreditAmount from 'component/common/credit-amount';
 import ChannelThumbnail from 'component/channelThumbnail';
 import Tooltip from 'component/common/tooltip';
+import * as ICONS from 'constants/icons';
 
 type Props = {
   uri: string,
@@ -297,10 +298,11 @@ export default function LivestreamComments(props: Props) {
 
           {scrollPos < 0 && (
             <Button
-              button="alt"
-              className="livestream__comments-scroll__down"
+              button="secondary"
+              className="livestream__comments__scroll-to-recent"
               label={__('Recent Comments')}
               onClick={restoreScrollPos}
+              iconRight={ICONS.DOWN}
             />
           )}
 

--- a/ui/scss/component/_livestream.scss
+++ b/ui/scss/component/_livestream.scss
@@ -1,4 +1,5 @@
 $discussion-header__height: 3rem;
+$recent-msg-button__height: 2rem;
 
 .livestream {
   flex: 1;
@@ -139,6 +140,19 @@ $discussion-header__height: 3rem;
   position: absolute;
   right: var(--spacing-xs);
   top: var(--spacing-xs);
+}
+
+.livestream__comments__scroll-to-recent {
+  margin-top: -$recent-msg-button__height;
+  align-self: center;
+  margin-bottom: var(--spacing-xs);
+  font-size: var(--font-xsmall);
+  padding: var(--spacing-xxs) var(--spacing-s);
+  opacity: 0.9;
+
+  &:hover {
+    opacity: 1;
+  }
 }
 
 .livestream__comment-create {


### PR DESCRIPTION
## Objectives
- Regain a few lines of comments given that the chat can be cramped when donations and pinned-comments are present.
- Visual improvements.

## Screenshot
![image](https://user-images.githubusercontent.com/64950861/130391380-facebd12-f05e-43ff-960d-620d4ac4b3dd.png)
