### PR TITLE
Blocklist: don't show pagination widget when searching.

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1917,6 +1917,7 @@
   "e.g. John Doe": "e.g. John Doe",
   "e.g. john@example.com": "e.g. john@example.com",
   "e.g. satoshi@example.com": "e.g. satoshi@example.com",
+  "e.g. odysee": "e.g. odysee",
   "Your channel": "Your channel",
   "Set to \"Anonymous\" if you do not want to associate your channel in this report.": "Set to \"Anonymous\" if you do not want to associate your channel in this report.",
   "Send report?": "Send report?",
@@ -2168,7 +2169,5 @@
   "Content Page": "Content Page",
   "Card Last 4": "Card Last 4",
   "Search blocked channel name": "Search blocked channel name",
-  "e.g. odysee": "e.g. odysee",
-  "No results found": "No results found",
   "--end--": "--end--"
 }

--- a/ui/component/blockList/view.jsx
+++ b/ui/component/blockList/view.jsx
@@ -47,8 +47,9 @@ export default function BlockList(props: Props) {
   const hasLocalList = localList && localList.length > 0;
   const justBlocked = list && localList && localList.length < list.length;
 
-  const [searchList, setSearchList] = React.useState(null); // null: not searching; []: no results;
   const [page, setPage] = React.useState(1);
+  const [searchList, setSearchList] = React.useState(null); // null: not searching; []: no results;
+  const isShowingSearchResults = searchList !== null;
 
   let totalPages = 0;
   let paginatedLocalList;
@@ -134,7 +135,7 @@ export default function BlockList(props: Props) {
           renderActions={getRenderActions()}
         />
       </div>
-      <Paginate totalPages={totalPages} disableHistory onPageChange={(p) => setPage(p)} />
+      {!isShowingSearchResults && <Paginate totalPages={totalPages} disableHistory onPageChange={(p) => setPage(p)} />}
     </>
   );
 }
@@ -182,7 +183,7 @@ function SearchList(props: LsbProps) {
                 ))}
               </ComboboxList>
             ) : (
-              <span style={{ display: 'block', margin: 8 }}>{__('No results found')}</span>
+              <span style={{ display: 'block', margin: 8 }}>{__('No results')}</span>
             )}
           </ComboboxPopover>
         )}


### PR DESCRIPTION
Also, re-use existing strings instead.