### PR TITLE
Updated important instances of LBRY.tv to LBRY.com 

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -26,15 +26,15 @@ MATOMO_URL=https://analytics.lbry.com/
 MATOMO_ID=4
 
 # OG
-OG_TITLE_SUFFIX=| lbry.tv
-OG_HOMEPAGE_TITLE=lbry.tv
+OG_TITLE_SUFFIX=| lbry.com
+OG_HOMEPAGE_TITLE=lbry.com
 OG_IMAGE_URL=
-SITE_CANONICAL_URL=https://lbry.tv
+SITE_CANONICAL_URL=https://lbry.com
 
 # UI
 ## Custom Site info
-DOMAIN=lbry.tv
-URL=https://lbry.tv
+DOMAIN=lbry.com
+URL=https://lbry.com
 SITE_TITLE=LBRY
 SITE_NAME=LBRY
 SITE_DESCRIPTION=Meet LBRY, an open, free, and community-controlled content wonderland.

--- a/extras/lbryinc/constants/errors.js
+++ b/extras/lbryinc/constants/errors.js
@@ -1,4 +1,4 @@
 export const ALREADY_CLAIMED =
   'once the invite reward has been claimed the referrer cannot be changed';
 export const REFERRER_NOT_FOUND =
-  'A lbry.tv account could not be found for the referrer you provided.';
+  'An LBRY account could not be found for the referrer you provided.';


### PR DESCRIPTION
Updated important instances of LBRY.tv to LBRY.com or simply LBRY. This should no longer have the old "LBRY.tv is better when yadayadayada" message in the app. 