### PR TITLE
Blocklist page: fix perpetual spinner when trying to refresh with no channels

### DIFF
--- a/ui/page/listBlocked/view.jsx
+++ b/ui/page/listBlocked/view.jsx
@@ -221,15 +221,17 @@ function ListBlocked(props: Props) {
 
   function getRefreshElem() {
     return (
-      <Button
-        icon={ICONS.REFRESH}
-        button="alt"
-        label={__('Refresh')}
-        onClick={() => {
-          fetchModBlockedList();
-          fetchModAmIList();
-        }}
-      />
+      myChannelClaims && (
+        <Button
+          icon={ICONS.REFRESH}
+          button="alt"
+          label={__('Refresh')}
+          onClick={() => {
+            fetchModBlockedList();
+            fetchModAmIList();
+          }}
+        />
+      )
     );
   }
 

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -1055,6 +1055,10 @@ export function doFetchModBlockedList() {
   return async (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
     const myChannels = selectMyChannelClaims(state);
+    if (!myChannels) {
+      dispatch({ type: ACTIONS.COMMENT_MODERATION_BLOCK_LIST_FAILED });
+      return;
+    }
 
     dispatch({
       type: ACTIONS.COMMENT_MODERATION_BLOCK_LIST_STARTED,
@@ -1377,6 +1381,10 @@ export function doFetchCommentModAmIList(channelClaim: ChannelClaim) {
   return async (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
     const myChannels = selectMyChannelClaims(state);
+    if (!myChannels) {
+      dispatch({ type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_FAILED });
+      return;
+    }
 
     dispatch({ type: ACTIONS.COMMENT_MODERATION_AM_I_LIST_STARTED });
 


### PR DESCRIPTION
There's nothing to do when you don't have a channel, so hide the button and ensure redux fails gracefully.