### PR TITLE
Fix WIndows artifact upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         if: |
-          github.event.pull_request.head.repo.full_name == github.repository
+          startsWith(runner.os, 'windows')
         with:
           name: Windows
           path: ./dist/electron/*.*


### PR DESCRIPTION
Fix `if statement` of the Windows binary artifact upload of GH Actions.

The current if statement makes no sense at all for the Windows build artifacts.
