### PR TITLE
Allow to cancel hyperchat if message is empty.

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -495,7 +495,12 @@ export function CommentCreate(props: Props) {
               requiresAuth={IS_WEB}
             />
 
-            <Button disabled={disabled} button="link" label={__('Cancel')} onClick={() => setIsSupportComment(false)} />
+            <Button
+              disabled={isSubmitting}
+              button="link"
+              label={__('Cancel')}
+              onClick={() => setIsSupportComment(false)}
+            />
           </>
         ) : (
           <>


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/6941

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Can't click cancel on hyperchat if message is empty.

## What is the new behavior?

You can click cancel on hyperchat even if the message is empty.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Type & Checklist

<details><summary>PR Type...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

</details>

<!---------------------------------------------------------------------------->

<details><summary>PR Checklist...</summary>

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
