### PR TITLE
Embed: add replay button + msg resizing

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2169,5 +2169,6 @@
   "Content Page": "Content Page",
   "Card Last 4": "Card Last 4",
   "Search blocked channel name": "Search blocked channel name",
+  "Discuss": "Discuss",
   "--end--": "--end--"
 }

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -231,6 +231,10 @@
   .button + .button {
     margin-left: var(--spacing-m);
   }
+
+  .button--link {
+    vertical-align: middle;
+  }
 }
 
 .file-viewer__overlay-logo {

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -196,7 +196,11 @@
 }
 
 .file-viewer_embed-ended-title {
-  white-space: pre-wrap;
+  max-width: 100%;
+  p {
+    font-size: 6vh;
+    white-space: pre-wrap;
+  }
 }
 
 .content__viewer--floating {

--- a/web/component/fileViewerEmbeddedEnded/view.jsx
+++ b/web/component/fileViewerEmbeddedEnded/view.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import Button from 'component/button';
+import * as ICONS from 'constants/icons';
 import { formatLbryUrlForWeb } from 'util/url';
 import { withRouter } from 'react-router';
 import { URL, SITE_NAME } from 'config';
@@ -34,6 +35,7 @@ function FileViewerEmbeddedEnded(props: Props) {
   // $FlowFixMe
   const prompt = prompts[promptKey];
   const lbrytvLink = `${URL}${formatLbryUrlForWeb(uri)}?src=${promptKey}`;
+  const showReplay = Boolean(window.player);
 
   return (
     <div className="file-viewer__overlay">
@@ -46,9 +48,18 @@ function FileViewerEmbeddedEnded(props: Props) {
         <>
           <div className="file-viewer__overlay-title file-viewer_embed-ended-title">{prompt}</div>
           <div className="file-viewer__overlay-actions">
-            { /* add button to replay? */ }
             <>
-              <Button label={__('Rewatch or Discuss')} button="primary" href={lbrytvLink} />
+              {showReplay && (
+                <Button
+                  title={__('Replay')}
+                  button="link"
+                  iconRight={ICONS.REPLAY}
+                  onClick={() => {
+                    if (window.player) window.player.play();
+                  }}
+                />
+              )}
+              <Button label={__('Discuss')} iconRight={ICONS.EXTERNAL} button="primary" href={lbrytvLink} />
               {!isAuthenticated && (
                 <Button
                   label={__('Join %SITE_NAME%', { SITE_NAME })}

--- a/web/component/fileViewerEmbeddedEnded/view.jsx
+++ b/web/component/fileViewerEmbeddedEnded/view.jsx
@@ -46,7 +46,9 @@ function FileViewerEmbeddedEnded(props: Props) {
       </div>
       {!preferEmbed && (
         <>
-          <div className="file-viewer__overlay-title file-viewer_embed-ended-title">{prompt}</div>
+          <div className="file-viewer__overlay-title file-viewer_embed-ended-title">
+            <p>{prompt}</p>
+          </div>
           <div className="file-viewer__overlay-actions">
             <>
               {showReplay && (


### PR DESCRIPTION
## Test
Point your embed to kp.odysee.com

## Ticket
Closes [#7113 embed improvements for peakprosperity ](https://github.com/lbryio/lbry-desktop/issues/7113)

## Changes
- Added a replace button;  replaced "Rewatch and Discuss" to "Discuss /".
- Make the message font size dynamic based on container height, so that it won't clip.

![Screenshot from 2021-09-21 16-19-16](https://user-images.githubusercontent.com/64950861/134139335-61fa471f-2212-40f9-9c0a-b72ee7dc6774.png)
 