### PR TITLE
vjs: hide errors when updating i18n

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -296,44 +296,49 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     // as the listener to update static texts.
     const player = playerRef.current;
     if (player) {
-      const controlBar = player.getChild('controlBar');
-      switch (e.type) {
-        case 'play':
-          controlBar.getChild('PlayToggle').controlText(__('Pause (space)'));
-          break;
-        case 'pause':
-          controlBar.getChild('PlayToggle').controlText(__('Play (space)'));
-          break;
-        case 'volumechange':
-          controlBar
-            .getChild('VolumePanel')
-            .getChild('MuteToggle')
-            .controlText(player.muted() || player.volume() === 0 ? __('Unmute (m)') : __('Mute (m)'));
-          break;
-        case 'fullscreenchange':
-          controlBar
-            .getChild('FullscreenToggle')
-            .controlText(player.isFullscreen() ? __('Exit Fullscreen (f)') : __('Fullscreen (f)'));
-          break;
-        case 'loadstart':
-          // --- Do everything ---
-          controlBar.getChild('PlaybackRateMenuButton').controlText(__('Playback Rate (<, >)'));
-          controlBar.getChild('QualityButton').controlText(__('Quality'));
-          resolveCtrlText({ type: 'play' });
-          resolveCtrlText({ type: 'pause' });
-          resolveCtrlText({ type: 'volumechange' });
-          resolveCtrlText({ type: 'fullscreenchange' });
-          // (1) The 'Theater mode' button should probably be changed to a class
-          // so that we can use getChild() with a specific name. There might be
-          // clashes if we add a new button in the future.
-          // (2) We'll have to get 'makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)'
-          // as a prop here so we can say "Theater mode|Default mode" instead of
-          // "Toggle Theater mode".
-          controlBar.getChild('Button').controlText(__('Toggle Theater mode (t)'));
-          break;
-        default:
-          if (isDev) throw Error('Unexpected: ' + e.type);
-          break;
+      try {
+        const controlBar = player.getChild('controlBar');
+        switch (e.type) {
+          case 'play':
+            controlBar.getChild('PlayToggle').controlText(__('Pause (space)'));
+            break;
+          case 'pause':
+            controlBar.getChild('PlayToggle').controlText(__('Play (space)'));
+            break;
+          case 'volumechange':
+            controlBar
+              .getChild('VolumePanel')
+              .getChild('MuteToggle')
+              .controlText(player.muted() || player.volume() === 0 ? __('Unmute (m)') : __('Mute (m)'));
+            break;
+          case 'fullscreenchange':
+            controlBar
+              .getChild('FullscreenToggle')
+              .controlText(player.isFullscreen() ? __('Exit Fullscreen (f)') : __('Fullscreen (f)'));
+            break;
+          case 'loadstart':
+            // --- Do everything ---
+            controlBar.getChild('PlaybackRateMenuButton').controlText(__('Playback Rate (<, >)'));
+            controlBar.getChild('QualityButton').controlText(__('Quality'));
+            resolveCtrlText({ type: 'play' });
+            resolveCtrlText({ type: 'pause' });
+            resolveCtrlText({ type: 'volumechange' });
+            resolveCtrlText({ type: 'fullscreenchange' });
+            // (1) The 'Theater mode' button should probably be changed to a class
+            // so that we can use getChild() with a specific name. There might be
+            // clashes if we add a new button in the future.
+            // (2) We'll have to get 'makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)'
+            // as a prop here so we can say "Theater mode|Default mode" instead of
+            // "Toggle Theater mode".
+            controlBar.getChild('Button').controlText(__('Toggle Theater mode (t)'));
+            break;
+          default:
+            if (isDev) throw Error('Unexpected: ' + e.type);
+            break;
+        }
+      } catch {
+        // Just fail silently. It'll just be due to hidden ctrls, and if it is
+        // due to control hierarchy change, we'll notice that in the GUI.
       }
     }
   }


### PR DESCRIPTION
## Issue
#6989 console errors and warnings are getting out of hand!

```
16:07:53.259 react_devtools_backend.js:2850 VIDEOJS: ERROR: TypeError: Cannot read properties of undefined (reading 'controlText')
    at Player.resolveCtrlText (videojs.jsx?8d8d:319)
    at HTMLDivElement.data.dispatcher (video.es.js?6651:2207)
    at trigger (video.es.js?6651:2349)
    at Player.trigger$1 [as trigger] (video.es.js?6651:3277)
    at Player.handleTechLoadStart_ (video.es.js?6651:23074)
    at Player.eval (video.es.js?6651:22824)
    at HTMLVideoElement.data.dispatcher (video.es.js?6651:2207)
```

## Notes
This method was previously criticized in 5643. But given that no better solution was submitted after a long while, nor was there a new solution for doing i18n, I'm reviving it again. It'll be no worse from the status quo.

Despite try-catch being overkill, I think the code-clarity outweighs the performance issues (if any, in the first place). Also, we are only suppressing the error in a very specialized function which even if it fails, will simply be a no-op and the GUI falling back to English.

But still open to better solutions.