### PR TITLE
Fix MenuButton behavior from toggle dropdown onMousePress to onClick

### DIFF
--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -265,14 +265,28 @@ function ClaimMenuList(props: Props) {
     push(`/$/${PAGES.REPORT_CONTENT}?claimId=${contentClaim && contentClaim.claim_id}`);
   }
 
+  // changes MenuButton behavior to show/hide MenuList not on press but on click event
+  let isEventSimulated = false;
+  const menuButtonHandler = (e) => {
+    if (!isEventSimulated && e.type === 'mousedown') {
+      e.preventDefault();
+    } else if (e.type === 'click') {
+      isEventSimulated = true;
+      e.target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      isEventSimulated = false;
+    }
+  };
+
   const shouldShow = !IS_WEB || (IS_WEB && isAuthenticated);
   return (
     <Menu>
       <MenuButton
         className={classnames('menu__button', { 'claim__menu-button': !inline, 'claim__menu-button--inline': inline })}
+        onMouseDown={menuButtonHandler}
         onClick={(e) => {
           e.stopPropagation();
           e.preventDefault();
+          menuButtonHandler(e);
         }}
       >
         <Icon size={20} icon={ICONS.MORE_VERTICAL} />

--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -268,6 +268,10 @@ function ClaimMenuList(props: Props) {
   // changes MenuButton behavior to show/hide MenuList not on press but on click event
   let isEventSimulated = false;
   const menuButtonHandler = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.type = 'click';
+    }
     if (!isEventSimulated && e.type === 'mousedown') {
       e.preventDefault();
     } else if (e.type === 'click') {
@@ -288,6 +292,7 @@ function ClaimMenuList(props: Props) {
           e.preventDefault();
           menuButtonHandler(e);
         }}
+        onKeyDown={menuButtonHandler}
       >
         <Icon size={20} icon={ICONS.MORE_VERTICAL} />
       </MenuButton>


### PR DESCRIPTION
## Fixes

Issue Number: #7326

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
`MenuButton` in the component `claimMenuList` toggles `MenuList`(dropdown) on mosePress event

## What is the new behavior?
`MenuButton` in the component `claimMenuList` toggles `MenuList`(dropdown) on click event

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->
`MenuButton`s in other components still toggle dropdowns on mouse press. It doesn't relate to this bugfix but my proposition is to change their behavior to toggle dropdown on click as well. 
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
