### PR TITLE
fix playlist resolving collectionurls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix floating player stopping on markdown or image files ([#7073](https://github.com/lbryio/lbry-desktop/pull/7073))
 - Fix list thumbnail upload ([#7074](https://github.com/lbryio/lbry-desktop/pull/7074))
 - Stream Key is now hidden _community pr!_ ([#7127](https://github.com/lbryio/lbry-desktop/pull/7127))
+- Fix playlist preview thumbnail ([#7174](https://github.com/lbryio/lbry-desktop/pull/7174)
 
 ## [0.51.2] - [2021-08-20]
 

--- a/ui/component/collectionPreviewOverlay/index.js
+++ b/ui/component/collectionPreviewOverlay/index.js
@@ -7,6 +7,7 @@ import {
   makeSelectNameForCollectionId,
   makeSelectPendingCollectionForId,
   makeSelectCountForCollectionId,
+  doFetchItemsInCollection,
 } from 'lbry-redux';
 import CollectionPreviewOverlay from './view';
 
@@ -27,4 +28,8 @@ const select = (state, props) => {
   };
 };
 
-export default connect(select)(CollectionPreviewOverlay);
+const perform = (dispatch) => ({
+  fetchCollectionItems: (claimId) => dispatch(doFetchItemsInCollection({ collectionId: claimId })), // if collection not resolved, resolve it
+});
+
+export default connect(select, perform)(CollectionPreviewOverlay);

--- a/ui/component/collectionPreviewOverlay/view.jsx
+++ b/ui/component/collectionPreviewOverlay/view.jsx
@@ -12,10 +12,17 @@ type Props = {
   pendingCollection?: Collection,
   claim: ?Claim,
   collectionItemUrls: Array<string>,
+  fetchCollectionItems: (string) => void,
 };
 
 function CollectionPreviewOverlay(props: Props) {
-  const { collectionItemUrls } = props;
+  const { collectionId, collectionItemUrls, fetchCollectionItems } = props;
+
+  React.useEffect(() => {
+    if (!collectionItemUrls) {
+      fetchCollectionItems(collectionId);
+    }
+  }, [collectionId, collectionItemUrls, fetchCollectionItems]);
 
   if (collectionItemUrls && collectionItemUrls.length > 0) {
     return (


### PR DESCRIPTION
## Fixes

Issue Number: fixes #7122
 
<!-- Tip:
  - Add keywords to directly close the Issue when the PR is merged.
  - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request    -to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
  -->
 
## What is the current behavior?
Currently previews do not show up when hovering over a playlist thumbnail untill you open     it up and then go back.
 
## What is the new behavior?
Now previews do show up without having to open the playlist.
 
## Other information
 
 <!-- If this PR contains a breaking change, please describe the impact and solution strate    gy for existing applications below. -->

## PR Checklist
 
<!-- For the checkbox formatting to work properly, make sure there are no spaces on either     side of the "x" -->
 
<details><summary>Toggle...</summary>
 
What kind of change does this PR introduce?
 
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:
 
Please check all that apply to this PR using "x":
  
 - [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or me    rged)
 - [X] I added a line describing my change to CHANGELOG.md
 - [X] I have checked that this PR does not introduce a breaking change
 - [ ] This PR introduces breaking changes and I have provided a detailed explanation below
 
</details>
