### PR TITLE
Do not display primary uri in related content.

### DIFF
--- a/ui/component/claimListDiscover/index.js
+++ b/ui/component/claimListDiscover/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import {
   doClaimSearch,
+  selectClaimsByUri,
   selectClaimSearchByQuery,
   selectClaimSearchByQueryLastPageReached,
   selectFetchingClaimSearch,
@@ -11,10 +12,12 @@ import { selectMutedChannels } from 'redux/selectors/blocked';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
 import { makeSelectClientSetting, selectShowMatureContent, selectLanguage } from 'redux/selectors/settings';
 import { selectModerationBlockList } from 'redux/selectors/comments';
+import { selectPrimaryUri } from 'redux/selectors/content';
 import ClaimListDiscover from './view';
 
 const select = (state) => ({
   followedTags: selectFollowedTags(state),
+  claimsByUri: selectClaimsByUri(state),
   claimSearchByQuery: selectClaimSearchByQuery(state),
   claimSearchByQueryLastPageReached: selectClaimSearchByQueryLastPageReached(state),
   loading: selectFetchingClaimSearch(state),
@@ -24,6 +27,7 @@ const select = (state) => ({
   mutedUris: selectMutedChannels(state),
   blockedUris: selectModerationBlockList(state),
   searchInLanguage: makeSelectClientSetting(SETTINGS.SEARCH_IN_LANGUAGE)(state),
+  primaryUri: selectPrimaryUri(state),
 });
 
 const perform = {

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -30,6 +30,9 @@ type Props = {
   hideReposts: boolean,
   history: { action: string, push: (string) => void, replace: (string) => void },
   location: { search: string, pathname: string },
+  claimsByUri: {
+    [string]: string,
+  },
   claimSearchByQuery: {
     [string]: Array<string>,
   },
@@ -77,11 +80,13 @@ type Props = {
   showNoSourceClaims?: boolean,
   isChannel?: boolean,
   empty?: string,
+  primaryUri?: string,
 };
 
 function ClaimListDiscover(props: Props) {
   const {
     doClaimSearch,
+    claimsByUri,
     claimSearchByQuery,
     showHeader = true,
     type,
@@ -136,6 +141,7 @@ function ClaimListDiscover(props: Props) {
     isChannel = false,
     showNoSourceClaims,
     empty,
+    primaryUri,
   } = props;
   const didNavigateForward = history.action === 'PUSH';
   const { search } = location;
@@ -391,6 +397,19 @@ function ClaimListDiscover(props: Props) {
   );
   const [prevOptions, setPrevOptions] = React.useState(null);
 
+  const finalUrisWithoutCurrentUri = React.useMemo(() => {
+    if (!finalUris || !primaryUri) {
+      return finalUris;
+    }
+
+    const primaryUriClaimId = claimsByUri[primaryUri];
+    
+    return finalUris.filter((uri) => {
+      const uriClaimId = claimsByUri[uri];
+      return primaryUriClaimId !== uriClaimId;
+    });
+  }, [claimsByUri, finalUris, primaryUri]);
+
   if (!isJustScrollingToNewPage(prevOptions, options)) {
     // --- New search, or search options changed.
     setPrevOptions(options);
@@ -581,7 +600,7 @@ function ClaimListDiscover(props: Props) {
             tileLayout
             id={mainSearchKey}
             loading={loading}
-            uris={finalUris}
+            uris={finalUrisWithoutCurrentUri}
             onScrollBottom={handleScrollBottom}
             page={page}
             pageSize={dynamicPageSize}
@@ -616,7 +635,7 @@ function ClaimListDiscover(props: Props) {
             id={mainSearchKey}
             type={type}
             loading={loading}
-            uris={finalUris}
+            uris={finalUrisWithoutCurrentUri}
             onScrollBottom={handleScrollBottom}
             page={page}
             pageSize={dynamicPageSize}


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/6434

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

The primary uri (content being played) can appear as related.

## What is the new behavior?

The primary uri is filter out from related.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
