### PR TITLE
Fix 'setting.Get' runaway calls

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -407,7 +407,7 @@ export function CommentCreate(props: Props) {
     if (!channelSettings && channelId) {
       doFetchCreatorSettings(channelId);
     }
-  }, [channelId, channelSettings, doFetchCreatorSettings]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Notifications: Fetch top-level comments to identify if it has been deleted and can reply to it
   React.useEffect(() => {


### PR DESCRIPTION
This is a copy of the ody version.  Was still seeing spikes, and recalled that lbry-desktop code needs the fix too.