### PR TITLE
Commentron now includes `replies` for `ByID` request

### DIFF
--- a/ui/redux/reducers/comments.js
+++ b/ui/redux/reducers/comments.js
@@ -349,9 +349,7 @@ export default handleActions(
       const linkedCommentAncestors = Object.assign({}, state.linkedCommentAncestors);
 
       const updateStore = (comment, commentById, byId, repliesByParentId, topLevelCommentsById) => {
-        // 'comment.ByID' doesn't populate 'replies'. We should have at least 1
-        // at the moment, and the correct value will populated by 'comment.List'.
-        commentById[comment.comment_id] = { ...comment, replies: 1 };
+        commentById[comment.comment_id] = comment;
         byId[claimId] ? byId[claimId].unshift(comment.comment_id) : (byId[claimId] = [comment.comment_id]);
 
         const parentId = comment.parent_id;


### PR DESCRIPTION
Closes #7146

Wasn't aware of that, and that was causing 7146 ("show replies" visible when there are no replies).