### PR TITLE
Do not reset description field while uploading thumbnail in playlist …

### DIFF
--- a/ui/component/collectionEdit/view.jsx
+++ b/ui/component/collectionEdit/view.jsx
@@ -362,6 +362,7 @@ function CollectionForm(props: Props) {
                           thumbnailParamError={thumbError}
                           thumbnailParamStatus={thumbStatus}
                           updateThumbnailParams={handleUpdateThumbnail}
+                          usePublishFormMode
                         />
                       </fieldset-section>
                       <FormField

--- a/ui/component/selectThumbnail/view.jsx
+++ b/ui/component/selectThumbnail/view.jsx
@@ -26,6 +26,7 @@ type Props = {
   updatePublishForm: ({}) => void,
   updateThumbnailParams: ({}) => void,
   resetThumbnailStatus: () => void,
+  usePublishFormMode: boolean,
 };
 
 function SelectThumbnail(props: Props) {
@@ -42,9 +43,10 @@ function SelectThumbnail(props: Props) {
     updateThumbnailParams,
     thumbnailPath,
     resetThumbnailStatus,
+    usePublishFormMode,
   } = props;
 
-  const publishForm = !updateThumbnailParams;
+  const publishForm = usePublishFormMode || !updateThumbnailParams;
   const thumbnail = publishForm ? props.thumbnail : thumbnailParam;
   const thumbnailError = publishForm ? props.thumbnailError : props.thumbnailParamError;
 


### PR DESCRIPTION
…edit/publish form; use same upload thumbnail layout as file upload for playlist edit/publish.

## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/7136

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

The layout of the thumbnail upload field in publish/edit playlists differs from the one displayed in the file upload page. Also, when uploading a thumbnail, when it finishes, it resets the description.

## What is the new behavior?

The layout is the same and no reset occurs when finishing uploading the thumbnail.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
