### PR TITLE
Remove abandoned claim from Uploads Page

### DIFF
--- a/ui/redux/reducers/claims.js
+++ b/ui/redux/reducers/claims.js
@@ -532,16 +532,24 @@ reducers[ACTIONS.ABANDON_CLAIM_SUCCEEDED] = (state: State, action: any): State =
   const { claimId }: { claimId: string } = action.data;
   const byId = Object.assign({}, state.byId);
   const newMyClaims = state.myClaims ? state.myClaims.slice() : [];
+  let myClaimsPageResults = null;
   const newMyChannelClaims = state.myChannelClaims ? state.myChannelClaims.slice() : [];
   const claimsByUri = Object.assign({}, state.claimsByUri);
   const abandoningById = Object.assign({}, state.abandoningById);
   const newMyCollectionClaims = state.myCollectionClaims ? state.myCollectionClaims.slice() : [];
 
+  let abandonedUris = [];
+
   Object.keys(claimsByUri).forEach((uri) => {
     if (claimsByUri[uri] === claimId) {
+      abandonedUris.push(uri);
       delete claimsByUri[uri];
     }
   });
+
+  if (abandonedUris.length > 0 && state.myClaimsPageResults) {
+    myClaimsPageResults = state.myClaimsPageResults.filter((uri) => !abandonedUris.includes(uri));
+  }
 
   if (abandoningById[claimId]) {
     delete abandoningById[claimId];
@@ -560,6 +568,7 @@ reducers[ACTIONS.ABANDON_CLAIM_SUCCEEDED] = (state: State, action: any): State =
     byId,
     claimsByUri,
     abandoningById,
+    myClaimsPageResults: myClaimsPageResults || state.myClaimsPageResults,
   });
 };
 


### PR DESCRIPTION
## Issue
In Uploads Page, Claim doesn't go away immediately when deleted, only after a refresh.

## Approach
- Also update `myClaimsPageResults` when abandoning.
- `abandonedUris` is an array because the uris come in various forms, so had to check all.

_(Cherry-pick of Odysee PR_1276)_
