### PR TITLE
Fix Category-Metadata path parsing

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -66,7 +66,7 @@ function escapeHtmlProperty(property) {
 }
 
 function getCategoryMeta(path) {
-  const page = Object.keys(CATEGORY_METADATA).find((x) => path.endsWith(x) || path.endsWith(`${x}/`));
+  const page = Object.keys(CATEGORY_METADATA).find((x) => path === `/$/${x}` || path === `/$/${x}/`);
   return CATEGORY_METADATA[page];
 }
 


### PR DESCRIPTION
## Issue
Closes #6849 category metadata shows in place of creator channel when using vanity URL