### PR TITLE
Prevent embedded videos in comments from breaking the layout on mobile

### DIFF
--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -200,6 +200,9 @@ $thumbnailWidthSmall: 1rem;
 }
 
 .comment__body-container {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
   flex: 1;
   margin-left: var(--spacing-xs);
 


### PR DESCRIPTION
## What is the current behavior?
If the comment contains embedded videos the page becomes wider than the viewport on mobile. This causes the page to scroll horizontally.

## What is the new behavior?
Comments are now contained properly.

## PR Checklist

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below
