### PR TITLE
Send video bitrate and user bandwidth to Watchman

### DIFF
--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -10,6 +10,13 @@ import ElectronCookies from '@exponent/electron-cookies';
 import { generateInitialUrl } from 'util/url';
 // @endif
 import { MATOMO_ID, MATOMO_URL } from 'config';
+import getConnectionSpeed from 'util/detect-user-bandwidth';
+
+let downloadSpeed;
+getConnectionSpeed(function(speedInMbps){
+  downloadSpeed = speedInMbps;
+  console.log(downloadSpeed);
+});
 
 const isProduction = process.env.NODE_ENV === 'production';
 const devInternalApis = process.env.LBRY_API_URL && process.env.LBRY_API_URL.includes('dev');
@@ -202,8 +209,10 @@ async function sendWatchmanData(body) {
 }
 
 const analytics: Analytics = {
-  // receive buffer events from tracking plugin and jklj
+  // receive buffer events from tracking plugin and save buffer amounts and times for backend call
   videoBufferEvent: async (claim, data) => {
+    console.log('running here!');
+    console.log(data);
     amountOfBufferEvents = amountOfBufferEvents + 1;
     amountOfBufferTimeInMS = amountOfBufferTimeInMS + data.bufferDuration;
   },

--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -12,11 +12,13 @@ import { generateInitialUrl } from 'util/url';
 import { MATOMO_ID, MATOMO_URL } from 'config';
 import getConnectionSpeed from 'util/detect-user-bandwidth';
 
-let downloadSpeed;
-getConnectionSpeed(function(speedInMbps){
-  downloadSpeed = speedInMbps;
-  console.log(downloadSpeed);
-});
+let userDownloadBandwidth;
+async function getUserBandwidth() {
+  userDownloadBandwidth = await getConnectionSpeed();
+}
+
+getUserBandwidth();
+setInterval(getUserBandwidth, 1000 * 30);
 
 const isProduction = process.env.NODE_ENV === 'production';
 const devInternalApis = process.env.LBRY_API_URL && process.env.LBRY_API_URL.includes('dev');

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -168,9 +168,17 @@ function VideoViewer(props: Props) {
     }
     analytics.playerStartedEvent(embedded);
 
+    // convert bytes to bits, and then divide by seconds
+    const contentInBits = Number(claim.value.source.size) * 8;
+    const durationInSeconds = claim.value.video && claim.value.video.duration;
+    let bitrateAsBitsPerSecond;
+    if (durationInSeconds) {
+      bitrateAsBitsPerSecond = Math.round(contentInBits / durationInSeconds);
+    }
+
     fetch(source, { method: 'HEAD', cache: 'no-store' }).then((response) => {
       let playerPoweredBy = response.headers.get('x-powered-by') || '';
-      analytics.videoStartEvent(claimId, timeToStart, playerPoweredBy, userId, claim.canonical_url, this);
+      analytics.videoStartEvent(claimId, timeToStart, playerPoweredBy, userId, claim.canonical_url, this, bitrateAsBitsPerSecond);
     });
 
     doAnalyticsView(uri, timeToStart).then(() => {

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -505,6 +505,7 @@ export function doAnalyticsBuffer(uri, bufferData) {
     const fileSizeInBits = fileSize * 8;
     const bitRate = parseInt(fileSizeInBits / fileDurationInSeconds);
     const userId = user && user.id.toString();
+    // if there's a logged in user, send buffer event data to watchman
     if (userId) {
       analytics.videoBufferEvent(claim, {
         timeAtBuffer,

--- a/ui/util/detect-user-bandwidth.js
+++ b/ui/util/detect-user-bandwidth.js
@@ -14,9 +14,7 @@ async function measureConnectionSpeed() {
   const duration = (endTime - startTime) / 1000;
   const bitsLoaded = downloadSize * 8;
   const speedBps = (bitsLoaded / duration).toFixed(2);
-  const speedKbps = (speedBps / 1024).toFixed(2);
-  const speedMbps = (speedKbps / 1024).toFixed(2);
-  return speedMbps;
+  return Math.round(Number(speedBps));
 }
 
 module.exports = measureConnectionSpeed;

--- a/ui/util/detect-user-bandwidth.js
+++ b/ui/util/detect-user-bandwidth.js
@@ -1,0 +1,38 @@
+var startTime;
+var endTime;
+
+var testConnectionSpeed = {
+  imageAddr: 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Brandenburger_Tor_abends.jpg', // this is just an example, you rather want an image hosted on your server
+  downloadSize: 2707459, // this must match with the image above
+
+  getConnectionSpeed: function(callback) {
+    testConnectionSpeed.InitiateSpeedDetection();
+    testConnectionSpeed.callback = callback;
+  },
+  InitiateSpeedDetection: function() {
+    window.setTimeout(testConnectionSpeed.MeasureConnectionSpeed, 1);
+  },
+  result: function() {
+    var duration = (endTime - startTime) / 1000;
+    var bitsLoaded = testConnectionSpeed.downloadSize * 8;
+    var speedBps = (bitsLoaded / duration).toFixed(2);
+    var speedKbps = (speedBps / 1024).toFixed(2);
+    var speedMbps = (speedKbps / 1024).toFixed(2);
+    testConnectionSpeed.callback(speedMbps);
+  },
+  MeasureConnectionSpeed: function() {
+    var download = new Image();
+    download.onload = function() {
+      endTime = (new Date()).getTime();
+      testConnectionSpeed.result();
+    };
+    startTime = (new Date()).getTime();
+    var cacheBuster = '?nnn=' + startTime;
+    download.src = testConnectionSpeed.imageAddr + cacheBuster;
+  },
+};
+
+// start test immediatly, you could also call this on any event or whenever you want
+// testConnectionSpeed.getConnectionSpeed(function(time) { console.log(time) });
+
+module.exports = testConnectionSpeed.getConnectionSpeed;

--- a/ui/util/detect-user-bandwidth.js
+++ b/ui/util/detect-user-bandwidth.js
@@ -1,5 +1,5 @@
-var startTime;
-var endTime;
+// var startTime;
+// var endTime;
 
 var testConnectionSpeed = {
   imageAddr: 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Brandenburger_Tor_abends.jpg', // this is just an example, you rather want an image hosted on your server
@@ -12,6 +12,7 @@ var testConnectionSpeed = {
   InitiateSpeedDetection: function() {
     window.setTimeout(testConnectionSpeed.MeasureConnectionSpeed, 1);
   },
+
   result: function() {
     var duration = (endTime - startTime) / 1000;
     var bitsLoaded = testConnectionSpeed.downloadSize * 8;
@@ -20,6 +21,7 @@ var testConnectionSpeed = {
     var speedMbps = (speedKbps / 1024).toFixed(2);
     testConnectionSpeed.callback(speedMbps);
   },
+
   MeasureConnectionSpeed: function() {
     var download = new Image();
     download.onload = function() {
@@ -31,6 +33,42 @@ var testConnectionSpeed = {
     download.src = testConnectionSpeed.imageAddr + cacheBuster;
   },
 };
+
+function timeout(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const imageAddr = 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Brandenburger_Tor_abends.jpg';
+const downloadSize = 2707459; // this must match with the image above
+
+let startTime, endTime;
+function measureConnectionSpeed() {
+  startTime = (new Date()).getTime();
+  var cacheBuster = '?nnn=' + startTime;
+
+  var download = new Image();
+  download.src = imageAddr + cacheBuster;
+
+  download.onload = function() {
+    endTime = (new Date()).getTime();
+    var duration = (endTime - startTime) / 1000;
+    var bitsLoaded = downloadSize * 8;
+    var speedBps = (bitsLoaded / duration).toFixed(2);
+    var speedKbps = (speedBps / 1024).toFixed(2);
+    var speedMbps = (speedKbps / 1024).toFixed(2);
+    console.log(speedMbps);
+    return new Promise(resolve => resolve(speedMbps));
+    // return speedMbps;
+  };
+
+
+}
+
+async function getDownloadSpeed() {
+  await timeout(1);
+  const downloadSpeed = await measureConnectionSpeed();
+  console.log(downloadSpeed);
+}
 
 // start test immediatly, you could also call this on any event or whenever you want
 // testConnectionSpeed.getConnectionSpeed(function(time) { console.log(time) });

--- a/ui/util/detect-user-bandwidth.js
+++ b/ui/util/detect-user-bandwidth.js
@@ -1,76 +1,22 @@
-// var startTime;
-// var endTime;
-
-var testConnectionSpeed = {
-  imageAddr: 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Brandenburger_Tor_abends.jpg', // this is just an example, you rather want an image hosted on your server
-  downloadSize: 2707459, // this must match with the image above
-
-  getConnectionSpeed: function(callback) {
-    testConnectionSpeed.InitiateSpeedDetection();
-    testConnectionSpeed.callback = callback;
-  },
-  InitiateSpeedDetection: function() {
-    window.setTimeout(testConnectionSpeed.MeasureConnectionSpeed, 1);
-  },
-
-  result: function() {
-    var duration = (endTime - startTime) / 1000;
-    var bitsLoaded = testConnectionSpeed.downloadSize * 8;
-    var speedBps = (bitsLoaded / duration).toFixed(2);
-    var speedKbps = (speedBps / 1024).toFixed(2);
-    var speedMbps = (speedKbps / 1024).toFixed(2);
-    testConnectionSpeed.callback(speedMbps);
-  },
-
-  MeasureConnectionSpeed: function() {
-    var download = new Image();
-    download.onload = function() {
-      endTime = (new Date()).getTime();
-      testConnectionSpeed.result();
-    };
-    startTime = (new Date()).getTime();
-    var cacheBuster = '?nnn=' + startTime;
-    download.src = testConnectionSpeed.imageAddr + cacheBuster;
-  },
-};
-
-function timeout(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 const imageAddr = 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Brandenburger_Tor_abends.jpg';
 const downloadSize = 2707459; // this must match with the image above
 
 let startTime, endTime;
-function measureConnectionSpeed() {
+async function measureConnectionSpeed() {
   startTime = (new Date()).getTime();
-  var cacheBuster = '?nnn=' + startTime;
+  const cacheBuster = '?nnn=' + startTime;
 
-  var download = new Image();
+  const download = new Image();
   download.src = imageAddr + cacheBuster;
-
-  download.onload = function() {
-    endTime = (new Date()).getTime();
-    var duration = (endTime - startTime) / 1000;
-    var bitsLoaded = downloadSize * 8;
-    var speedBps = (bitsLoaded / duration).toFixed(2);
-    var speedKbps = (speedBps / 1024).toFixed(2);
-    var speedMbps = (speedKbps / 1024).toFixed(2);
-    console.log(speedMbps);
-    return new Promise(resolve => resolve(speedMbps));
-    // return speedMbps;
-  };
-
-
+  // this returns when the image is finished downloading
+  await download.decode();
+  endTime = (new Date()).getTime();
+  const duration = (endTime - startTime) / 1000;
+  const bitsLoaded = downloadSize * 8;
+  const speedBps = (bitsLoaded / duration).toFixed(2);
+  const speedKbps = (speedBps / 1024).toFixed(2);
+  const speedMbps = (speedKbps / 1024).toFixed(2);
+  return speedMbps;
 }
 
-async function getDownloadSpeed() {
-  await timeout(1);
-  const downloadSpeed = await measureConnectionSpeed();
-  console.log(downloadSpeed);
-}
-
-// start test immediatly, you could also call this on any event or whenever you want
-// testConnectionSpeed.getConnectionSpeed(function(time) { console.log(time) });
-
-module.exports = testConnectionSpeed.getConnectionSpeed;
+module.exports = measureConnectionSpeed;


### PR DESCRIPTION
Fixes issue #6891 , 

Calculates user bandwidth on analytics load, and recalculates every 30s, send both values in bits per second