### PR TITLE
Add page titles (affects browser Tab, History, etc.)

### DIFF
--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { Route, Redirect, Switch, withRouter } from 'react-router-dom';
 
 import * as PAGES from 'constants/pages';
+import { PAGE_TITLE } from 'constants/pageTitles';
 import { lazyImport } from 'util/lazyImport';
 import { LINKED_COMMENT_QUERY_PARAM } from 'constants/comment';
 import { parseURI, isURIValid } from 'lbry-redux';
@@ -187,6 +188,11 @@ function AppRouter(props: Props) {
   }, [hasNavigated, uri, hasUnclaimedRefereeReward, setReferrer, isAuthenticated]);
 
   useEffect(() => {
+    const getDefaultTitle = (pathname: string) => {
+      const title = pathname.startsWith('/$/') ? PAGE_TITLE[pathname.substring(3)] : '';
+      return __(title) || (IS_WEB ? SITE_TITLE : 'LBRY');
+    };
+
     if (uri) {
       const { channelName, streamName } = parseURI(uri);
 
@@ -197,19 +203,16 @@ function AppRouter(props: Props) {
       } else if (channelName) {
         document.title = channelName;
       } else {
-        document.title = IS_WEB ? SITE_TITLE : 'LBRY';
+        document.title = getDefaultTitle(pathname);
       }
     } else {
-      document.title = IS_WEB ? SITE_TITLE : 'LBRY';
+      document.title = getDefaultTitle(pathname);
     }
 
     // @if TARGET='app'
     entries[entryIndex].title = document.title;
     // @endif
-    return () => {
-      document.title = IS_WEB ? SITE_TITLE : 'LBRY';
-    };
-  }, [entries, entryIndex, title, uri]);
+  }, [pathname, entries, entryIndex, title, uri]);
 
   useEffect(() => {
     if (!hasLinkedCommentInUrl) {

--- a/ui/constants/pageTitles.js
+++ b/ui/constants/pageTitles.js
@@ -1,0 +1,59 @@
+// Customer-facing title for a page.
+//
+// Primarily used for the browser tab and history title.
+
+import * as PAGES from 'constants/pages';
+
+export const PAGE_TITLE = {
+  // --- Categories ---
+  [PAGES.BIG_HITS]: 'Big Hits',
+  [PAGES.DISCOVER]: 'Wild West',
+  // [PAGES.ENLIGHTENMENT] = 'Enlightenment',
+  [PAGES.FINANCE]: 'Finance',
+  [PAGES.GAMING]: 'Gaming',
+  [PAGES.GENERAL]: 'Cheese',
+  [PAGES.LAB]: 'Lab',
+  [PAGES.MOVIES]: 'Movies',
+  [PAGES.MUSIC]: 'Music',
+  [PAGES.NEWS]: 'News & Politics',
+  // [PAGES.RABBIT_HOLE] = 'The Rabbit Hole';
+  [PAGES.WILD_WEST]: 'Wild West',
+
+  // --- Everything else in alphabetical order ---
+  [PAGES.BUY]: 'Buy or Swap',
+  [PAGES.CHANNELS]: 'Your channels',
+  [PAGES.CHANNELS_FOLLOWING]: 'Following',
+  [PAGES.CHANNELS_FOLLOWING_DISCOVER]: 'Discover Channels',
+  [PAGES.CHANNEL_NEW]: 'Create a channel',
+  [PAGES.CHECKOUT]: 'Checkout',
+  [PAGES.CODE_2257]: '2257',
+  [PAGES.CREATOR_DASHBOARD]: 'Creator Analytics',
+  [PAGES.HELP]: 'Help',
+  [PAGES.INVITE]: 'Invite',
+  [PAGES.LISTS]: 'Lists',
+  [PAGES.LIVESTREAM]: 'Go Live on Odysee',
+  [PAGES.LIVESTREAM_CURRENT]: 'Live (Experimental)',
+  [PAGES.NOTIFICATIONS]: 'Notifications',
+  [PAGES.RECEIVE]: 'Your address',
+  [PAGES.REPORT]: 'Report an issue or request a feature',
+  [PAGES.REPORT_CONTENT]: 'Report content',
+  [PAGES.REPOST_NEW]: 'Repost',
+  [PAGES.REWARDS]: 'Rewards',
+  [PAGES.REWARDS_VERIFY]: 'Verify to earn Credits',
+  [PAGES.SEARCH]: 'Search',
+  [PAGES.SEND]: 'Send Credits',
+  [PAGES.SETTINGS]: 'Settings',
+  [PAGES.SETTINGS_BLOCKED_MUTED]: 'Block and muted channels',
+  [PAGES.SETTINGS_CREATOR]: 'Creator settings',
+  [PAGES.SETTINGS_NOTIFICATIONS]: 'Manage notifications',
+  [PAGES.SETTINGS_STRIPE_ACCOUNT]: 'settings/tip_account',
+  [PAGES.SETTINGS_STRIPE_CARD]: 'settings/card',
+  [PAGES.SETTINGS_UPDATE_PWD]: 'Update password',
+  [PAGES.SWAP]: 'Swap Credits',
+  [PAGES.TAGS_FOLLOWING]: 'Tags',
+  [PAGES.TAGS_FOLLOWING_MANAGE]: 'Manage tags',
+  [PAGES.UPLOAD]: 'Upload',
+  [PAGES.UPLOADS]: 'Your uploads',
+  [PAGES.WALLET]: 'Wallet',
+  [PAGES.WELCOME]: 'Welcome',
+};


### PR DESCRIPTION
## Issues
- While changing the "Back" behavior in the Settings Page PR, it was a pain to troubleshoot when the entire history list is listed as "odysee.com".
- If you have multiple tabs open, it's hard to know which is which for non-claim and non-channel pages.
    - <img src="https://user-images.githubusercontent.com/64950861/130814854-da2e582c-f801-4ce3-822b-f3618723466f.png" height="300"> <img src="https://user-images.githubusercontent.com/64950861/130814981-5380032e-2788-48f0-b573-e1d32906924e.png" width="300">

## New behavior
![image](https://user-images.githubusercontent.com/64950861/130815302-788b91e0-b3c5-4562-a3c3-9326466c80d8.png)<img src="https://user-images.githubusercontent.com/64950861/130815406-804a3505-e52f-4ef8-8b12-45ecb4011a21.png" width="500">

## Approach
Initially, I thought of overriding the document's title through the `<Page>` component, since the titles are usually defined there. However, given that the router is already doing the overriding, I think it's best to do the same thing all in one place.

Downside: devs might forget to add the title when a new page is added (but it'll just default to Odysee.com, no worse than current version).

## Unknown
- Not sure if are rules for titles. There seems to be a mix between sites -- some have specific titles per page, most just use the site title for each page.
- I think the `return` statement in the `useEffect` is unnecessary, since it'll just be setting to the same value now during the cleanup stage. (??)