### PR TITLE
Skip muted list update if no change

### DIFF
--- a/ui/redux/reducers/blocked.js
+++ b/ui/redux/reducers/blocked.js
@@ -30,6 +30,14 @@ export default handleActions(
     ) => {
       const { blocked } = action.data;
       const sanitizedBlocked = blocked && blocked.filter((e) => typeof e === 'string');
+
+      const next = sanitizedBlocked;
+      const prev = state.blockedChannels;
+
+      if (next && prev && prev.length === next.length && prev.every((value, index) => value === next[index])) {
+        return state;
+      }
+
       return {
         ...state,
         blockedChannels: sanitizedBlocked && sanitizedBlocked.length ? sanitizedBlocked : state.blockedChannels,


### PR DESCRIPTION
`selectMutedChannels` run and return a new reference each time the app gains focus, causing components like `ClaimPreview` and several others to render unnecessarily.

`createSelector` will not help in this case, because we are indeed invalidating the data in the store.

Not sure if it's a valid pattern to return existing state, but it helps in not invalidating cache.

<img src="https://user-images.githubusercontent.com/64950861/136040723-65b51335-a3a3-4c71-84c9-bcdcc78199c9.png" width="500">
