### PR TITLE
Fix moderator data misalignment.

### DIFF
--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -21,6 +21,7 @@ import { doAlertWaitingForSync } from 'redux/actions/app';
 
 const isDev = process.env.NODE_ENV !== 'production';
 const FETCH_API_FAILED_TO_FETCH = 'Failed to fetch';
+const PROMISE_FULFILLED = 'fulfilled';
 
 declare type CommentronErrorMap = {
   [string]: {
@@ -1377,9 +1378,7 @@ export function doFetchCommentModAmIList(channelClaim: ChannelClaim) {
     const state = getState();
     const myChannels = selectMyChannelClaims(state);
 
-    dispatch({
-      type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_STARTED,
-    });
+    dispatch({ type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_STARTED });
 
     let channelSignatures = [];
 
@@ -1399,13 +1398,13 @@ export function doFetchCommentModAmIList(channelClaim: ChannelClaim) {
               })
             )
         )
-          .then((res) => {
+          .then((results) => {
             const delegatorsById = {};
 
-            channelSignatures.forEach((chanSig, index) => {
-              if (chanSig && res[index]) {
-                const value = res[index].value;
-                delegatorsById[chanSig.claim_id] = {
+            results.forEach((result, index) => {
+              if (result.status === PROMISE_FULFILLED) {
+                const value = result.value;
+                delegatorsById[value.channel_id] = {
                   global: value ? value.type === 'Global' : false,
                   delegators: value && value.authorized_channels ? value.authorized_channels : {},
                 };
@@ -1418,15 +1417,12 @@ export function doFetchCommentModAmIList(channelClaim: ChannelClaim) {
             });
           })
           .catch((err) => {
-            dispatch({
-              type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_FAILED,
-            });
+            devToast(dispatch, `AmI: ${err}`);
+            dispatch({ type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_FAILED });
           });
       })
       .catch(() => {
-        dispatch({
-          type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_FAILED,
-        });
+        dispatch({ type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_FAILED });
       });
   };
 }


### PR DESCRIPTION
https://kp.odysee.com

## Issue
Closes [#7121 Missing mod block option (large number of moderated channels?)](https://github.com/lbryio/lbry-desktop/issues/7121)

## Notes
It was bad to assume `channelSignatures` would be the same length as the promise result -- any failure in signing would cause a misalignment.

For my case, an accidentally-merged channel couldn't be signed due to a missing private key. I think it's the same for Drew.
