### PR TITLE
Fix scrollbar in upgrade modal

### DIFF
--- a/ui/modal/modalUpgrade/view.jsx
+++ b/ui/modal/modalUpgrade/view.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { Modal } from 'modal/modal';
 import LastReleaseChanges from 'component/lastReleaseChanges';
 
+const IS_MAC = navigator.userAgent.indexOf('Mac OS X') !== -1;
+
 type Props = {
   downloadUpgrade: () => void,
   skipUpgrade: () => void,
@@ -14,6 +16,7 @@ class ModalUpgrade extends React.PureComponent<Props> {
 
     return (
       <Modal
+        className={IS_MAC ? '' : 'main-wrapper--scrollbar'}
         isOpen
         contentLabel={__('Upgrade available')}
         title={__('LBRY leveled up')}

--- a/ui/scss/init/_gui.scss
+++ b/ui/scss/init/_gui.scss
@@ -485,7 +485,7 @@ textarea {
 
 .release__notes {
   max-height: 50vh;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .signup__odysee-logo {

--- a/web/scss/themes/odysee/init/_gui.scss
+++ b/web/scss/themes/odysee/init/_gui.scss
@@ -488,7 +488,7 @@ textarea {
 
 .release__notes {
   max-height: 50vh;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .signup__odysee-logo {


### PR DESCRIPTION
## Issue
Closes [#5848 Remove scroll-bar in update prompt](https://github.com/lbryio/lbry-desktop/issues/5848)

## Changes
- Make scrollbars appear only when necessary.
- Style the scrollbar. Similar to other areas, we skip this for Mac (can't recall why we need to skip).

## Before-After:
<img src="https://user-images.githubusercontent.com/64950861/133104817-0e79e322-ef3e-4577-9597-67c6a1df4e1b.png" width="300">   <img src="https://user-images.githubusercontent.com/64950861/133104839-7f77b706-e151-40ce-b6bf-2bd664afaba0.png" width="300">
