### PR TITLE
Fix missed render and flashing (regression) when blocklist is fetched

### DIFF
--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -73,7 +73,7 @@ function resolveSearchOptions(props) {
 
   const mutedAndBlockedChannelIds = Array.from(
     new Set((mutedUris || []).concat(blockedUris || []).map((uri) => splitBySeparator(uri)[1]))
-  );
+  ).sort();
 
   const urlParams = new URLSearchParams(location.search);
   const feeAmountInUrl = urlParams.get('fee_amount');


### PR DESCRIPTION
## Issue
Closes #7176

## Changes
Pitfalls of pausing render via React.memo:
  - We'll miss the `doClaimSearch()` since that is sparked by an `useEffect`.
Seems like we can't avoid having a redundant copy of the previously-displayed URIs.

The blocklist order was also causing the extra blinking render.