### PR TITLE
Fix markdown guide button.

### DIFF
--- a/electron/createWindow.js
+++ b/electron/createWindow.js
@@ -10,6 +10,7 @@ import { TO_TRAY_WHEN_CLOSED } from 'constants/settings';
 import setupBarMenu from './menu/setupBarMenu';
 import * as PAGES from 'constants/pages';
 const remote = require('@electron/remote/main');
+const shell = require('electron').shell;
 function GetAppLangCode() {
   // https://www.electronjs.org/docs/api/locales
   // 1. Gets the user locale.
@@ -190,6 +191,8 @@ export default appState => {
   });
 
   window.webContents.setWindowOpenHandler((details) => {
+    // Open the link in a browser tab.
+    shell.openExternal(details.url);
     return { action: 'deny' };
   });
 

--- a/electron/createWindow.js
+++ b/electron/createWindow.js
@@ -191,8 +191,11 @@ export default appState => {
   });
 
   window.webContents.setWindowOpenHandler((details) => {
-    // Open the link in a browser tab.
-    shell.openExternal(details.url);
+    // Only open http and https links to prevent
+    // security issues.
+    if (['https:', 'http:'].includes(new URL(details.url).protocol)) {
+      shell.openExternal(details.url);
+    }
     return { action: 'deny' };
   });
 

--- a/ui/component/common/form-components/form-field.jsx
+++ b/ui/component/common/form-components/form-field.jsx
@@ -217,7 +217,7 @@ export class FormField extends React.PureComponent<Props> {
                   getMdeInstance={getInstance}
                   options={{
                     spellChecker: true,
-                    hideIcons: ['heading', 'image', 'fullscreen', 'side-by-side', 'guide'], // guide hidden until fixed
+                    hideIcons: ['heading', 'image', 'fullscreen', 'side-by-side'],
                     previewRender(plainText) {
                       const preview = <MarkdownPreview content={plainText} noDataStore />;
                       return ReactDOMServer.renderToString(preview);


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/7478

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
The guide button in the markdown editor doesn't work.

## What is the new behavior?
The guide button in the markdown editor now works and opens up the guide in a new browser tab.
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
