### PR TITLE
Fix view-count showing up in non-Channel pages

### DIFF
--- a/ui/component/fileViewCountInline/view.jsx
+++ b/ui/component/fileViewCountInline/view.jsx
@@ -24,7 +24,12 @@ export default function FileViewCountInline(props: Props) {
     formattedViewCount = Number(viewCount).toLocaleString();
   }
 
-  if (!viewCount || (claim && claim.repost_url) || isLivestream) {
+  // Limit the view-count visibility to Channel Pages for now. I believe we'll
+  // eventually show it everywhere, so this band-aid would be the easiest to
+  // clean up (only one place edit/remove).
+  const isChannelPage = window.location.pathname.startsWith('/@');
+
+  if (!viewCount || (claim && claim.repost_url) || isLivestream || !isChannelPage) {
     // (1) Currently, makeSelectViewCountForUri doesn't differentiate between
     // un-fetched view-count vs zero view-count. But since it's probably not
     // ideal to highlight that a view has 0 count, let's just not show anything.


### PR DESCRIPTION
## Issue
If you navigated to a Channel Page and returned to the homepage (or any page with ClaimPreview), the view-count is shown because we have that data.

## Fix
Instead of passing props around through the long "list" component chain (`ChannelContent -> ClaimListDiscover -> ClaimList -> ClaimPreview`) to indicate whether we should display it , just check the pathname at the lowest component level;  I believe eventually we would display it everywhere anyways, so this we'll be the easiest to clean up.