### PR TITLE
OG: fix url for categories

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -74,12 +74,12 @@ function getCategoryMeta(path) {
 // Normal metadata with option to override certain values
 //
 function buildOgMetadata(overrideOptions = {}) {
-  const { title, description, image } = overrideOptions;
+  const { title, description, image, path } = overrideOptions;
   const cleanDescription = removeMd(description || SITE_DESCRIPTION);
   const head =
     `<title>${SITE_TITLE}</title>\n` +
     `<meta name="description" content="${cleanDescription}" />\n` +
-    `<meta property="og:url" content="${URL}" />\n` +
+    `<meta property="og:url" content="${path ? `${URL}${path}` : URL}" />\n` +
     `<meta property="og:title" content="${title || OG_HOMEPAGE_TITLE || SITE_TITLE}" />\n` +
     `<meta property="og:site_name" content="${SITE_NAME || SITE_TITLE}"/>\n` +
     `<meta property="og:description" content="${cleanDescription}" />\n` +
@@ -91,7 +91,6 @@ function buildOgMetadata(overrideOptions = {}) {
     }" />\n` +
     `<meta name="twitter:description" content="${cleanDescription}" />\n` +
     `<meta name="twitter:image" content="${image || OG_IMAGE_URL || `${URL}/public/v2-og.png`}"/>\n` +
-    `<meta name="twitter:url" content="${URL}" />\n` +
     '<meta property="fb:app_id" content="1673146449633983" />\n' +
     `<link rel="canonical" content="${SITE_CANONICAL_URL || URL}"/>` +
     `<link rel="search" type="application/opensearchdescription+xml" title="${
@@ -348,6 +347,7 @@ async function getHtml(ctx) {
       title: categoryMeta.title,
       description: categoryMeta.description,
       image: categoryMeta.image,
+      path: requestPath,
     });
     return insertToHead(html, categoryPageMetadata);
   }


### PR DESCRIPTION
## Issue
Category cards are showing up as "odysee.com" cards in Facebook.

## Change
- `og:url` is supposed to be the canonical URL. It was hardcoded to "odysee.com", so every category was being redirected when the card is being generated.
    - ![image](https://user-images.githubusercontent.com/64950861/135784811-539b5080-8d2a-4eec-836f-bef998f242d0.png)
- Removed `twitter:url`. The documentation says it will fall back to `og:url`, so there is not need to define both if it's the same.