### PR TITLE
Vertically center 'icon--help'

### DIFF
--- a/ui/scss/component/_icon.scss
+++ b/ui/scss/component/_icon.scss
@@ -45,6 +45,7 @@
   color: var(--color-subtitle);
   margin-left: var(--spacing-xs);
   opacity: 0.7;
+  vertical-align: middle;
 }
 
 .icon--hidden {


### PR DESCRIPTION
Reasons:
- Better symmetry.
- When used on a form-field label, the off-centeredness causes an extra offset at the top. Since the icon goes away when there is an input error, the form-field shifts a bit. (An alternative is to use a smaller icon, but I think size 16 is the best for legibility).