### PR TITLE
Fix comment count not incremented when it was previously 0

### DIFF
--- a/ui/redux/reducers/comments.js
+++ b/ui/redux/reducers/comments.js
@@ -89,7 +89,7 @@ export default handleActions(
       newCommentIds.unshift(comment.comment_id);
       byId[claimId] = newCommentIds;
 
-      if (totalCommentsById[claimId]) {
+      if (totalCommentsById.hasOwnProperty(claimId)) {
         totalCommentsById[claimId] += 1;
       }
 
@@ -562,7 +562,7 @@ export default handleActions(
         }
       }
 
-      if (totalCommentsById[claimId]) {
+      if (totalCommentsById.hasOwnProperty(claimId)) {
         totalCommentsById[claimId] = Math.max(0, totalCommentsById[claimId] - 1);
       }
 


### PR DESCRIPTION
It was causing the nudge to add a comment to still appear after one has just entered a comment.

Ticket: Odysee 928
