### PR TITLE
Fix rendering for articles starting with quotes.

### DIFF
--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -178,10 +178,6 @@ const MarkdownPreview = (props: MarkdownProps) => {
       })
     : '';
 
-  const initialQuote = strippedContent.split(' ').find((word) => word.length > 0 || word.charAt(0) === '>');
-  let stripQuote;
-  if (initialQuote && initialQuote.charAt(0) === '>') stripQuote = true;
-
   const remarkOptions: Object = {
     sanitize: schema,
     fragment: React.Fragment,
@@ -216,22 +212,10 @@ const MarkdownPreview = (props: MarkdownProps) => {
   };
 
   // Strip all content and just render text
-  if (strip || stripQuote) {
+  if (strip) {
     // Remove new lines and extra space
     remarkOptions.remarkReactComponents.p = SimpleText;
-    return stripQuote ? (
-      <span dir="auto" className="markdown-preview">
-        <blockquote>
-          {
-            remark()
-              .use(remarkStrip)
-              .use(remarkFrontMatter, ['yaml'])
-              .use(reactRenderer, remarkOptions)
-              .processSync(content).contents
-          }
-        </blockquote>
-      </span>
-    ) : (
+    return (
       <span dir="auto" className="markdown-preview">
         {
           remark()


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/7473

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
Articles do not render correctly when the post begins with a quote.

## What is the new behavior?
The article renders correctly when the post begins with a quote.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
