### PR TITLE
Add play button on pause ios

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -19,8 +19,6 @@ import isUserTyping from 'util/detect-typing';
 // @endif
 const isDev = process.env.NODE_ENV !== 'production';
 
-process.on('unhandledRejection', console.log)
-
 export type Player = {
   on: (string, (any) => void) => void,
   one: (string, (any) => void) => void,
@@ -496,6 +494,8 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     wrapper.setAttribute('data-vjs-player', 'true');
     const el = document.createElement(isAudio ? 'audio' : 'video');
     el.className = 'video-js vjs-big-play-centered ';
+
+    // show large play button when paused on ios
     if (IS_IOS) {
       el.classList.add('vjs-show-big-play-button-on-pause');
     }
@@ -559,6 +559,22 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       player.on('volumechange', onVolumeChange);
       player.on('error', onError);
       player.on('ended', onEnded);
+
+      // on ios, center the play button when paused
+      player.on('pause', function() {
+        if (IS_IOS) {
+          const playBT = document.getElementsByClassName('vjs-big-play-button')[0];
+          const videoDiv = player.children_[0];
+          const controlBar = document.getElementsByClassName('vjs-control-bar')[0];
+          const leftWidth = ((videoDiv.offsetWidth - playBT.offsetWidth) / 2) + 'px';
+          const availableHeight = videoDiv.offsetHeight - controlBar.offsetHeight;
+          const topHeight = (((availableHeight - playBT.offsetHeight) / 2) + 3) + 'px';
+
+          playBT.style.top = topHeight;
+          playBT.style.left = leftWidth;
+          playBT.style.margin = 0;
+        }
+      });
 
       // Replace volume bar with custom LBRY volume bar
       LbryVolumeBarClass.replaceExisting(player);

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -19,6 +19,8 @@ import isUserTyping from 'util/detect-typing';
 // @endif
 const isDev = process.env.NODE_ENV !== 'production';
 
+process.on('unhandledRejection', console.log)
+
 export type Player = {
   on: (string, (any) => void) => void,
   one: (string, (any) => void) => void,
@@ -84,11 +86,12 @@ const VIDEO_JS_OPTIONS = {
   controls: true,
   html5: {
     vhs: {
-      overrideNative: !videojs.browser.IS_ANY_SAFARI,
+      overrideNative: !videojs.browser.IS_ANY_SAFARI, // don't override on safari
     },
   },
 };
 
+// keys to bind to for keyboard shortcuts
 const SPACE_BAR_KEYCODE = 32;
 const SMALL_F_KEYCODE = 70;
 const SMALL_M_KEYCODE = 77;
@@ -493,6 +496,10 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     wrapper.setAttribute('data-vjs-player', 'true');
     const el = document.createElement(isAudio ? 'audio' : 'video');
     el.className = 'video-js vjs-big-play-centered ';
+    if (IS_IOS) {
+      el.classList.add('vjs-show-big-play-button-on-pause');
+    }
+
     wrapper.appendChild(el);
 
     container.appendChild(wrapper);

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -59,6 +59,7 @@ type Props = {
   userId: ?number,
   // allowPreRoll: ?boolean,
   shareTelemetry: boolean,
+  showAutoplayCountdown: boolean
 };
 
 // type VideoJSOptions = {
@@ -198,6 +199,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     userId,
     // allowPreRoll,
     shareTelemetry,
+    showAutoplayCountdown,
   } = props;
 
   const [reload, setReload] = useState('initial');
@@ -560,10 +562,11 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       player.on('error', onError);
       player.on('ended', onEnded);
 
-      // on ios, center the play button when paused
-      player.on('pause', function() {
-        if (IS_IOS) {
-          const playBT = document.getElementsByClassName('vjs-big-play-button')[0];
+      // on ios, show a play button when paused
+      if (IS_IOS) {
+        const playBT = document.getElementsByClassName('vjs-big-play-button')[0];
+
+        player.on('pause', function() {
           const videoDiv = player.children_[0];
           const controlBar = document.getElementsByClassName('vjs-control-bar')[0];
           const leftWidth = ((videoDiv.offsetWidth - playBT.offsetWidth) / 2) + 'px';
@@ -573,8 +576,14 @@ export default React.memo<Props>(function VideoJs(props: Props) {
           playBT.style.top = topHeight;
           playBT.style.left = leftWidth;
           playBT.style.margin = 0;
-        }
-      });
+        });
+
+        player.on('ended', function() {
+          if (showAutoplayCountdown) {
+            playBT.style.display = 'none';
+          }
+        });
+      }
 
       // Replace volume bar with custom LBRY volume bar
       LbryVolumeBarClass.replaceExisting(player);

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -59,7 +59,7 @@ type Props = {
   userId: ?number,
   // allowPreRoll: ?boolean,
   shareTelemetry: boolean,
-  showAutoplayCountdown: boolean
+  showAutoplayCountdown: boolean,
 };
 
 // type VideoJSOptions = {
@@ -566,19 +566,19 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       if (IS_IOS) {
         const playBT = document.getElementsByClassName('vjs-big-play-button')[0];
 
-        player.on('pause', function() {
+        player.on('pause', function () {
           const videoDiv = player.children_[0];
           const controlBar = document.getElementsByClassName('vjs-control-bar')[0];
-          const leftWidth = ((videoDiv.offsetWidth - playBT.offsetWidth) / 2) + 'px';
+          const leftWidth = (videoDiv.offsetWidth - playBT.offsetWidth) / 2 + 'px';
           const availableHeight = videoDiv.offsetHeight - controlBar.offsetHeight;
-          const topHeight = (((availableHeight - playBT.offsetHeight) / 2) + 3) + 'px';
+          const topHeight = (availableHeight - playBT.offsetHeight) / 2 + 3 + 'px';
 
           playBT.style.top = topHeight;
           playBT.style.left = leftWidth;
-          playBT.style.margin = 0;
+          playBT.style.margin = '0';
         });
 
-        player.on('ended', function() {
+        player.on('ended', function () {
           if (showAutoplayCountdown) {
             playBT.style.display = 'none';
           }

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -336,6 +336,7 @@ function VideoViewer(props: Props) {
           userId={userId}
           allowPreRoll={!embedded && !authenticated}
           shareTelemetry={shareTelemetry}
+          showAutoplayCountdown={autoplaySetting}
         />
       )}
     </div>


### PR DESCRIPTION
Adds a play button when content is paused on iOS. Useful because the current play button is very small and in an annoying place for righthanded users, and because iOS Safari is requiring a manual play intervention on each video upload.