### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/electron/createWindow.js
+++ b/electron/createWindow.js
@@ -95,7 +95,7 @@ export default appState => {
 
   // is it a lbry://? pointing to an app page
   if (deepLinkingURI.includes(lbryProtoQ)) {
-    let path = deepLinkingURI.substr(lbryProtoQ.length);
+    let path = deepLinkingURI.slice(lbryProtoQ.length);
     let page = path.indexOf('?') >= 0 ? path.substring(0, path.indexOf('?')) : path;
     if (Object.values(PAGES).includes(page)) {
       deepLinkingURI = deepLinkingURI.replace(lbryProtoQ, '#/$/');

--- a/ui/component/common/form-components/form-field.jsx
+++ b/ui/component/common/form-components/form-field.jsx
@@ -157,7 +157,7 @@ export class FormField extends React.PureComponent<Props> {
 
                 delta = instance.getValue().length + delta - textAreaMaxLength;
                 if (delta > 0) {
-                  str = str.substr(0, str.length - delta);
+                  str = str.substring(0, str.length - delta);
                   changes.update(changes.from, changes.to, str.split('\n'));
                 }
               }

--- a/ui/component/common/transaction-link.jsx
+++ b/ui/component/common/transaction-link.jsx
@@ -10,7 +10,7 @@ const TransactionLink = (props: Props) => {
   const { id } = props;
 
   const href = `https://explorer.lbry.com/tx/${id}`;
-  const label = id.substr(0, 7);
+  const label = id.slice(0, 7);
 
   return <Button button="link" href={href} label={label} />;
 };

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -49,7 +49,7 @@ class DateTime extends React.Component<Props, State> {
 
     // Strip off the 's' for the singular suffix, construct the string ID,
     // then load the localized version.
-    const suffix = duration === 1 ? suffixList[i].substr(0, suffixList[i].length - 1) : suffixList[i];
+    const suffix = duration === 1 ? suffixList[i].slice(0, -1) : suffixList[i];
     let strId = '%duration% ' + suffix + ' ago';
 
     if (!suffix) {

--- a/ui/component/markdownLink/view.jsx
+++ b/ui/component/markdownLink/view.jsx
@@ -90,7 +90,7 @@ function MarkdownLink(props: Props) {
         className="button--external-link"
         onClick={() => {
           if (window.player) {
-            window.player.currentTime(parseInt(href.substr(3)));
+            window.player.currentTime(parseInt(href.slice(3)));
             window.scrollTo(0, 0);
           }
         }}

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -276,7 +276,7 @@ function PublishFile(props: Props) {
       filePath: file.path || file,
     };
     // Strip off extention and replace invalid characters
-    let fileName = name || (file.name && file.name.substr(0, file.name.lastIndexOf('.'))) || '';
+    let fileName = name || (file.name && file.name.substring(0, file.name.lastIndexOf('.'))) || '';
 
     if (!isStillEditing) {
       publishFormParams.name = parseName(fileName);

--- a/ui/component/tagsSearch/view.jsx
+++ b/ui/component/tagsSearch/view.jsx
@@ -65,7 +65,7 @@ export default function TagsSearch(props: Props) {
   } = props;
   const [newTag, setNewTag] = useState('');
   const doesTagMatch = (name) => {
-    const nextTag = newTag.substr(newTag.lastIndexOf(',') + 1, newTag.length).trim();
+    const nextTag = newTag.slice(newTag.lastIndexOf(',') + 1, newTag.length).trim();
     return newTag ? name.toLowerCase().includes(nextTag.toLowerCase()) : true;
   };
 

--- a/ui/redux/actions/wallet.js
+++ b/ui/redux/actions/wallet.js
@@ -80,7 +80,7 @@ export function doFetchTransactions(page = 1, pageSize = 999999) {
 
 export function doFetchTxoPage() {
   return (dispatch, getState) => {
-    const fetchId = Math.random().toString(36).substr(2, 9);
+    const fetchId = Math.random().toString(36).slice(2, 11);
 
     dispatch({
       type: ACTIONS.FETCH_TXO_PAGE_STARTED,

--- a/ui/util/enhanced-layout.js
+++ b/ui/util/enhanced-layout.js
@@ -55,7 +55,7 @@ var Konami = function(callback) {
       konami.input += e ? e.keyCode : event.keyCode;
 
       if (konami.input.length > konami.pattern.length) {
-        konami.input = konami.input.substr(konami.input.length - konami.pattern.length);
+        konami.input = konami.input.slice(konami.input.length - konami.pattern.length);
       }
       if (konami.input === konami.pattern) {
         konami.code(konami._currentLink);

--- a/ui/util/formatMediaDuration.js
+++ b/ui/util/formatMediaDuration.js
@@ -15,9 +15,9 @@ export default function formatMediaDuration(duration = 0, config) {
   let date = new Date(null);
   date.setSeconds(duration);
 
-  let timeString = date.toISOString().substr(11, 8);
+  let timeString = date.toISOString().slice(11, 19);
   if (timeString.startsWith('00:')) {
-    timeString = timeString.substr(3);
+    timeString = timeString.slice(3);
   }
 
   return timeString;


### PR DESCRIPTION
## Fixes

Removes a deprecated function

## What is the current behavior?

No change to new

## What is the new behavior?

No change to current

## Other information

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
