### PR TITLE
Memoize 'mutedAndBlockedChannelIds'

### DIFF
--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -6,14 +6,12 @@ import {
   selectFetchingClaimSearchByQuery,
   SETTINGS,
   selectClaimsByUri,
-  splitBySeparator,
   MATURE_TAGS,
 } from 'lbry-redux';
 import { doFetchViewCount } from 'lbryinc';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
 import { makeSelectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
-import { selectModerationBlockList } from 'redux/selectors/comments';
-import { selectMutedChannels } from 'redux/selectors/blocked';
+import { selectMutedAndBlockedChannelIds } from 'redux/selectors/blocked';
 import { ENABLE_NO_SOURCE_CLAIMS, SIMPLE_SITE } from 'config';
 import * as CS from 'constants/claim_search';
 
@@ -22,8 +20,7 @@ import ClaimListDiscover from './view';
 const select = (state, props) => {
   const showNsfw = selectShowMatureContent(state);
   const hideReposts = makeSelectClientSetting(SETTINGS.HIDE_REPOSTS)(state);
-  const mutedUris = selectMutedChannels(state);
-  const blockedUris = selectModerationBlockList(state);
+  const mutedAndBlockedChannelIds = selectMutedAndBlockedChannelIds(state);
 
   return {
     claimSearchByQuery: selectClaimSearchByQuery(state),
@@ -31,9 +28,7 @@ const select = (state, props) => {
     fetchingClaimSearchByQuery: selectFetchingClaimSearchByQuery(state),
     showNsfw,
     hideReposts,
-    mutedUris,
-    blockedUris,
-    options: resolveSearchOptions({ showNsfw, hideReposts, mutedUris, blockedUris, pageSize: 8, ...props }),
+    options: resolveSearchOptions({ showNsfw, hideReposts, mutedAndBlockedChannelIds, pageSize: 8, ...props }),
   };
 };
 
@@ -52,8 +47,7 @@ function resolveSearchOptions(props) {
   const {
     showNsfw,
     hideReposts,
-    mutedUris,
-    blockedUris,
+    mutedAndBlockedChannelIds,
     location,
     pageSize,
     claimType,
@@ -70,10 +64,6 @@ function resolveSearchOptions(props) {
     timestamp,
     claimIds,
   } = props;
-
-  const mutedAndBlockedChannelIds = Array.from(
-    new Set((mutedUris || []).concat(blockedUris || []).map((uri) => splitBySeparator(uri)[1]))
-  ).sort();
 
   const urlParams = new URLSearchParams(location.search);
   const feeAmountInUrl = urlParams.get('fee_amount');

--- a/ui/component/claimTilesDiscover/view.jsx
+++ b/ui/component/claimTilesDiscover/view.jsx
@@ -72,8 +72,6 @@ type Props = {
   fetchingClaimSearchByQuery: { [string]: boolean },
   showNsfw: boolean,
   hideReposts: boolean,
-  mutedUris: Array<string>,
-  blockedUris: Array<string>,
   options: SearchOptions,
   // --- perform ---
   doClaimSearch: ({}) => void,
@@ -190,7 +188,7 @@ function areEqual(prev: Props, next: Props) {
     return false;
   }
 
-  const ARRAY_KEYS = ['prefixUris', 'channelIds', 'mutedUris', 'blockedUris'];
+  const ARRAY_KEYS = ['prefixUris', 'channelIds'];
   for (let i = 0; i < ARRAY_KEYS.length; ++i) {
     const key = ARRAY_KEYS[i];
     if (!urisEqual(prev[key], next[key])) {

--- a/ui/redux/selectors/blocked.js
+++ b/ui/redux/selectors/blocked.js
@@ -1,5 +1,6 @@
 // @flow
 import { createSelector } from 'reselect';
+import { splitBySeparator } from 'lbry-redux';
 
 const selectState = (state: { blocked: BlocklistState }) => state.blocked || {};
 
@@ -11,3 +12,15 @@ export const makeSelectChannelIsMuted = (uri: string) =>
   createSelector(selectMutedChannels, (state: Array<string>) => {
     return state.includes(uri);
   });
+
+export const selectMutedAndBlockedChannelIds = createSelector(
+  selectState,
+  (state) => state.comments,
+  (state, commentsState) => {
+    const mutedUris = state.blockedChannels;
+    const blockedUris = commentsState.moderationBlockList;
+    return Array.from(
+      new Set((mutedUris || []).concat(blockedUris || []).map((uri) => splitBySeparator(uri)[1]))
+    ).sort();
+  }
+);


### PR DESCRIPTION
@jessopb, can you help review this, particular the usage of `selectCommentsState` (whether it is anti-pattern or not). If it is good, I'll apply the same method to other beefy selectors.

## Issue
Muted and blocked channel IDs are constantly being re-calculate on every update cycle. This PR tries to memoize it through `createSelector`

## Notes
The input selectors to `createSelectors` must be plain, i.e. no transformations, otherwise it breaks memoization 
<sub>(aside: I believe most of our `makeSelect**` selectors break this rule, which explains why we've been getting new references in each cycle, causing extra renders).</sub>

That was why I used `selectCommentsState` instead of importing `selectModerationBlockList` from the other file. Even if I created a new `selectModerationBlockListRaw` (which doesn't transform) and then import that, it didn't work (memoization didn't happen). It could just be a coder error, though.

## How I tested it
- I added logs for the selector call. Most of the time, the selector doesn't re-calculate and just returns past value.  However, it does re-calculate occasionally, and I believe it is due to the preference sync invalidating the entire store.
    - ![Screenshot from 2021-09-29 17-03-04](https://user-images.githubusercontent.com/64950861/135238087-e5e41ee6-704e-42b2-a1bd-71c3b05580bf.png)
    - ![Screenshot from 2021-09-29 17-03-17](https://user-images.githubusercontent.com/64950861/135238096-c47e969f-8213-4d22-b2c7-60722917b257.png)
- Result: it doesn't re-calculate on each update if there's no change.  The one instance shown is an exception -- from a tab-focus preference sync.
    - ![Screenshot from 2021-09-29 17-04-08](https://user-images.githubusercontent.com/64950861/135238105-c10d1aea-1e08-4616-9464-de2036885099.png)


