### PR TITLE
[Comments] Batch resolve

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -27,6 +27,7 @@ type Props = {
   noOptimization?: boolean,
   setThumbUploadError: (boolean) => void,
   ThumbUploadError: boolean,
+  alreadyResolved: boolean,
 };
 
 function ChannelThumbnail(props: Props) {
@@ -47,9 +48,10 @@ function ChannelThumbnail(props: Props) {
     hideStakedIndicator = false,
     setThumbUploadError,
     ThumbUploadError,
+    alreadyResolved,
   } = props;
   const [thumbLoadError, setThumbLoadError] = React.useState(ThumbUploadError);
-  const shouldResolve = claim === undefined;
+  const shouldResolve = !alreadyResolved && claim === undefined;
   const thumbnail = rawThumbnail && rawThumbnail.trim().replace(/^http:\/\//i, 'https://');
   const thumbnailPreview = rawThumbnailPreview && rawThumbnailPreview.trim().replace(/^http:\/\//i, 'https://');
   const defaultAvatar = AVATAR_DEFAULT || Gerbil;

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -70,6 +70,7 @@ type Props = {
   supportDisabled: boolean,
   setQuickReply: (any) => void,
   quickReply: any,
+  alreadyResolved: boolean,
 };
 
 const LENGTH_TO_COLLAPSE = 300;
@@ -109,6 +110,7 @@ function Comment(props: Props) {
     supportDisabled,
     setQuickReply,
     quickReply,
+    alreadyResolved,
   } = props;
 
   const {
@@ -229,9 +231,15 @@ function Comment(props: Props) {
       >
         <div className="comment__thumbnail-wrapper">
           {authorUri ? (
-            <ChannelThumbnail uri={authorUri} obscure={channelIsBlocked} xsmall className="comment__author-thumbnail" />
+            <ChannelThumbnail
+              uri={authorUri}
+              obscure={channelIsBlocked}
+              xsmall
+              className="comment__author-thumbnail"
+              alreadyResolved={alreadyResolved}
+            />
           ) : (
-            <ChannelThumbnail xsmall className="comment__author-thumbnail" />
+            <ChannelThumbnail xsmall className="comment__author-thumbnail" alreadyResolved={alreadyResolved} />
           )}
         </div>
 
@@ -263,6 +271,7 @@ function Comment(props: Props) {
                   })}
                   link
                   uri={authorUri}
+                  alreadyResolved={alreadyResolved}
                 />
               )}
               <Button

--- a/ui/component/commentsList/index.js
+++ b/ui/component/commentsList/index.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import {
+  doResolveUris,
   makeSelectClaimForUri,
   makeSelectClaimIsMine,
   selectFetchingMyChannels,
@@ -24,11 +25,21 @@ import CommentsList from './view';
 
 const select = (state, props) => {
   const activeChannelClaim = selectActiveChannelClaim(state);
+  const pinnedComments = makeSelectPinnedCommentsForUri(props.uri)(state);
+  const topLevelComments = makeSelectTopLevelCommentsForUri(props.uri)(state);
+  const allComments = [...pinnedComments, ...topLevelComments];
+  const unresolvedCommentChannels =
+    allComments.length &&
+    allComments
+      .map(({ channel_url }) => makeSelectClaimForUri(channel_url)(state) === undefined && channel_url)
+      .filter((url) => url !== false);
+
   return {
+    pinnedComments,
+    topLevelComments,
+    unresolvedCommentChannels,
     myChannels: selectMyChannelClaims(state),
     allCommentIds: makeSelectCommentIdsForUri(props.uri)(state),
-    pinnedComments: makeSelectPinnedCommentsForUri(props.uri)(state),
-    topLevelComments: makeSelectTopLevelCommentsForUri(props.uri)(state),
     topLevelTotalPages: makeSelectTopLevelTotalPagesForUri(props.uri)(state),
     totalComments: makeSelectTotalCommentsCountForUri(props.uri)(state),
     claim: makeSelectClaimForUri(props.uri)(state),
@@ -49,6 +60,7 @@ const perform = (dispatch) => ({
   fetchComment: (commentId) => dispatch(doCommentById(commentId)),
   fetchReacts: (commentIds) => dispatch(doCommentReactList(commentIds)),
   resetComments: (claimId) => dispatch(doCommentReset(claimId)),
+  doResolveUris: (uris) => dispatch(doResolveUris(uris)),
 });
 
 export default connect(select, perform)(CommentsList);

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -32,6 +32,7 @@ type Props = {
   allCommentIds: any,
   pinnedComments: Array<Comment>,
   topLevelComments: Array<Comment>,
+  unresolvedCommentChannels: Array<string>,
   topLevelTotalPages: number,
   uri: string,
   claim: ?Claim,
@@ -47,8 +48,9 @@ type Props = {
   othersReactsById: ?{ [string]: { [REACTION_TYPES.LIKE | REACTION_TYPES.DISLIKE]: number } },
   activeChannelId: ?string,
   settingsByChannelId: { [channelId: string]: PerChannelSettings },
-  fetchReacts: (Array<string>) => Promise<any>,
   commentsAreExpanded?: boolean,
+  fetchReacts: (Array<string>) => Promise<any>,
+  doResolveUris: (Array<string>) => void,
   fetchTopLevelComments: (string, number, number, number) => void,
   fetchComment: (string) => void,
   resetComments: (string) => void,
@@ -60,6 +62,7 @@ function CommentList(props: Props) {
     uri,
     pinnedComments,
     topLevelComments,
+    unresolvedCommentChannels,
     topLevelTotalPages,
     claim,
     claimIsMine,
@@ -74,8 +77,9 @@ function CommentList(props: Props) {
     othersReactsById,
     activeChannelId,
     settingsByChannelId,
-    fetchReacts,
     commentsAreExpanded,
+    fetchReacts,
+    doResolveUris,
     fetchTopLevelComments,
     fetchComment,
     resetComments,
@@ -221,6 +225,11 @@ function CommentList(props: Props) {
     }
   }, [hasDefaultExpansion, isFetchingComments, moreBelow, page, readyToDisplayComments, topLevelTotalPages]);
 
+  // Batch resolve comment channel urls
+  useEffect(() => {
+    if (unresolvedCommentChannels.length > 0) doResolveUris(unresolvedCommentChannels);
+  }, [unresolvedCommentChannels, doResolveUris]);
+
   const getCommentElems = (comments) => {
     return comments.map((comment) => (
       <CommentView
@@ -245,6 +254,7 @@ function CommentList(props: Props) {
         isModerator={comment.is_moderator}
         isGlobalMod={comment.is_global_mod}
         isFiat={comment.is_fiat}
+        alreadyResolved
       />
     ));
   };

--- a/ui/component/commentsReplies/index.js
+++ b/ui/component/commentsReplies/index.js
@@ -7,7 +7,7 @@ import CommentsReplies from './view';
 const select = (state, props) => ({
   fetchedReplies: makeSelectRepliesForParentId(props.parentId)(state),
   claimIsMine: makeSelectClaimIsMine(props.uri)(state),
-  commentingEnabled: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
+  userCanComment: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
   myChannels: selectMyChannelClaims(state),
   isFetchingByParentId: selectIsFetchingCommentsByParentId(state),
 });

--- a/ui/component/commentsReplies/index.js
+++ b/ui/component/commentsReplies/index.js
@@ -1,15 +1,25 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimIsMine, selectMyChannelClaims } from 'lbry-redux';
+import { makeSelectClaimIsMine, selectMyChannelClaims, makeSelectClaimForUri, doResolveUris } from 'lbry-redux';
 import { selectIsFetchingCommentsByParentId, makeSelectRepliesForParentId } from 'redux/selectors/comments';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import CommentsReplies from './view';
 
-const select = (state, props) => ({
-  fetchedReplies: makeSelectRepliesForParentId(props.parentId)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
-  userCanComment: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
-  myChannels: selectMyChannelClaims(state),
-  isFetchingByParentId: selectIsFetchingCommentsByParentId(state),
-});
+const select = (state, props) => {
+  const fetchedReplies = makeSelectRepliesForParentId(props.parentId)(state);
+  const unresolvedReplies =
+    fetchedReplies &&
+    fetchedReplies
+      .map(({ channel_url }) => makeSelectClaimForUri(channel_url)(state) === undefined && channel_url)
+      .filter((url) => url !== false);
 
-export default connect(select)(CommentsReplies);
+  return {
+    fetchedReplies,
+    unresolvedReplies,
+    claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+    userCanComment: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
+    myChannels: selectMyChannelClaims(state),
+    isFetchingByParentId: selectIsFetchingCommentsByParentId(state),
+  };
+};
+
+export default connect(select, { doResolveUris })(CommentsReplies);

--- a/ui/component/commentsReplies/view.jsx
+++ b/ui/component/commentsReplies/view.jsx
@@ -7,6 +7,7 @@ import Spinner from 'component/spinner';
 
 type Props = {
   fetchedReplies: Array<any>,
+  unresolvedReplies: Array<string>,
   uri: string,
   parentId: string,
   claimIsMine: boolean,
@@ -18,6 +19,7 @@ type Props = {
   isFetchingByParentId: { [string]: boolean },
   hasMore: boolean,
   supportDisabled: boolean,
+  doResolveUris: (Array<string>) => void,
   onShowMore?: () => void,
 };
 
@@ -26,6 +28,7 @@ function CommentsReplies(props: Props) {
     uri,
     parentId,
     fetchedReplies,
+    unresolvedReplies,
     claimIsMine,
     myChannels,
     linkedCommentId,
@@ -35,10 +38,16 @@ function CommentsReplies(props: Props) {
     isFetchingByParentId,
     hasMore,
     supportDisabled,
+    doResolveUris,
     onShowMore,
   } = props;
 
   const [isExpanded, setExpanded] = React.useState(true);
+
+  // Batch resolve reply channel urls
+  React.useEffect(() => {
+    if (unresolvedReplies && unresolvedReplies.length > 0) doResolveUris(unresolvedReplies);
+  }, [unresolvedReplies, doResolveUris]);
 
   return !numDirectReplies ? null : (
     <div className="comment__replies-container">

--- a/ui/component/commentsReplies/view.jsx
+++ b/ui/component/commentsReplies/view.jsx
@@ -1,8 +1,8 @@
 // @flow
 import * as ICONS from 'constants/icons';
-import React from 'react';
-import Comment from 'component/comment';
 import Button from 'component/button';
+import Comment from 'component/comment';
+import React from 'react';
 import Spinner from 'component/spinner';
 
 type Props = {
@@ -12,13 +12,13 @@ type Props = {
   claimIsMine: boolean,
   myChannels: ?Array<ChannelClaim>,
   linkedCommentId?: string,
-  commentingEnabled: boolean,
+  userCanComment: boolean,
   threadDepth: number,
   numDirectReplies: number, // Total replies for parentId as reported by 'comment[replies]'. Includes blocked items.
   isFetchingByParentId: { [string]: boolean },
-  onShowMore?: () => void,
   hasMore: boolean,
   supportDisabled: boolean,
+  onShowMore?: () => void,
 };
 
 function CommentsReplies(props: Props) {
@@ -29,99 +29,85 @@ function CommentsReplies(props: Props) {
     claimIsMine,
     myChannels,
     linkedCommentId,
-    commentingEnabled,
+    userCanComment,
     threadDepth,
     numDirectReplies,
     isFetchingByParentId,
-    onShowMore,
     hasMore,
     supportDisabled,
+    onShowMore,
   } = props;
 
   const [isExpanded, setExpanded] = React.useState(true);
 
-  function showMore() {
-    if (onShowMore) {
-      onShowMore();
-    }
-  }
+  return !numDirectReplies ? null : (
+    <div className="comment__replies-container">
+      {!isExpanded ? (
+        <div className="comment__actions--nested">
+          <Button
+            className="comment__action"
+            label={__('Show Replies')}
+            onClick={() => setExpanded(!isExpanded)}
+            icon={isExpanded ? ICONS.UP : ICONS.DOWN}
+          />
+        </div>
+      ) : (
+        <div>
+          <div className="comment__replies">
+            <Button className="comment__threadline" aria-label="Hide Replies" onClick={() => setExpanded(false)} />
 
-  // todo: implement comment_list --mine in SDK so redux can grab with selectCommentIsMine
-  function isMyComment(channelId: string) {
-    if (myChannels != null && channelId != null) {
-      for (let i = 0; i < myChannels.length; i++) {
-        if (myChannels[i].claim_id === channelId) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  const displayedComments = fetchedReplies;
-
-  return (
-    Boolean(numDirectReplies) && (
-      <div className="comment__replies-container">
-        {Boolean(numDirectReplies) && !isExpanded && (
+            <ul className="comments--replies">
+              {fetchedReplies &&
+                fetchedReplies.map((comment) => {
+                  return (
+                    <Comment
+                      threadDepth={threadDepth}
+                      uri={uri}
+                      authorUri={comment.channel_url}
+                      author={comment.channel_name}
+                      claimId={comment.claim_id}
+                      commentId={comment.comment_id}
+                      key={comment.comment_id}
+                      message={comment.comment}
+                      timePosted={comment.timestamp * 1000}
+                      claimIsMine={claimIsMine}
+                      commentIsMine={
+                        comment.channel_id &&
+                        myChannels &&
+                        myChannels.some(({ claim_id }) => claim_id === comment.channel_id)
+                      }
+                      linkedCommentId={linkedCommentId}
+                      commentingEnabled={userCanComment}
+                      supportAmount={comment.support_amount}
+                      numDirectReplies={comment.replies}
+                      isModerator={comment.is_moderator}
+                      isGlobalMod={comment.is_global_mod}
+                      supportDisabled={supportDisabled}
+                    />
+                  );
+                })}
+            </ul>
+          </div>
+        </div>
+      )}
+      {isExpanded && fetchedReplies && hasMore && (
+        <div className="comment__actions--nested">
+          <Button
+            button="link"
+            label={__('Show more')}
+            onClick={() => (onShowMore ? onShowMore() : null)}
+            className="button--uri-indicator"
+          />
+        </div>
+      )}
+      {isFetchingByParentId[parentId] && (
+        <div className="comment__replies-container">
           <div className="comment__actions--nested">
-            <Button
-              className="comment__action"
-              label={__('Show Replies')}
-              onClick={() => setExpanded(!isExpanded)}
-              icon={isExpanded ? ICONS.UP : ICONS.DOWN}
-            />
+            <Spinner type="small" />
           </div>
-        )}
-        {isExpanded && (
-          <div>
-            <div className="comment__replies">
-              <Button className="comment__threadline" aria-label="Hide Replies" onClick={() => setExpanded(false)} />
-
-              <ul className="comments--replies">
-                {displayedComments &&
-                  displayedComments.map((comment) => {
-                    return (
-                      <Comment
-                        threadDepth={threadDepth}
-                        uri={uri}
-                        authorUri={comment.channel_url}
-                        author={comment.channel_name}
-                        claimId={comment.claim_id}
-                        commentId={comment.comment_id}
-                        key={comment.comment_id}
-                        message={comment.comment}
-                        timePosted={comment.timestamp * 1000}
-                        claimIsMine={claimIsMine}
-                        commentIsMine={comment.channel_id && isMyComment(comment.channel_id)}
-                        linkedCommentId={linkedCommentId}
-                        commentingEnabled={commentingEnabled}
-                        supportAmount={comment.support_amount}
-                        numDirectReplies={comment.replies}
-                        isModerator={comment.is_moderator}
-                        isGlobalMod={comment.is_global_mod}
-                        supportDisabled={supportDisabled}
-                      />
-                    );
-                  })}
-              </ul>
-            </div>
-          </div>
-        )}
-        {isExpanded && fetchedReplies && hasMore && (
-          <div className="comment__actions--nested">
-            <Button button="link" label={__('Show more')} onClick={showMore} className="button--uri-indicator" />
-          </div>
-        )}
-        {isFetchingByParentId[parentId] && (
-          <div className="comment__replies-container">
-            <div className="comment__actions--nested">
-              <Spinner type="small" />
-            </div>
-          </div>
-        )}
-      </div>
-    )
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -20,6 +20,7 @@ type Props = {
   external?: boolean,
   className?: string,
   focusable: boolean,
+  alreadyResolved: boolean,
 };
 
 class UriIndicator extends React.PureComponent<Props> {
@@ -32,9 +33,9 @@ class UriIndicator extends React.PureComponent<Props> {
   }
 
   resolve = (props: Props) => {
-    const { isResolvingUri, resolveUri, claim, uri } = props;
+    const { alreadyResolved, isResolvingUri, resolveUri, claim, uri } = props;
 
-    if (!isResolvingUri && claim === undefined && uri) {
+    if (!alreadyResolved && !isResolvingUri && claim === undefined && uri) {
       resolveUri(uri);
     }
   };


### PR DESCRIPTION
## Fixes

Now comments, and replies when expanded, get batch-resolved, and avoid getting re-resolved on components like channelThumbnail or uriIndicator. There is no issue for it but all those resolve requests are unnecessary, also does this help with CPU stuff (#6473, #7177) @infinite-persistence ?

