### PR TITLE
Fix wrong 'recsysId' sent due to search-key mismatch

### DIFF
--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -1,6 +1,5 @@
 // @flow
 import * as ACTIONS from 'constants/action_types';
-import { SEARCH_OPTIONS } from 'constants/search';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import {
   buildURI,
@@ -13,7 +12,8 @@ import {
 import { makeSelectSearchUrisForQuery, selectSearchValue } from 'redux/selectors/search';
 import handleFetchResponse from 'util/handle-fetch';
 import { getSearchQueryString } from 'util/query-params';
-import { SIMPLE_SITE, SEARCH_SERVER_API } from 'config';
+import { getRecommendationSearchOptions } from 'util/search';
+import { SEARCH_SERVER_API } from 'config';
 
 type Dispatch = (action: any) => any;
 type GetState = () => { search: SearchState };
@@ -140,17 +140,7 @@ export const doFetchRecommendedContent = (uri: string) => (dispatch: Dispatch, g
   const claimIsMature = makeSelectClaimIsNsfw(uri)(state);
 
   if (claim && claim.value && claim.claim_id) {
-    const options: SearchOptions = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
-
-    if (SIMPLE_SITE) {
-      options[SEARCH_OPTIONS.CLAIM_TYPE] = SEARCH_OPTIONS.INCLUDE_FILES;
-      options[SEARCH_OPTIONS.MEDIA_VIDEO] = true;
-      options[SEARCH_OPTIONS.PRICE_FILTER_FREE] = true;
-    }
-    if (matureEnabled || !claimIsMature) {
-      options[SEARCH_OPTIONS.RELATED_TO] = claim.claim_id;
-    }
-
+    const options: SearchOptions = getRecommendationSearchOptions(matureEnabled, claimIsMature, claim.claim_id);
     const { title } = claim.value;
 
     if (title && options) {

--- a/ui/util/search.js
+++ b/ui/util/search.js
@@ -1,7 +1,8 @@
 // @flow
 
 import { isNameValid, isURIValid, normalizeURI, parseURI } from 'lbry-redux';
-import { URL as SITE_URL, URL_LOCAL, URL_DEV } from 'config';
+import { URL as SITE_URL, URL_LOCAL, URL_DEV, SIMPLE_SITE } from 'config';
+import { SEARCH_OPTIONS } from 'constants/search';
 
 export function createNormalizedSearchKey(query: string) {
   const FROM = '&from=';
@@ -86,4 +87,20 @@ export function getUriForSearchTerm(term: string) {
       return [term, 'error'];
     }
   }
+}
+
+export function getRecommendationSearchOptions(matureEnabled: boolean, claimIsMature: boolean, claimId: string) {
+  const options = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
+
+  if (SIMPLE_SITE) {
+    options[SEARCH_OPTIONS.CLAIM_TYPE] = SEARCH_OPTIONS.INCLUDE_FILES;
+    options[SEARCH_OPTIONS.MEDIA_VIDEO] = true;
+    options[SEARCH_OPTIONS.PRICE_FILTER_FREE] = true;
+  }
+
+  if (matureEnabled || !claimIsMature) {
+    options[SEARCH_OPTIONS.RELATED_TO] = claimId;
+  }
+
+  return options;
 }


### PR DESCRIPTION
## Issue
.../archives/C02FQBM00Q0/p1633044695010600

## Changes
When querying a search key, it has to be an exact match. This was broken by the insertion of `free_only` in the fetch in #7089.

Added a function to generate the options, so that all clients stay in sync.