### PR TITLE
Fix dropdown caret spacing

### DIFF
--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -19,6 +19,8 @@
 
 .claim-list__dropdown {
   padding: 0 var(--spacing-m);
+  padding-right: 2.75rem;
+  background-position: right var(--spacing-m) center;
 
   @media (max-width: $breakpoint-small) {
     margin-left: 0;

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -19,7 +19,7 @@
 
 .claim-list__dropdown {
   padding: 0 var(--spacing-m);
-  padding-right: 2.75rem;
+  padding-right: var(--spacing-xl);
   background-position: right var(--spacing-m) center;
 
   @media (max-width: $breakpoint-small) {

--- a/ui/scss/component/_claim-search.scss
+++ b/ui/scss/component/_claim-search.scss
@@ -26,7 +26,7 @@
 
 .claim-search__dropdown {
   padding: 0 var(--spacing-m);
-  padding-right: 2.75rem;
+  padding-right: var(--spacing-xl);
   font-size: var(--font-body);
   background-color: var(--color-card-background);
   background-position: right var(--spacing-m) center;

--- a/ui/scss/component/_claim-search.scss
+++ b/ui/scss/component/_claim-search.scss
@@ -26,9 +26,10 @@
 
 .claim-search__dropdown {
   padding: 0 var(--spacing-m);
-  padding-right: var(--spacing-l);
+  padding-right: 2.75rem;
   font-size: var(--font-body);
   background-color: var(--color-card-background);
+  background-position: right var(--spacing-m) center;
 }
 
 .claim-search__dropdown--selected {

--- a/ui/scss/component/_form-field.scss
+++ b/ui/scss/component/_form-field.scss
@@ -45,10 +45,10 @@ select {
 
 select {
   background-image: var(--select-toggle-background);
-  background-position: 99% center;
+  background-position: right var(--spacing-s) center;
   background-repeat: no-repeat;
   background-size: 1rem;
-  padding-right: var(--spacing-l);
+  padding-right: 2.25rem;
   padding-left: var(--spacing-s);
   font-weight: bold;
 }

--- a/ui/scss/component/_form-field.scss
+++ b/ui/scss/component/_form-field.scss
@@ -48,7 +48,7 @@ select {
   background-position: right var(--spacing-s) center;
   background-repeat: no-repeat;
   background-size: 1rem;
-  padding-right: 2.25rem;
+  padding-right: var(--spacing-xl);
   padding-left: var(--spacing-s);
   font-weight: bold;
 }


### PR DESCRIPTION
## Fixes

Fixes #6927

## What is the current behavior?

Dropdown caret has no space to the right

<img width="704" alt="Screen Shot 2021-09-14 at 10 59 58 AM" src="https://user-images.githubusercontent.com/64950861/130342618-1b84d970-3a82-4224-a822-4d59be401bff.png">
<img width="299" alt="Screen Shot 2021-09-14 at 10 57 06 AM" src="https://user-images.githubusercontent.com/64950861/130342731-cf24fbce-ca89-4c0c-9c1e-b05a26addf3f.png">

## What is the new behavior?

Dropdown caret has space on either side

<img width="704" alt="Screen Shot 2021-09-14 at 10 59 58 AM" src="https://user-images.githubusercontent.com/31634995/133338306-fe623de5-0611-489a-811b-c663bc7de14f.png">
<img width="344" alt="Screen Shot 2021-09-14 at 12 33 38 PM" src="https://user-images.githubusercontent.com/31634995/133338272-671a2d69-44df-49ea-a3c0-8d04b6b0924f.png">
<img width="299" alt="Screen Shot 2021-09-14 at 10 57 06 AM" src="https://user-images.githubusercontent.com/31634995/133338320-8904466a-0696-4c22-b15b-0953654371d2.png">

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
