### PR TITLE
Prevent random description in Google Search results for "odysee"

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -78,6 +78,7 @@ function buildOgMetadata(overrideOptions = {}) {
   const cleanDescription = removeMd(description || SITE_DESCRIPTION);
   const head =
     `<title>${SITE_TITLE}</title>\n` +
+    `<meta property="description" content="${cleanDescription}" />\n` +
     `<meta property="og:url" content="${URL}" />\n` +
     `<meta property="og:title" content="${title || OG_HOMEPAGE_TITLE || SITE_TITLE}" />\n` +
     `<meta property="og:site_name" content="${SITE_NAME || SITE_TITLE}"/>\n` +


### PR DESCRIPTION
## Issue
Part of [#7166 improve search metadata](https://github.com/lbryio/lbry-desktop/issues/7166)

Depending on the search term and timing, Google extracts data from the sidebar or page content to use as the search-result description.

## Change
Defined `description` (on top of the existing `og:description` and `twitter:description`).

While I couldn't find a definitive doc saying that this is the solution, this is present in all other sites (and matches their description in a Google Search results).

## Comments
Until Julian replies, and assuming this works, the description will appear as:
```
Launch your own channel | Watch and share videos
```
This is defined in the `.env`, and we might also need to update the one in the server if the old string exists in the override file.  No access to that.

## Aside (update on SiteLinks)
It appears we can't alter the SiteLinks that appear under the results. although we might be able to influence it through the sitemap.  Still looking into it.

I think other site's SiteLink are bad too, e.g. searching "dailymotion" shows useful SiteLinks, but searching "dailymotion.com" shows a bunch of (popular?) junk.