### PR TITLE
Fix notifications fetching issues

### DIFF
--- a/ui/component/commentReactions/index.js
+++ b/ui/component/commentReactions/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Comment from './view';
-import { makeSelectClaimIsMine, makeSelectClaimForUri } from 'lbry-redux';
+import { makeSelectClaimIsMine, makeSelectClaimForUri, doResolveUri } from 'lbry-redux';
 import { doToast } from 'redux/actions/notifications';
 import { makeSelectMyReactionsForComment, makeSelectOthersReactionsForComment } from 'redux/selectors/comments';
 import { doCommentReact } from 'redux/actions/comments';
@@ -21,6 +21,7 @@ const select = (state, props) => {
 };
 
 const perform = (dispatch) => ({
+  resolve: (uri) => dispatch(doResolveUri(uri)),
   react: (commentId, type) => dispatch(doCommentReact(commentId, type)),
   doToast: (params) => dispatch(doToast(params)),
 });

--- a/ui/component/commentReactions/view.jsx
+++ b/ui/component/commentReactions/view.jsx
@@ -17,9 +17,11 @@ type Props = {
   pendingCommentReacts: Array<string>,
   claimIsMine: boolean,
   activeChannelId: ?string,
+  uri: string,
   claim: ?ChannelClaim,
   doToast: ({ message: string }) => void,
   hideCreatorLike: boolean,
+  resolve: (string) => void,
 };
 
 export default function CommentReactions(props: Props) {
@@ -29,15 +31,24 @@ export default function CommentReactions(props: Props) {
     commentId,
     react,
     claimIsMine,
+    uri,
     claim,
     activeChannelId,
     doToast,
     hideCreatorLike,
+    resolve,
   } = props;
   const {
     push,
     location: { pathname },
   } = useHistory();
+
+  React.useEffect(() => {
+    if (!claim) {
+      resolve(uri);
+    }
+  }, [claim, resolve, uri]);
+
   const canCreatorReact =
     claim &&
     claimIsMine &&

--- a/ui/page/notifications/view.jsx
+++ b/ui/page/notifications/view.jsx
@@ -47,7 +47,7 @@ export default function NotificationsPage(props: Props) {
 
   // Fetch reacts
   React.useEffect(() => {
-    if (initialFetchDone && activeChannel) {
+    if ((!fetching || initialFetchDone) && activeChannel) {
       let idsForReactionFetch = [];
       list.map((notification) => {
         const { notification_rule, notification_parameters } = notification;
@@ -70,7 +70,7 @@ export default function NotificationsPage(props: Props) {
         doCommentReactList(idsForReactionFetch);
       }
     }
-  }, [initialFetchDone, doCommentReactList, list, activeChannel]);
+  }, [doCommentReactList, list, activeChannel, fetching, initialFetchDone]);
 
   React.useEffect(() => {
     if (unseenCount > 0 || unreadCount > 0) {


### PR DESCRIPTION
## Fixes

Issue Number: Closes #6980, closes #6992, closes #6993

- Claim wasn't resolved so it would fail to reply (no claim_id) and to return if should show creator heart
- Notifications page wasn't fetching reactions list if not fetched yet

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
