### PR TITLE
Blocklist: paginate + search

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^4.17.1",
     "humanize-duration": "^3.27.0",
     "if-env": "^1.0.4",
+    "match-sorter": "^6.3.0",
     "parse-duration": "^1.0.0",
     "react-datetime-picker": "^3.2.1",
     "react-plastic": "^1.1.1",

--- a/ui/component/blockList/index.js
+++ b/ui/component/blockList/index.js
@@ -1,0 +1,2 @@
+import BlockList from './view';
+export default BlockList;

--- a/ui/component/blockList/view.jsx
+++ b/ui/component/blockList/view.jsx
@@ -1,0 +1,83 @@
+// @flow
+import React from 'react';
+import classnames from 'classnames';
+import Button from 'component/button';
+import ClaimList from 'component/claimList';
+import Yrbl from 'component/yrbl';
+
+type Props = {
+  uris: Array<string>,
+  help: string,
+  titleEmptyList: string,
+  subtitleEmptyList: string,
+  getActionButtons?: (url: string) => React$Node,
+  className: ?string,
+};
+
+export default function BlockList(props: Props) {
+  const { uris: list, help, titleEmptyList, subtitleEmptyList, getActionButtons, className } = props;
+
+  // Keep a local list to allow for undoing actions in this component
+  const [localList, setLocalList] = React.useState(undefined);
+  const stringifiedList = JSON.stringify(list);
+  const hasLocalList = localList && localList.length > 0;
+  const justBlocked = list && localList && localList.length < list.length;
+
+  // **************************************************************************
+  // **************************************************************************
+
+  function getRenderActions() {
+    if (getActionButtons) {
+      return (claim) => <div className="section__actions">{getActionButtons(claim.permanent_url)}</div>;
+    }
+    return undefined;
+  }
+
+  // **************************************************************************
+  // **************************************************************************
+
+  React.useEffect(() => {
+    const list = stringifiedList && JSON.parse(stringifiedList);
+    if (!hasLocalList) {
+      setLocalList(list && list.length > 0 ? list : []);
+    }
+  }, [stringifiedList, hasLocalList]);
+
+  React.useEffect(() => {
+    if (justBlocked && stringifiedList) {
+      setLocalList(JSON.parse(stringifiedList));
+    }
+  }, [stringifiedList, justBlocked, setLocalList]);
+
+  // **************************************************************************
+  // **************************************************************************
+
+  if (localList === undefined) {
+    return null;
+  }
+
+  if (!hasLocalList) {
+    return (
+      <div className="main--empty">
+        <Yrbl
+          title={titleEmptyList}
+          subtitle={subtitleEmptyList}
+          actions={
+            <div className="section__actions">
+              <Button button="primary" label={__('Go Home')} navigate="/" />
+            </div>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="help--notice">{help}</div>
+      <div className={classnames('block-list', className)}>
+        <ClaimList uris={localList} showUnresolvedClaims showHiddenByUser hideMenu renderActions={getRenderActions()} />
+      </div>
+    </>
+  );
+}

--- a/ui/component/blockList/view.jsx
+++ b/ui/component/blockList/view.jsx
@@ -3,7 +3,10 @@ import React from 'react';
 import classnames from 'classnames';
 import Button from 'component/button';
 import ClaimList from 'component/claimList';
+import Paginate from 'component/common/paginate';
 import Yrbl from 'component/yrbl';
+
+const PAGE_SIZE = 10;
 
 type Props = {
   uris: Array<string>,
@@ -22,6 +25,15 @@ export default function BlockList(props: Props) {
   const stringifiedList = JSON.stringify(list);
   const hasLocalList = localList && localList.length > 0;
   const justBlocked = list && localList && localList.length < list.length;
+
+  const [page, setPage] = React.useState(1);
+
+  let totalPages = 0;
+  let paginatedLocalList;
+  if (localList) {
+    paginatedLocalList = localList.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+    totalPages = Math.ceil(localList.length / PAGE_SIZE);
+  }
 
   // **************************************************************************
   // **************************************************************************
@@ -52,7 +64,7 @@ export default function BlockList(props: Props) {
   // **************************************************************************
   // **************************************************************************
 
-  if (localList === undefined) {
+  if (paginatedLocalList === undefined) {
     return null;
   }
 
@@ -76,8 +88,15 @@ export default function BlockList(props: Props) {
     <>
       <div className="help--notice">{help}</div>
       <div className={classnames('block-list', className)}>
-        <ClaimList uris={localList} showUnresolvedClaims showHiddenByUser hideMenu renderActions={getRenderActions()} />
+        <ClaimList
+          uris={paginatedLocalList}
+          showUnresolvedClaims
+          showHiddenByUser
+          hideMenu
+          renderActions={getRenderActions()}
+        />
       </div>
+      <Paginate totalPages={totalPages} disableHistory onPageChange={(p) => setPage(p)} />
     </>
   );
 }

--- a/ui/component/blockList/view.jsx
+++ b/ui/component/blockList/view.jsx
@@ -1,12 +1,33 @@
 // @flow
+import { Combobox, ComboboxInput, ComboboxPopover, ComboboxList, ComboboxOption } from '@reach/combobox';
+// import '@reach/combobox/styles.css'; --> 'scss/third-party.scss'
+import { matchSorter } from 'match-sorter';
 import React from 'react';
 import classnames from 'classnames';
 import Button from 'component/button';
 import ClaimList from 'component/claimList';
+import Icon from 'component/common/icon';
 import Paginate from 'component/common/paginate';
 import Yrbl from 'component/yrbl';
+import * as ICONS from 'constants/icons';
+import useThrottle from 'effects/use-throttle';
 
 const PAGE_SIZE = 10;
+
+function reduceUriToChannelName(uri: string) {
+  // 'parseURI' is too slow to handle a large list. Since our list should be
+  // kosher in the first place, just do a quick substring call. Add a
+  // try-catch just in case.
+  try {
+    return uri.substring(uri.indexOf('@') + 1, uri.indexOf('#'));
+  } catch {
+    return uri;
+  }
+}
+
+// ****************************************************************************
+// BlockList
+// ****************************************************************************
 
 type Props = {
   uris: Array<string>,
@@ -26,6 +47,7 @@ export default function BlockList(props: Props) {
   const hasLocalList = localList && localList.length > 0;
   const justBlocked = list && localList && localList.length < list.length;
 
+  const [searchList, setSearchList] = React.useState(null); // null: not searching; []: no results;
   const [page, setPage] = React.useState(1);
 
   let totalPages = 0;
@@ -43,6 +65,14 @@ export default function BlockList(props: Props) {
       return (claim) => <div className="section__actions">{getActionButtons(claim.permanent_url)}</div>;
     }
     return undefined;
+  }
+
+  function formatSearchSuggestion(suggestion: string) {
+    return reduceUriToChannelName(suggestion);
+  }
+
+  function filterSearchResults(results: ?Array<string>) {
+    setSearchList(results);
   }
 
   // **************************************************************************
@@ -87,9 +117,17 @@ export default function BlockList(props: Props) {
   return (
     <>
       <div className="help--notice">{help}</div>
-      <div className={classnames('block-list', className)}>
+      <div className="section">
+        <SearchList
+          list={localList}
+          placeholder={__('e.g. odysee')}
+          formatter={formatSearchSuggestion}
+          onResultsUpdated={filterSearchResults}
+        />
+      </div>
+      <div className={classnames('section block-list', className)}>
         <ClaimList
-          uris={paginatedLocalList}
+          uris={searchList || paginatedLocalList}
           showUnresolvedClaims
           showHiddenByUser
           hideMenu
@@ -99,4 +137,68 @@ export default function BlockList(props: Props) {
       <Paginate totalPages={totalPages} disableHistory onPageChange={(p) => setPage(p)} />
     </>
   );
+}
+
+// ****************************************************************************
+// SearchList
+// ****************************************************************************
+
+type LsbProps = {
+  list: ?Array<string>,
+  placeholder?: string,
+  formatter?: (suggestion: string) => string,
+  onResultsUpdated?: (?Array<string>) => void,
+};
+
+function SearchList(props: LsbProps) {
+  const { list, placeholder, formatter, onResultsUpdated } = props;
+  const [term, setTerm] = React.useState('');
+  const results = useAuthorMatch(term, list);
+  const handleChange = (event) => setTerm(event.target.value);
+  const handleSelect = (e) => setTerm(e);
+
+  React.useEffect(() => {
+    if (onResultsUpdated) {
+      onResultsUpdated(results);
+    }
+  }, [results]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="wunderbar__wrapper">
+      <label>{__('Search blocked channel name')}</label>
+      <Combobox className="wunderbar" onSelect={handleSelect}>
+        <Icon icon={ICONS.SEARCH} />
+        <ComboboxInput selectOnClick className="wunderbar__input" onChange={handleChange} placeholder={placeholder} />
+        {results && (
+          <ComboboxPopover className="wunderbar__suggestions" portal={false}>
+            {results.length > 0 ? (
+              <ComboboxList>
+                {results.slice(0, 10).map((result, index) => (
+                  <ComboboxOption
+                    className="wunderbar__more-results"
+                    key={index}
+                    value={formatter ? formatter(result) : result}
+                  />
+                ))}
+              </ComboboxList>
+            ) : (
+              <span style={{ display: 'block', margin: 8 }}>{__('No results found')}</span>
+            )}
+          </ComboboxPopover>
+        )}
+      </Combobox>
+    </div>
+  );
+}
+
+function useAuthorMatch(term, list) {
+  const throttledTerm = useThrottle(term, 200);
+  return React.useMemo(() => {
+    return !throttledTerm || throttledTerm.trim() === ''
+      ? null
+      : matchSorter(list, throttledTerm, {
+          keys: [(item) => reduceUriToChannelName(item)],
+          threshold: matchSorter.rankings.CONTAINS,
+        });
+  }, [throttledTerm]); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/ui/component/common/paginate.jsx
+++ b/ui/component/common/paginate.jsx
@@ -10,16 +10,18 @@ const PAGINATE_PARAM = 'page';
 type Props = {
   totalPages: number,
   location: { search: string },
-  history: { push: string => void },
-  onPageChange?: number => void,
+  history: { push: (string) => void },
+  onPageChange?: (number) => void,
+  disableHistory?: boolean, // Disables the use of '&page=' param and history stack.
 };
 
 function Paginate(props: Props) {
-  const { totalPages = 1, location, history, onPageChange } = props;
+  const { totalPages = 1, location, history, onPageChange, disableHistory } = props;
   const { search } = location;
   const [textValue, setTextValue] = React.useState('');
   const urlParams = new URLSearchParams(search);
-  const currentPage = Number(urlParams.get(PAGINATE_PARAM)) || 1;
+  const initialPage = disableHistory ? 1 : Number(urlParams.get(PAGINATE_PARAM)) || 1;
+  const [currentPage, setCurrentPage] = React.useState(initialPage);
   const isMobile = useIsMobile();
 
   function handleChangePage(newPageNumber: number) {
@@ -28,9 +30,13 @@ function Paginate(props: Props) {
     }
 
     if (currentPage !== newPageNumber) {
-      const params = new URLSearchParams(search);
-      params.set(PAGINATE_PARAM, newPageNumber.toString());
-      history.push('?' + params.toString());
+      setCurrentPage(newPageNumber);
+
+      if (!disableHistory) {
+        const params = new URLSearchParams(search);
+        params.set(PAGINATE_PARAM, newPageNumber.toString());
+        history.push('?' + params.toString());
+      }
     }
   }
 
@@ -58,7 +64,7 @@ function Paginate(props: Props) {
             nextClassName="pagination__item pagination__item--next"
             breakClassName="pagination__item pagination__item--break"
             marginPagesDisplayed={2}
-            onPageChange={e => handleChangePage(e.selected + 1)}
+            onPageChange={(e) => handleChangePage(e.selected + 1)}
             forcePage={currentPage - 1}
             initialPage={currentPage - 1}
             containerClassName="pagination"
@@ -67,7 +73,7 @@ function Paginate(props: Props) {
         {!isMobile && (
           <FormField
             value={textValue}
-            onChange={e => setTextValue(e.target.value)}
+            onChange={(e) => setTextValue(e.target.value)}
             className="paginate-channel"
             label={__('Go to page:')}
             type="text"

--- a/ui/page/listBlocked/view.jsx
+++ b/ui/page/listBlocked/view.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import classnames from 'classnames';
 import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
-import ClaimList from 'component/claimList';
+import BlockList from 'component/blockList';
 import ClaimPreview from 'component/claimPreview';
 import Page from 'component/page';
 import Spinner from 'component/spinner';
@@ -13,7 +13,6 @@ import Button from 'component/button';
 import usePersistedState from 'effects/use-persisted-state';
 import ChannelBlockButton from 'component/channelBlockButton';
 import ChannelMuteButton from 'component/channelMuteButton';
-import Yrbl from 'component/yrbl';
 
 const VIEW = {
   BLOCKED: 'blocked',
@@ -47,7 +46,7 @@ function ListBlocked(props: Props) {
     personalTimeoutMap,
     adminTimeoutMap,
     moderatorTimeoutMap,
-    moderatorBlockListDelegatorsMap,
+    moderatorBlockListDelegatorsMap: delegatorsMap,
     fetchingModerationBlockList,
     fetchModBlockedList,
     fetchModAmIList,
@@ -56,55 +55,36 @@ function ListBlocked(props: Props) {
   } = props;
   const [viewMode, setViewMode] = usePersistedState('blocked-muted:display', VIEW.BLOCKED);
 
-  // Keep a local list to allow for undoing actions in this component
-  const [localPersonalList, setLocalPersonalList] = React.useState(undefined);
-  const [localAdminList, setLocalAdminList] = React.useState(undefined);
-  const [localModeratorList, setLocalModeratorList] = React.useState(undefined);
-  const [localModeratorListDelegatorsMap, setLocalModeratorListDelegatorsMap] = React.useState(undefined);
-  const [localMutedList, setLocalMutedList] = React.useState(undefined);
+  const [localDelegatorsMap, setLocalDelegatorsMap] = React.useState(undefined);
 
-  const hasLocalMuteList = localMutedList && localMutedList.length > 0;
-  const hasLocalPersonalList = localPersonalList && localPersonalList.length > 0;
-
-  const stringifiedMutedList = JSON.stringify(mutedUris);
-  const stringifiedPersonalList = JSON.stringify(personalBlockList);
-  const stringifiedAdminList = JSON.stringify(adminBlockList);
-  const stringifiedModeratorList = JSON.stringify(moderatorBlockList);
-  const stringifiedModeratorListDelegatorsMap = JSON.stringify(moderatorBlockListDelegatorsMap);
-
-  const stringifiedLocalAdminList = JSON.stringify(localAdminList);
-  const stringifiedLocalModeratorList = JSON.stringify(localModeratorList);
-  const stringifiedLocalModeratorListDelegatorsMap = JSON.stringify(localModeratorListDelegatorsMap);
-
-  const justMuted = localMutedList && mutedUris && localMutedList.length < mutedUris.length;
-  const justPersonalBlocked =
-    localPersonalList && personalBlockList && localPersonalList.length < personalBlockList.length;
+  const stringifiedDelegatorsMap = JSON.stringify(delegatorsMap);
+  const stringifiedLocalDelegatorsMap = JSON.stringify(localDelegatorsMap);
 
   const isAdmin =
     myChannelClaims && myChannelClaims.some((c) => delegatorsById[c.claim_id] && delegatorsById[c.claim_id].global);
+
   const isModerator =
     myChannelClaims &&
     myChannelClaims.some(
       (c) => delegatorsById[c.claim_id] && Object.keys(delegatorsById[c.claim_id].delegators).length > 0
     );
 
-  const listForView = getLocalList(viewMode);
-  const showUris = listForView && listForView.length > 0;
+  // **************************************************************************
 
-  function getLocalList(view) {
+  function getList(view) {
     switch (view) {
       case VIEW.BLOCKED:
-        return localPersonalList;
+        return personalBlockList;
       case VIEW.ADMIN:
-        return localAdminList;
+        return adminBlockList;
       case VIEW.MODERATOR:
-        return localModeratorList;
+        return moderatorBlockList;
       case VIEW.MUTED:
-        return localMutedList;
+        return mutedUris;
     }
   }
 
-  function getButtons(view, uri) {
+  function getActionButtons(uri) {
     const getDurationStr = (durationNs) => {
       const NANO_TO_MS = 1000000;
       return humanizeDuration(durationNs / NANO_TO_MS, { round: true });
@@ -127,7 +107,7 @@ function ListBlocked(props: Props) {
       );
     };
 
-    switch (view) {
+    switch (viewMode) {
       case VIEW.BLOCKED:
         return (
           <>
@@ -146,7 +126,7 @@ function ListBlocked(props: Props) {
         );
 
       case VIEW.MODERATOR:
-        const delegatorUrisForBlockedUri = localModeratorListDelegatorsMap && localModeratorListDelegatorsMap[uri];
+        const delegatorUrisForBlockedUri = localDelegatorsMap && localDelegatorsMap[uri];
         if (!delegatorUrisForBlockedUri) return null;
         return (
           <>
@@ -218,52 +198,43 @@ function ListBlocked(props: Props) {
     return source && (!local || local.length < source.length);
   }
 
-  React.useEffect(() => {
-    const jsonMutedChannels = stringifiedMutedList && JSON.parse(stringifiedMutedList);
-    if (!hasLocalMuteList && jsonMutedChannels && jsonMutedChannels.length > 0) {
-      setLocalMutedList(jsonMutedChannels);
-    }
-  }, [stringifiedMutedList, hasLocalMuteList]);
+  function getViewElem(view, label, icon) {
+    return (
+      <Button
+        icon={icon}
+        button="alt"
+        label={__(label)}
+        className={classnames(`button-toggle`, {
+          'button-toggle--active': viewMode === view,
+        })}
+        onClick={() => setViewMode(view)}
+      />
+    );
+  }
+
+  function getRefreshElem() {
+    return (
+      <Button
+        icon={ICONS.REFRESH}
+        button="alt"
+        label={__('Refresh')}
+        onClick={() => {
+          fetchModBlockedList();
+          fetchModAmIList();
+        }}
+      />
+    );
+  }
+
+  // **************************************************************************
 
   React.useEffect(() => {
-    const jsonBlockedChannels = stringifiedPersonalList && JSON.parse(stringifiedPersonalList);
-    if (!hasLocalPersonalList && jsonBlockedChannels && jsonBlockedChannels.length > 0) {
-      setLocalPersonalList(jsonBlockedChannels);
+    if (stringifiedDelegatorsMap && isSourceListLarger(stringifiedDelegatorsMap, stringifiedLocalDelegatorsMap)) {
+      setLocalDelegatorsMap(JSON.parse(stringifiedDelegatorsMap));
     }
-  }, [stringifiedPersonalList, hasLocalPersonalList]);
+  }, [stringifiedDelegatorsMap, stringifiedLocalDelegatorsMap]);
 
-  React.useEffect(() => {
-    if (stringifiedAdminList && isSourceListLarger(stringifiedAdminList, stringifiedLocalAdminList)) {
-      setLocalAdminList(JSON.parse(stringifiedAdminList));
-    }
-  }, [stringifiedAdminList, stringifiedLocalAdminList]);
-
-  React.useEffect(() => {
-    if (stringifiedModeratorList && isSourceListLarger(stringifiedModeratorList, stringifiedLocalModeratorList)) {
-      setLocalModeratorList(JSON.parse(stringifiedModeratorList));
-    }
-  }, [stringifiedModeratorList, stringifiedLocalModeratorList]);
-
-  React.useEffect(() => {
-    if (
-      stringifiedModeratorListDelegatorsMap &&
-      isSourceListLarger(stringifiedModeratorListDelegatorsMap, stringifiedLocalModeratorListDelegatorsMap)
-    ) {
-      setLocalModeratorListDelegatorsMap(JSON.parse(stringifiedModeratorListDelegatorsMap));
-    }
-  }, [stringifiedModeratorListDelegatorsMap, stringifiedLocalModeratorListDelegatorsMap]);
-
-  React.useEffect(() => {
-    if (justMuted && stringifiedMutedList) {
-      setLocalMutedList(JSON.parse(stringifiedMutedList));
-    }
-  }, [stringifiedMutedList, justMuted, setLocalMutedList]);
-
-  React.useEffect(() => {
-    if (justPersonalBlocked && stringifiedPersonalList) {
-      setLocalPersonalList(JSON.parse(stringifiedPersonalList));
-    }
-  }, [stringifiedPersonalList, justPersonalBlocked, setLocalPersonalList]);
+  // **************************************************************************
 
   return (
     <Page
@@ -282,87 +253,23 @@ function ListBlocked(props: Props) {
         <>
           <div className="section__header--actions">
             <div className="section__actions--inline">
-              <Button
-                icon={ICONS.BLOCK}
-                button="alt"
-                label={__('Blocked')}
-                className={classnames(`button-toggle`, {
-                  'button-toggle--active': viewMode === VIEW.BLOCKED,
-                })}
-                onClick={() => setViewMode(VIEW.BLOCKED)}
-              />
-              {isAdmin && (
-                <Button
-                  icon={ICONS.BLOCK}
-                  button="alt"
-                  label={__('Global')}
-                  className={classnames(`button-toggle`, {
-                    'button-toggle--active': viewMode === VIEW.ADMIN,
-                  })}
-                  onClick={() => setViewMode(VIEW.ADMIN)}
-                />
-              )}
-              {isModerator && (
-                <Button
-                  icon={ICONS.BLOCK}
-                  button="alt"
-                  label={__('Moderator')}
-                  className={classnames(`button-toggle`, {
-                    'button-toggle--active': viewMode === VIEW.MODERATOR,
-                  })}
-                  onClick={() => setViewMode(VIEW.MODERATOR)}
-                />
-              )}
-              <Button
-                icon={ICONS.MUTE}
-                button="alt"
-                label={__('Muted')}
-                className={classnames(`button-toggle`, {
-                  'button-toggle--active': viewMode === VIEW.MUTED,
-                })}
-                onClick={() => setViewMode(VIEW.MUTED)}
-              />
+              {getViewElem(VIEW.BLOCKED, 'Blocked', ICONS.BLOCK)}
+              {isAdmin && getViewElem(VIEW.ADMIN, 'Global', ICONS.BLOCK)}
+              {isModerator && getViewElem(VIEW.MODERATOR, 'Moderator', ICONS.BLOCK)}
+              {getViewElem(VIEW.MUTED, 'Muted', ICONS.MUTE)}
             </div>
-            <div className="section__actions--inline">
-              <Button
-                icon={ICONS.REFRESH}
-                button="alt"
-                label={__('Refresh')}
-                onClick={() => {
-                  fetchModBlockedList();
-                  fetchModAmIList();
-                }}
-              />
-            </div>
+            <div className="section__actions--inline">{getRefreshElem()}</div>
           </div>
 
-          {showUris && <div className="help--notice">{getHelpText(viewMode)}</div>}
-
-          {showUris ? (
-            <div className={viewMode === VIEW.MODERATOR ? 'block-list--moderator' : 'block-list'}>
-              <ClaimList
-                uris={getLocalList(viewMode)}
-                showUnresolvedClaims
-                showHiddenByUser
-                hideMenu
-                renderActions={(claim) => {
-                  return <div className="section__actions">{getButtons(viewMode, claim.permanent_url)}</div>;
-                }}
-              />
-            </div>
-          ) : (
-            <div className="main--empty">
-              <Yrbl
-                title={getEmptyListTitle(viewMode)}
-                subtitle={getEmptyListSubtitle(viewMode)}
-                actions={
-                  <div className="section__actions">
-                    <Button button="primary" label={__('Go Home')} navigate="/" />
-                  </div>
-                }
-              />
-            </div>
-          )}
+          <BlockList
+            key={viewMode}
+            uris={getList(viewMode)}
+            help={getHelpText(viewMode)}
+            titleEmptyList={getEmptyListTitle(viewMode)}
+            subtitle={getEmptyListSubtitle(viewMode)}
+            getActionButtons={getActionButtons}
+            className={viewMode === VIEW.MODERATOR ? 'block-list--moderator' : undefined}
+          />
         </>
       )}
     </Page>

--- a/ui/page/listBlocked/view.jsx
+++ b/ui/page/listBlocked/view.jsx
@@ -133,11 +133,14 @@ function ListBlocked(props: Props) {
             {delegatorUrisForBlockedUri.map((delegatorUri) => {
               return (
                 <div className="block-list--delegator" key={delegatorUri}>
-                  <ul className="section content__non-clickable">
-                    <ClaimPreview uri={delegatorUri} hideMenu hideActions type="small" />
+                  <label>{__('Blocked on behalf of:')}</label>
+                  <ul className="section">
+                    <div className="content__non-clickable">
+                      <ClaimPreview uri={delegatorUri} hideMenu hideActions type="inline" properties={false} />
+                      {moderatorTimeoutMap[uri] && getBanInfoElem(moderatorTimeoutMap[uri])}
+                    </div>
+                    <ChannelBlockButton uri={uri} blockLevel={BLOCK_LEVEL.MODERATOR} creatorUri={delegatorUri} />
                   </ul>
-                  <ChannelBlockButton uri={uri} blockLevel={BLOCK_LEVEL.MODERATOR} creatorUri={delegatorUri} />
-                  {moderatorTimeoutMap[uri] && getBanInfoElem(moderatorTimeoutMap[uri])}
                 </div>
               );
             })}

--- a/ui/scss/component/_block-list.scss
+++ b/ui/scss/component/_block-list.scss
@@ -15,6 +15,33 @@
   .button--secondary {
     margin-top: var(--spacing-xxs);
   }
+
+  .claim-preview__wrapper {
+    border-bottom: none !important;
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .claim-preview--inline {
+    .channel-thumbnail {
+      @include handleChannelGif(3rem);
+    }
+  }
+
+  .claim-preview__title {
+    font-size: var(--font-small);
+  }
+
+  .channel-name {
+    font-size: var(--font-xsmall);
+  }
+
+  .section {
+    margin-left: var(--spacing-m);
+  }
+
+  label {
+    font-style: italic;
+  }
 }
 
 .block-modal--values {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10707,6 +10707,14 @@ marked@^1.2.3:
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.8.tgz#5008ece15cfa43e653e85845f3525af4beb6bdd4"
   integrity sha512-lzmFjGnzWHkmbk85q/ILZjFoHHJIQGF+SxGEfIdGk/XhiTPhqGs37gbru6Kkd48diJnEyYwnG67nru0Z2gQtuQ==
 
+match-sorter@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 matcher@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"
@@ -14046,6 +14054,11 @@ remark@^9.0.0:
     remark-parse "^5.0.0"
     remark-stringify "^5.0.0"
     unified "^6.0.0"
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
 
 remove-markdown@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
## Test
kp.odysee.com

## Ticket
Closes [#6834 Support pagination + search in moderation sections](https://github.com/lbryio/lbry-desktop/issues/6834)

## Main changes
- Added app-side pagination.
- Improved the "moderator-block" visuals a bit
- Added search bar for blocklists.
    - Fuzzy search is supported, but is slow when the list is huge. Ended up using "CONTAINS" search.
    - Can play around with other types if the search is not good enough:

        > CASE SENSITIVE EQUALS: Case-sensitive equality trumps all. These will be first. (ex. France would match France, but not france)
EQUALS: Case-insensitive equality (ex. France would match france)
STARTS WITH: If the item starts with the given value (ex. Sou would match South Korea or South Africa)
WORD STARTS WITH: If the item has multiple words, then if one of those words starts with the given value (ex. Repub would match Dominican Republic)
CONTAINS: If the item contains the given value (ex. ham would match Bahamas)
ACRONYM: If the item's acronym is the given value (ex. us would match United States)
SIMPLE MATCH: If the item has letters in the same order as the letters of the given value (ex. iw would match Zimbabwe, but not Kuwait because it must be in the same order). Furthermore, if the item is a closer match, it will rank higher (ex. ua matches Uruguay more closely than United States of America, therefore Uruguay will be ordered before United States of America)
