### PR TITLE
Comments: fix memoization of selectors

### DIFF
--- a/ui/component/comment/index.js
+++ b/ui/component/comment/index.js
@@ -19,24 +19,30 @@ import { selectActiveChannelClaim } from 'redux/selectors/app';
 import { selectPlayingUri } from 'redux/selectors/content';
 import Comment from './view';
 
-const select = (state, props) => {
-  const activeChannelClaim = selectActiveChannelClaim(state);
+const makeMapStateToProps = (originalState, originalProps) => {
+  const activeChannelClaim = selectActiveChannelClaim(originalState);
   const activeChannelId = activeChannelClaim && activeChannelClaim.claim_id;
-  const reactionKey = activeChannelId ? `${props.commentId}:${activeChannelId}` : props.commentId;
+  const reactionKey = activeChannelId ? `${originalProps.commentId}:${activeChannelId}` : originalProps.commentId;
+  const selectOthersReactionsForComment = makeSelectOthersReactionsForComment(reactionKey);
 
-  return {
-    claim: makeSelectClaimForUri(props.uri)(state),
-    thumbnail: props.authorUri && makeSelectThumbnailForUri(props.authorUri)(state),
-    channelIsBlocked: props.authorUri && makeSelectChannelIsMuted(props.authorUri)(state),
-    commentingEnabled: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
-    othersReacts: makeSelectOthersReactionsForComment(reactionKey)(state),
-    activeChannelClaim,
-    myChannels: selectMyChannelClaims(state),
-    playingUri: selectPlayingUri(state),
-    stakedLevel: makeSelectStakedLevelForChannelUri(props.authorUri)(state),
-    linkedCommentAncestors: selectLinkedCommentAncestors(state),
-    totalReplyPages: makeSelectTotalReplyPagesForParentId(props.commentId)(state),
+  const select = (state, props) => {
+    const othersReacts = selectOthersReactionsForComment(state);
+
+    return {
+      claim: makeSelectClaimForUri(props.uri)(state),
+      thumbnail: props.authorUri && makeSelectThumbnailForUri(props.authorUri)(state),
+      channelIsBlocked: props.authorUri && makeSelectChannelIsMuted(props.authorUri)(state),
+      commentingEnabled: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
+      othersReacts,
+      activeChannelClaim,
+      myChannels: selectMyChannelClaims(state),
+      playingUri: selectPlayingUri(state),
+      stakedLevel: makeSelectStakedLevelForChannelUri(props.authorUri)(state),
+      linkedCommentAncestors: selectLinkedCommentAncestors(state),
+      totalReplyPages: makeSelectTotalReplyPagesForParentId(props.commentId)(state),
+    };
   };
+  return select;
 };
 
 const perform = (dispatch) => ({
@@ -47,4 +53,4 @@ const perform = (dispatch) => ({
   doToast: (options) => dispatch(doToast(options)),
 });
 
-export default connect(select, perform)(Comment);
+export default connect(makeMapStateToProps, perform)(Comment);

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -361,7 +361,9 @@ function Comment(props: Props) {
                         icon={ICONS.REPLY}
                       />
                     )}
-                    {ENABLE_COMMENT_REACTIONS && <CommentReactions uri={uri} commentId={commentId} />}
+                    {ENABLE_COMMENT_REACTIONS && (
+                      <CommentReactions uri={uri} commentId={commentId} othersReacts={othersReacts} />
+                    )}
                   </div>
                 )}
 

--- a/ui/component/commentReactions/index.js
+++ b/ui/component/commentReactions/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import Comment from './view';
+import CommentReactions from './view';
 import { makeSelectClaimIsMine, makeSelectClaimForUri, doResolveUri } from 'lbry-redux';
 import { doToast } from 'redux/actions/notifications';
 import { makeSelectMyReactionsForComment, makeSelectOthersReactionsForComment } from 'redux/selectors/comments';
@@ -15,7 +15,7 @@ const select = (state, props) => {
     claim: makeSelectClaimForUri(props.uri)(state),
     claimIsMine: makeSelectClaimIsMine(props.uri)(state),
     myReacts: makeSelectMyReactionsForComment(reactionKey)(state),
-    othersReacts: makeSelectOthersReactionsForComment(reactionKey)(state),
+    othersReacts: props.othersReacts || makeSelectOthersReactionsForComment(reactionKey)(state),
     activeChannelId,
   };
 };
@@ -26,4 +26,4 @@ const perform = (dispatch) => ({
   doToast: (params) => dispatch(doToast(params)),
 });
 
-export default connect(select, perform)(Comment);
+export default connect(select, perform)(CommentReactions);

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -5,6 +5,8 @@ import { selectShowMatureContent } from 'redux/selectors/settings';
 import { selectBlacklistedOutpointMap, selectFilteredOutpointMap } from 'lbryinc';
 import { selectClaimsById, isClaimNsfw, selectMyActiveClaims } from 'lbry-redux';
 
+type State = { comments: CommentsState };
+
 const selectState = (state) => state.comments || {};
 
 export const selectCommentsById = createSelector(selectState, (state) => state.commentById || {});
@@ -13,7 +15,7 @@ export const selectIsFetchingCommentsById = createSelector(selectState, (state) 
 export const selectIsFetchingCommentsByParentId = createSelector(selectState, (state) => state.isLoadingByParentId);
 export const selectIsPostingComment = createSelector(selectState, (state) => state.isCommenting);
 export const selectIsFetchingReacts = createSelector(selectState, (state) => state.isFetchingReacts);
-export const selectOthersReactsById = createSelector(selectState, (state) => state.othersReactsByCommentId);
+export const selectOthersReactsById = (state: State) => state.comments.othersReactsByCommentId;
 
 export const selectPinnedCommentsById = createSelector(selectState, (state) => state.pinnedCommentsById);
 export const makeSelectPinnedCommentsForUri = (uri: string) =>
@@ -191,12 +193,12 @@ export const makeSelectMyReactionsForComment = (commentIdChannelId: string) =>
   });
 
 export const makeSelectOthersReactionsForComment = (commentId: string) =>
-  createSelector(selectState, (state) => {
-    if (!state.othersReactsByCommentId) {
+  createSelector(selectOthersReactsById, (othersReactsByCommentId) => {
+    if (!othersReactsByCommentId) {
       return {};
     }
 
-    return state.othersReactsByCommentId[commentId] || {};
+    return othersReactsByCommentId[commentId] || {};
   });
 
 export const selectPendingCommentReacts = createSelector(selectState, (state) => state.pendingCommentReactions);


### PR DESCRIPTION
Jessop, this serves as a one-time review for all upcoming PRs that are similar, so I don't need to bug you every time.

Pretty much what we've discussed in Slack:  general idea is to ensure we don't re-calculate heavy items and return new references:
1. Ensure selectors uses stashed value from `createSelector`.
2. For selectors where the input differs between instances (e.g. `props.uri` passed in), use the suggested factory method to create a unique selector per instance.
3. At the React side, we can remove any deep-compare work done in `React.memo` or `shouldComponentUpdate` to skip renders, since the default shallow compare would suffice.

----

_See commit messages, especially the last one, regarding a quick solution to avoid repetition in `CommentReactions`._ 

For this specific example, the `Comment` component renders 4-5 times because it thinks the `othersReacts` object is different, when it actually only updated once. This is just 1 comment alone.

<img src="https://user-images.githubusercontent.com/64950861/135984637-7fc620d5-24da-4d77-9836-d6f2d571a6c1.png" width="500">

After the changes, the number of renders is cut down to 2 -- one for initial render (can't avoid), and the next one when reactions are fetched:

<img src="https://user-images.githubusercontent.com/64950861/135984802-22260ae2-8bf4-42d5-8902-40e1ec17fdaa.png" width="500">

