### PR TITLE
Video: fix grayed out "/" in time indicator

### DIFF
--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -411,6 +411,10 @@
     .vjs-duration {
       display: flex;
     }
+
+    .vjs-time-divider {
+      z-index: 0; // solves the grayed-out divider
+    }
   }
 
   .vjs-picture-in-picture-control {


### PR DESCRIPTION
The "/" in "0:00 / 1:00" in the video player was not really visible.  This makes it the same color as the rest of the text.