### PR TITLE
Settings: use 'smooth' instead of 'instant' scroll.

### DIFF
--- a/ui/component/settingsSideNavigation/view.jsx
+++ b/ui/component/settingsSideNavigation/view.jsx
@@ -56,7 +56,11 @@ export default function SettingsSideNavigation() {
     const TOP_MARGIN_PX = 20;
     const element = document.getElementById(section);
     if (element) {
-      window.scrollTo(0, element.offsetTop - TOP_MARGIN_PX);
+      window.scrollTo({
+        top: element.offsetTop - TOP_MARGIN_PX,
+        left: 0,
+        behavior: 'smooth',
+      });
     }
   }
 


### PR DESCRIPTION
With 'instant', it is not clear that we are actually scrolling within the existing page (not opening a new page).