### PR TITLE
Fix: Can't unblock if delegator deleted their channel

### DIFF
--- a/ui/component/channelBlockButton/view.jsx
+++ b/ui/component/channelBlockButton/view.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import Button from 'component/button';
 import { BLOCK_LEVEL } from 'constants/comment';
-import { parseURI } from 'lbry-redux';
 
 type Props = {
   uri: string,
@@ -48,11 +47,10 @@ function ChannelBlockButton(props: Props) {
 
       case BLOCK_LEVEL.MODERATOR:
         if (creatorUri) {
-          const { channelClaimId } = parseURI(creatorUri);
           if (isBlocked) {
-            doCommentModUnBlockAsModerator(uri, channelClaimId, '');
+            doCommentModUnBlockAsModerator(uri, creatorUri, '');
           } else {
-            doCommentModBlockAsModerator(uri, channelClaimId, '');
+            doCommentModBlockAsModerator(uri, creatorUri, '');
           }
         }
         break;

--- a/ui/modal/modalBlockChannel/index.js
+++ b/ui/modal/modalBlockChannel/index.js
@@ -15,11 +15,9 @@ const select = (state, props) => ({
 
 const perform = (dispatch) => ({
   closeModal: () => dispatch(doHideModal()),
-  commentModBlock: (commenterUri, timeoutHours) => dispatch(doCommentModBlock(commenterUri, timeoutHours)),
-  commentModBlockAsAdmin: (commenterUri, blockerId, timeoutHours) =>
-    dispatch(doCommentModBlockAsAdmin(commenterUri, blockerId, timeoutHours)),
-  commentModBlockAsModerator: (commenterUri, creatorId, blockerId, timeoutHours) =>
-    dispatch(doCommentModBlockAsModerator(commenterUri, creatorId, blockerId, timeoutHours)),
+  commentModBlock: (a, b) => dispatch(doCommentModBlock(a, b)),
+  commentModBlockAsAdmin: (a, b, c) => dispatch(doCommentModBlockAsAdmin(a, b, c)),
+  commentModBlockAsModerator: (a, b, c, d) => dispatch(doCommentModBlockAsModerator(a, b, c, d)),
 });
 
 export default connect(select, perform)(ModalBlockChannel);

--- a/ui/modal/modalBlockChannel/view.jsx
+++ b/ui/modal/modalBlockChannel/view.jsx
@@ -33,9 +33,14 @@ type Props = {
   moderationDelegatorsById: { [string]: { global: boolean, delegators: { name: string, claimId: string } } },
   // --- perform ---
   closeModal: () => void,
-  commentModBlock: (string, ?number) => void,
-  commentModBlockAsAdmin: (string, string, ?number) => void,
-  commentModBlockAsModerator: (string, string, string, ?number) => void,
+  commentModBlock: (commenterUri: string, timeoutSec: ?number) => void,
+  commentModBlockAsAdmin: (commenterUri: string, blockerId: string, timeoutSec: ?number) => void,
+  commentModBlockAsModerator: (
+    commenterUri: string,
+    creatorUri: string,
+    blockerId: string,
+    timeoutSec: ?number
+  ) => void,
 };
 
 export default function ModalBlockChannel(props: Props) {
@@ -227,7 +232,12 @@ export default function ModalBlockChannel(props: Props) {
 
       case TAB.MODERATOR:
         if (activeChannelClaim && contentChannelClaim) {
-          commentModBlockAsModerator(commenterUri, contentChannelClaim.claim_id, activeChannelClaim.claim_id, duration);
+          commentModBlockAsModerator(
+            commenterUri,
+            contentChannelClaim.permanent_url,
+            activeChannelClaim.claim_id,
+            duration
+          );
         }
         break;
 


### PR DESCRIPTION
## Issue
Closes #7003 Can't unblock if delegator deleted their channel

## Changes
- Changed the function parameter from 'creatorId' to 'creatorUri'
    - It got short-circuited because we don't resolve deleted channels. But the client already have the full creator URI (containing the needed 'name' and 'id'), so there is no need to actually look at the resolved list -- just pass the uri like all the other functions.