### PR TITLE
Fix “Your Account” popup on mobile (#5652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix floating player stopping on markdown or image files ([#7073](https://github.com/lbryio/lbry-desktop/pull/7073))
 - Fix list thumbnail upload ([#7074](https://github.com/lbryio/lbry-desktop/pull/7074))
 - Stream Key is now hidden _community pr!_ ([#7127](https://github.com/lbryio/lbry-desktop/pull/7127))
+- Fixed “Your Account” popup on mobile ([#7172](https://github.com/lbryio/lbry-desktop/pull/7172))
 
 ## [0.51.2] - [2021-08-20]
 

--- a/ui/scss/component/menu-button.scss
+++ b/ui/scss/component/menu-button.scss
@@ -9,6 +9,7 @@
   position: absolute;
   z-index: 2;
   font-size: var(--font-body);
+  max-width: calc(100% - var(--height-button) - var(--spacing-xs));
 }
 
 [data-reach-menu-list] {
@@ -73,8 +74,6 @@
 .menu__list {
   box-shadow: var(--card-box-shadow);
   animation: menu-animate-in var(--animation-duration) var(--animation-style);
-  border-bottom-left-radius: var(--border-radius);
-  border-bottom-right-radius: var(--border-radius);
 
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
@@ -113,9 +112,13 @@
 
 .menu__link-help {
   @extend .menu__link;
+  display: block;
   color: var(--color-text-help);
   font-size: var(--font-small);
   padding-top: 0;
+  white-space: normal;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
 }
 
 .menu__link--notification {


### PR DESCRIPTION
## Fixes

Issue Number: #5652 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
When the user’s email exceeds a certain width (depending on the viewport) the menu gets stuck in an animated behavior sliding from right to left or simply gets rendered outside the viewport.

## What is the new behavior?
The menu now has a maximum width. If the email still needs more horizontal space, it will be rendered with an ellipsis at the end. For example “thisisalongemail@gm...”. Even if the email gets truncated it should still contain enough information that the user can be confident in knowing which account they are currently signed into.

## Other information
The problem lies within the [Reach UI](https://reach.tech/menu-button) collision detection mechanism which cannot resolve these types of rendering challenges well. [This issue](https://github.com/reach/reach-ui/issues/631) seems to be the one we are dealing with here.

It is not clear but this might have been addressed in the newer versions of Reach UI. In any case, bumping the version of the reach UI lib requires extensive refactoring throughout the application because of the breaking changes. This issue alone does not seem to justify that step.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
