### PR TITLE
Changes to improve videojs playing experience on iOS

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
@@ -151,8 +151,8 @@ const onPlayerReady = (player, options) => {
  *           Never shows if the endscreen plugin is present
  */
 const mobileUi = function(options) {
-  // if (videojs.browser.IS_ANDROID || videojs.browser.IS_IOS) {
-  if (videojs.browser.IS_ANDROID) {
+  // target both iOS and Android
+  if (videojs.browser.IS_ANDROID || videojs.browser.IS_IOS) {
     this.ready(() => {
       onPlayerReady(this, videojs.mergeOptions(defaults, options));
     });

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -283,10 +283,10 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     // as the listener to update static texts.
 
     const setLabel = (controlBar, childName, label) => {
-      const c = controlBar.getChild(childName);
-      if (c) {
-        c.controlText(label);
-      }
+      // const c = controlBar.getChild(childName);
+      // if (c) {
+      //   c.controlText(label);
+      // }
     };
 
     const player = playerRef.current;

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -341,13 +341,31 @@ function VideoViewer(props: Props) {
             // player.muted(true);
             // another version had player.play()
           }
+          console.log('running here!')
         } else {
+          console.log('running here123')
           const isPaused = player.paused();
+
+          console.log('is paused');
+          console.log(isPaused)
           if (IS_IOS && isPaused) {
             document.getElementsByClassName('video-js--tap-to-unmute')[0].style.visibility = 'visible';
             player.muted(true);
             const iosResponse = player.play();
+            console.log(iosResponse)
           }
+          setTimeout(function(){
+            console.log('running here124')
+            const isPaused = player.paused();
+            console.log('is paused');
+            console.log(isPaused)
+            if (IS_IOS && isPaused) {
+              document.getElementsByClassName('video-js--tap-to-unmute')[0].style.visibility = 'visible';
+              player.muted(true);
+              const iosResponse = player.play();
+              console.log(iosResponse)
+            }
+          }, 1000)
         }
         setIsLoading(false);
         setIsPlaying(false);

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -110,6 +110,12 @@ function VideoViewer(props: Props) {
     previousListUri,
     videoTheaterMode,
   } = props;
+
+  const IS_IOS =
+    (/iPad|iPhone|iPod/.test(navigator.platform) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
+    !window.MSStream;
+
   const permanentUrl = claim && claim.permanent_url;
   const adApprovedChannelIds = homepageData ? getAllIds(homepageData) : [];
   const claimId = claim && claim.claim_id;
@@ -334,6 +340,13 @@ function VideoViewer(props: Props) {
           if (player.autoplay() && !player.muted()) {
             // player.muted(true);
             // another version had player.play()
+          }
+        } else {
+          const isPaused = player.paused();
+          if (IS_IOS && isPaused) {
+            document.getElementsByClassName('video-js--tap-to-unmute')[0].style.visibility = 'visible';
+            player.muted(true);
+            const iosResponse = player.play();
           }
         }
         setIsLoading(false);


### PR DESCRIPTION
Re-enables mobile-ui for videojs on iOS and plays videos by default as muted with the 'Tap to unmute' button