### PR TITLE
Do not throw error when trying to play empty collections.

### DIFF
--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -110,6 +110,11 @@ function ClaimMenuList(props: Props) {
   const [doShuffle, setDoShuffle] = React.useState(false);
   const incognitoClaim = contentChannelUri && !contentChannelUri.includes('@');
   const isChannel = !incognitoClaim && !contentSigningChannel;
+  // $FlowFixMe
+  const claimLength = claim && claim.value && claim.value.claims && claim.value.claims.length;
+  // $FlowFixMe
+  const claimCount = editedCollection ? editedCollection.items.length : claimLength;
+  const isEmptyCollection = (Number(claimCount) || 0) <= 0;
   const { channelName } = parseURI(contentChannelUri);
   const showDelete = claimIsMine || (fileInfo && (fileInfo.written_bytes > 0 || fileInfo.blobs_completed > 0));
   const subscriptionLabel = repostedClaim
@@ -297,18 +302,20 @@ function ClaimMenuList(props: Props) {
                   {__('View List')}
                 </a>
               </MenuItem>
-              <MenuItem
-                className="comment__menu-option"
-                onSelect={() => {
-                  if (!resolvedList) fetchItems();
-                  setDoShuffle(true);
-                }}
-              >
-                <div className="menu__link">
-                  <Icon aria-hidden icon={ICONS.SHUFFLE} />
-                  {__('Shuffle Play')}
-                </div>
-              </MenuItem>
+              {!isEmptyCollection && (
+                <MenuItem
+                  className="comment__menu-option"
+                  onSelect={() => {
+                    if (!resolvedList) fetchItems();
+                    setDoShuffle(true);
+                  }}
+                >
+                  <div className="menu__link">
+                    <Icon aria-hidden icon={ICONS.SHUFFLE} />
+                    {__('Shuffle Play')}
+                  </div>
+                </MenuItem>
+              )}
               {isMyCollection && (
                 <>
                   <MenuItem

--- a/ui/component/collectionActions/view.jsx
+++ b/ui/component/collectionActions/view.jsx
@@ -57,6 +57,9 @@ function CollectionActions(props: Props) {
 
   const doPlay = React.useCallback(
     (playUri) => {
+      if (!playUri) {
+        return;
+      }
       const navigateUrl = formatLbryUrlForWeb(playUri);
       push({
         pathname: navigateUrl,

--- a/ui/component/collectionActions/view.jsx
+++ b/ui/component/collectionActions/view.jsx
@@ -54,6 +54,7 @@ function CollectionActions(props: Props) {
   const isMobile = useIsMobile();
   const claimId = claim && claim.claim_id;
   const webShareable = true; // collections have cost?
+  const isEmptyCollection = !firstItem;
 
   const doPlay = React.useCallback(
     (playUri) => {
@@ -84,6 +85,7 @@ function CollectionActions(props: Props) {
         icon={ICONS.PLAY}
         label={__('Play')}
         title={__('Play')}
+        disabled={isEmptyCollection}
         onClick={() => {
           doToggleShuffleList(collectionId, false);
           doPlay(firstItem);
@@ -94,6 +96,7 @@ function CollectionActions(props: Props) {
         icon={ICONS.SHUFFLE}
         label={__('Shuffle Play')}
         title={__('Shuffle Play')}
+        disabled={isEmptyCollection}
         onClick={() => {
           doToggleShuffleList(collectionId, true);
           setDoShuffle(true);

--- a/ui/component/collectionPreviewOverlay/view.jsx
+++ b/ui/component/collectionPreviewOverlay/view.jsx
@@ -33,7 +33,7 @@ function CollectionPreviewOverlay(props: Props) {
             collectionItemUrls.map((item, index) => {
               if (index < 2) {
                 return (
-                  <div className="collection-preview__overlay-grid-items">
+                  <div key={item} className="collection-preview__overlay-grid-items">
                     <FileThumbnail uri={item} key={item} />
                   </div>
                 );

--- a/ui/component/collectionsListMine/view.jsx
+++ b/ui/component/collectionsListMine/view.jsx
@@ -95,7 +95,7 @@ export default function CollectionsListMine(props: Props) {
       {builtin.map((list: Collection) => {
         const { items: itemUrls } = list;
         return (
-          <>
+          <React.Fragment key={list.name}>
             {Boolean(itemUrls && itemUrls.length) && (
               <div className="claim-grid__wrapper" key={list.name}>
                 <h1 className="claim-grid__header">
@@ -124,7 +124,7 @@ export default function CollectionsListMine(props: Props) {
                 <ClaimList tileLayout key={list.name} uris={itemUrls.slice(0, 6)} collectionId={list.id} />
               </div>
             )}
-          </>
+          </React.Fragment>
         );
       })}
       <div className="claim-grid__wrapper">


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/7140

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

When playing empty lists there is an error showing up.

## What is the new behavior?

- No error is thrown when trying to play an empty list.
- The play/shuffle button gets disabled for an empty list.
- The shuffle button doesn't appear for empty lists.

![image](https://user-images.githubusercontent.com/1719111/166702927-36b72580-8268-4d6b-a8c4-a59fe006b286.png)

![image](https://user-images.githubusercontent.com/1719111/166715076-bf991d26-c8ef-4007-9b7c-8907bd057ffa.png)

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
