### PR TITLE
Fix Mis-typed claimLink

### DIFF
--- a/ui/component/claimLink/index.js
+++ b/ui/component/claimLink/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { doResolveUri, makeSelectClaimForUri, makeSelectIsUriResolving } from 'lbry-redux';
 import { doSetPlayingUri } from 'redux/actions/content';
+import { punctuationMarks } from 'util/remark-lbry';
 import { selectBlackListedOutpoints } from 'lbryinc';
 import { selectPlayingUri } from 'redux/selectors/content';
 import ClaimLink from './view';
@@ -11,7 +12,7 @@ const select = (state, props) => {
 
   function getValidClaim(testUri) {
     claim = makeSelectClaimForUri(testUri)(state);
-    if (claim === null) {
+    if (claim === null && punctuationMarks.includes(testUri.charAt(testUri.length - 1))) {
       getValidClaim(testUri.substring(0, testUri.length - 1));
     } else {
       uri = testUri;

--- a/ui/util/remark-lbry.js
+++ b/ui/util/remark-lbry.js
@@ -3,7 +3,7 @@ import visit from 'unist-util-visit';
 
 const protocol = 'lbry://';
 const uriRegex = /(lbry:\/\/)[^\s"]*[^)]/g;
-const punctuationMarks = [',', '.', '!', '?', ':', ';', '-', ']', ')', '}'];
+export const punctuationMarks = [',', '.', '!', '?', ':', ';', '-', ']', ')', '}'];
 
 const mentionToken = '@';
 // const mentionTokenCode = 64; // @


### PR DESCRIPTION
## Fixes

Issue Number: Closes #7208

here https://madiator.com/@Super-Grand-Ad:f?view=about can be seen the user had a mis-typed mention on the 'Description', and getValidClaim was intended to only keep going in case of a failed claim that has a punctuation mark at the end, and not for non existent claims

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
