### PR TITLE
Revert "Use SI notation for view_count ... bbcdcfe4"

### DIFF
--- a/ui/component/fileViewCountInline/index.js
+++ b/ui/component/fileViewCountInline/index.js
@@ -1,14 +1,12 @@
 import { connect } from 'react-redux';
 import { makeSelectClaimForUri } from 'lbry-redux';
 import { makeSelectViewCountForUri } from 'lbryinc';
-import { selectLanguage } from 'redux/selectors/settings';
 import FileViewCountInline from './view';
 
 const select = (state, props) => {
   return {
     claim: makeSelectClaimForUri(props.uri)(state),
     viewCount: makeSelectViewCountForUri(props.uri)(state),
-    lang: selectLanguage(state),
   };
 };
 

--- a/ui/component/fileViewCountInline/view.jsx
+++ b/ui/component/fileViewCountInline/view.jsx
@@ -7,15 +7,11 @@ type Props = {
   // --- select ---
   claim: ?StreamClaim,
   viewCount: string,
-  lang: ?string,
 };
 
 export default function FileViewCountInline(props: Props) {
-  const { isLivestream, claim, viewCount, lang } = props;
-  const formattedViewCount = Number(viewCount).toLocaleString(lang || 'en', {
-    compactDisplay: 'short',
-    notation: 'compact',
-  });
+  const { isLivestream, claim, viewCount } = props;
+  const formattedViewCount = Number(viewCount).toLocaleString();
 
   if (!viewCount || (claim && claim.repost_url) || isLivestream) {
     // (1) Currently, makeSelectViewCountForUri doesn't differentiate between


### PR DESCRIPTION
It is breaking in old Safari 10. Revert for until; will get to a cleaner solution later.