### PR TITLE
Fix extra renders when hovering over comments

### DIFF
--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -118,8 +118,6 @@ function Comment(props: Props) {
   const [isEditing, setEditing] = useState(false);
   const [editedMessage, setCommentValue] = useState(message);
   const [charCount, setCharCount] = useState(editedMessage.length);
-  // used for controlling the visibility of the menu icon
-  const [mouseIsHovering, setMouseHover] = useState(false);
   const [showReplies, setShowReplies] = useState(false);
   const [page, setPage] = useState(0);
   const [advancedEditor] = usePersistedState('comment-editor-mode', false);
@@ -219,8 +217,6 @@ function Comment(props: Props) {
         'comment--superchat': supportAmount > 0,
       })}
       id={commentId}
-      onMouseOver={() => setMouseHover(true)}
-      onMouseOut={() => setMouseHover(false)}
     >
       <div
         className={classnames('comment__content', {
@@ -286,11 +282,7 @@ function Comment(props: Props) {
             <div className="comment__menu">
               <Menu>
                 <MenuButton className="menu__button">
-                  <Icon
-                    size={18}
-                    className={mouseIsHovering ? 'comment__menu-icon--hovering' : 'comment__menu-icon'}
-                    icon={ICONS.MORE_VERTICAL}
-                  />
+                  <Icon size={18} icon={ICONS.MORE_VERTICAL} />
                 </MenuButton>
                 <CommentMenuList
                   uri={uri}

--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -42,7 +42,7 @@ function LivestreamComment(props: Props) {
     isFiat,
     isPinned,
   } = props;
-  const [mouseIsHovering, setMouseHover] = React.useState(false);
+
   const commentByOwnerOfContent = claim && claim.signing_channel && claim.signing_channel.permanent_url === authorUri;
   const { claimName } = parseURI(authorUri);
 
@@ -51,8 +51,6 @@ function LivestreamComment(props: Props) {
       className={classnames('livestream-comment', {
         'livestream-comment--superchat': supportAmount > 0,
       })}
-      onMouseOver={() => setMouseHover(true)}
-      onMouseOut={() => setMouseHover(false)}
     >
       {supportAmount > 0 && (
         <div className="super-chat livestream-superchat__banner">
@@ -106,11 +104,7 @@ function LivestreamComment(props: Props) {
       <div className="livestream-comment__menu">
         <Menu>
           <MenuButton className="menu__button">
-            <Icon
-              size={18}
-              className={mouseIsHovering ? 'comment__menu-icon--hovering' : 'comment__menu-icon'}
-              icon={ICONS.MORE_VERTICAL}
-            />
+            <Icon size={18} icon={ICONS.MORE_VERTICAL} />
           </MenuButton>
           <CommentMenuList
             uri={uri}


### PR DESCRIPTION
Remove defunct "show comment menu on hover" implementation.

It was re-rendering on every mouse movement, plus the css classname no longer exists, and also it wasn't working right in the first place (reverted few Desktop revision back, and all it did was highlighting the menu rather than controlling the visibility).

If we want the "show comment menu on hover" behavior again in the future, the CPU usage problem can probably be addressed by debouncing/throttling state-change.