### PR TITLE
Fix 'pinnedUrl' error.

### DIFF
--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -75,7 +75,8 @@ function SideNavigation(props: Props) {
     followedTags,
   } = props;
 
-  const EXTRA_SIDEBAR_LINKS = GetLinksData(homepageData);
+  const EXTRA_SIDEBAR_LINKS = GetLinksData(homepageData).map(({ pinnedUrls, ...theRest }) => theRest);
+
   const FULL_LINKS: Array<SideNavLink> = [
     {
       title: 'Your Tags',


### PR DESCRIPTION
Part of #6989 `Fix console spam in dev`

`EXTRA_SIDEBAR_LINKS` should be a `SideNavLink` object, so trim down the return object from `GetLinksData`.