### PR TITLE
Remove duplicate after sign hook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,6 @@ jobs:
           yarn global add cross-env
           yarn
           yarn build
-          node ./build/afterSignHook.js
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}


### PR DESCRIPTION
The [afterSignHook](build/afterSignHook.js) script is already executed via electron-builder.json "afterSign" configuration.

As you can see here: https://github.com/lbryio/lbry-desktop/blob/master/electron-builder.json#L96

So the electron builder is calling this script already. No need to add this to the CI job again. 

Correct, right?

Regards,
Melroy 
