### PR TITLE
Hide overflow on search suggestion thumbnails

### DIFF
--- a/ui/scss/component/_wunderbar.scss
+++ b/ui/scss/component/_wunderbar.scss
@@ -142,6 +142,7 @@
 
   .media__thumb {
     flex-shrink: 0;
+    overflow: hidden;
     $width: 5rem;
     @include handleClaimListGifThumbnail($width);
     width: $width;


### PR DESCRIPTION
## Fixes

Fixes #6912

## What is the current behavior?

File price overflows the search suggestion thumbnail.

## What is the new behavior?

Overflow is hidden on the search suggestion thumbnail.

<img width="493" alt="search-suggestion-thumbnail-overflow-hidden" src="https://user-images.githubusercontent.com/31634995/133006679-5ecbef51-658e-470d-9695-78906c82b318.png">

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
