### PR TITLE
Handle non playable items in playlists.

### DIFF
--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -333,9 +333,9 @@ function ClaimMenuList(props: Props) {
               )}
             </>
           ) : (
-            isPlayable && (
-              <>
-                {/* WATCH LATER */}
+            <>
+              {/* WATCH LATER */}
+              {isPlayable && (
                 <MenuItem
                   className="comment__menu-option"
                   onSelect={() => handleAdd(hasClaimInWatchLater, __('Watch Later'), COLLECTIONS_CONSTS.WATCH_LATER_ID)}
@@ -345,45 +345,45 @@ function ClaimMenuList(props: Props) {
                     {hasClaimInWatchLater ? __('In Watch Later') : __('Watch Later')}
                   </div>
                 </MenuItem>
-                {/* FAVORITES LIST */}
+              )}
+              {/* FAVORITES LIST */}
+              <MenuItem
+                className="comment__menu-option"
+                onSelect={() => handleAdd(hasClaimInFavorites, __('Favorites'), COLLECTIONS_CONSTS.FAVORITES_ID)}
+              >
+                <div className="menu__link">
+                  <Icon aria-hidden icon={hasClaimInFavorites ? ICONS.DELETE : ICONS.STAR} />
+                  {hasClaimInFavorites ? __('In Favorites') : __('Favorites')}
+                </div>
+              </MenuItem>
+              {/* CURRENTLY ONLY SUPPORT PLAYLISTS FOR PLAYABLE; LATER DIFFERENT TYPES */}
+              <MenuItem
+                className="comment__menu-option"
+                onSelect={() => openModal(MODALS.COLLECTION_ADD, { uri, type: 'playlist' })}
+              >
+                <div className="menu__link">
+                  <Icon aria-hidden icon={ICONS.STACK} />
+                  {__('Add to Lists')}
+                </div>
+              </MenuItem>
+              {lastUsedCollection && lastUsedCollectionIsNotBuiltin && (
                 <MenuItem
                   className="comment__menu-option"
-                  onSelect={() => handleAdd(hasClaimInFavorites, __('Favorites'), COLLECTIONS_CONSTS.FAVORITES_ID)}
+                  onSelect={() =>
+                    handleAdd(hasClaimInLastUsedCollection, lastUsedCollection.name, lastUsedCollection.id)
+                  }
                 >
                   <div className="menu__link">
-                    <Icon aria-hidden icon={hasClaimInFavorites ? ICONS.DELETE : ICONS.STAR} />
-                    {hasClaimInFavorites ? __('In Favorites') : __('Favorites')}
+                    {!hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.ADD} />}
+                    {hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.DELETE} />}
+                    {!hasClaimInLastUsedCollection &&
+                      __('Add to %collection%', { collection: lastUsedCollection.name })}
+                    {hasClaimInLastUsedCollection && __('In %collection%', { collection: lastUsedCollection.name })}
                   </div>
                 </MenuItem>
-                {/* CURRENTLY ONLY SUPPORT PLAYLISTS FOR PLAYABLE; LATER DIFFERENT TYPES */}
-                <MenuItem
-                  className="comment__menu-option"
-                  onSelect={() => openModal(MODALS.COLLECTION_ADD, { uri, type: 'playlist' })}
-                >
-                  <div className="menu__link">
-                    <Icon aria-hidden icon={ICONS.STACK} />
-                    {__('Add to Lists')}
-                  </div>
-                </MenuItem>
-                {lastUsedCollection && lastUsedCollectionIsNotBuiltin && (
-                  <MenuItem
-                    className="comment__menu-option"
-                    onSelect={() =>
-                      handleAdd(hasClaimInLastUsedCollection, lastUsedCollection.name, lastUsedCollection.id)
-                    }
-                  >
-                    <div className="menu__link">
-                      {!hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.ADD} />}
-                      {hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.DELETE} />}
-                      {!hasClaimInLastUsedCollection &&
-                        __('Add to %collection%', { collection: lastUsedCollection.name })}
-                      {hasClaimInLastUsedCollection && __('In %collection%', { collection: lastUsedCollection.name })}
-                    </div>
-                  </MenuItem>
-                )}
-                <hr className="menu__separator" />
-              </>
-            )
+              )}
+              <hr className="menu__separator" />
+            </>
           )}
         </>
         {!isChannelPage && (

--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -333,9 +333,9 @@ function ClaimMenuList(props: Props) {
               )}
             </>
           ) : (
-            <>
-              {/* WATCH LATER */}
-              {isPlayable && (
+            isPlayable && (
+              <>
+                {/* WATCH LATER */}
                 <MenuItem
                   className="comment__menu-option"
                   onSelect={() => handleAdd(hasClaimInWatchLater, __('Watch Later'), COLLECTIONS_CONSTS.WATCH_LATER_ID)}
@@ -345,45 +345,45 @@ function ClaimMenuList(props: Props) {
                     {hasClaimInWatchLater ? __('In Watch Later') : __('Watch Later')}
                   </div>
                 </MenuItem>
-              )}
-              {/* FAVORITES LIST */}
-              <MenuItem
-                className="comment__menu-option"
-                onSelect={() => handleAdd(hasClaimInFavorites, __('Favorites'), COLLECTIONS_CONSTS.FAVORITES_ID)}
-              >
-                <div className="menu__link">
-                  <Icon aria-hidden icon={hasClaimInFavorites ? ICONS.DELETE : ICONS.STAR} />
-                  {hasClaimInFavorites ? __('In Favorites') : __('Favorites')}
-                </div>
-              </MenuItem>
-              {/* CURRENTLY ONLY SUPPORT PLAYLISTS FOR PLAYABLE; LATER DIFFERENT TYPES */}
-              <MenuItem
-                className="comment__menu-option"
-                onSelect={() => openModal(MODALS.COLLECTION_ADD, { uri, type: 'playlist' })}
-              >
-                <div className="menu__link">
-                  <Icon aria-hidden icon={ICONS.STACK} />
-                  {__('Add to Lists')}
-                </div>
-              </MenuItem>
-              {lastUsedCollection && lastUsedCollectionIsNotBuiltin && (
+                {/* FAVORITES LIST */}
                 <MenuItem
                   className="comment__menu-option"
-                  onSelect={() =>
-                    handleAdd(hasClaimInLastUsedCollection, lastUsedCollection.name, lastUsedCollection.id)
-                  }
+                  onSelect={() => handleAdd(hasClaimInFavorites, __('Favorites'), COLLECTIONS_CONSTS.FAVORITES_ID)}
                 >
                   <div className="menu__link">
-                    {!hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.ADD} />}
-                    {hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.DELETE} />}
-                    {!hasClaimInLastUsedCollection &&
-                      __('Add to %collection%', { collection: lastUsedCollection.name })}
-                    {hasClaimInLastUsedCollection && __('In %collection%', { collection: lastUsedCollection.name })}
+                    <Icon aria-hidden icon={hasClaimInFavorites ? ICONS.DELETE : ICONS.STAR} />
+                    {hasClaimInFavorites ? __('In Favorites') : __('Favorites')}
                   </div>
                 </MenuItem>
-              )}
-              <hr className="menu__separator" />
-            </>
+                {/* CURRENTLY ONLY SUPPORT PLAYLISTS FOR PLAYABLE; LATER DIFFERENT TYPES */}
+                <MenuItem
+                  className="comment__menu-option"
+                  onSelect={() => openModal(MODALS.COLLECTION_ADD, { uri, type: 'playlist' })}
+                >
+                  <div className="menu__link">
+                    <Icon aria-hidden icon={ICONS.STACK} />
+                    {__('Add to Lists')}
+                  </div>
+                </MenuItem>
+                {lastUsedCollection && lastUsedCollectionIsNotBuiltin && (
+                  <MenuItem
+                    className="comment__menu-option"
+                    onSelect={() =>
+                      handleAdd(hasClaimInLastUsedCollection, lastUsedCollection.name, lastUsedCollection.id)
+                    }
+                  >
+                    <div className="menu__link">
+                      {!hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.ADD} />}
+                      {hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.DELETE} />}
+                      {!hasClaimInLastUsedCollection &&
+                        __('Add to %collection%', { collection: lastUsedCollection.name })}
+                      {hasClaimInLastUsedCollection && __('In %collection%', { collection: lastUsedCollection.name })}
+                    </div>
+                  </MenuItem>
+                )}
+                <hr className="menu__separator" />
+              </>
+            )
           )}
         </>
         {!isChannelPage && (

--- a/ui/component/viewers/videoViewer/index.js
+++ b/ui/component/viewers/videoViewer/index.js
@@ -1,8 +1,8 @@
 import { connect } from 'react-redux';
 import { makeSelectClaimForUri, selectThumbnailForUri } from 'redux/selectors/claims';
 import {
-  makeSelectNextUrlForCollectionAndUrl,
-  makeSelectPreviousUrlForCollectionAndUrl,
+  makeSelectPrevPlayableUrlFromCollectionAndUrl,
+  makeSelectNextPlayableUrlFromCollectionAndUrl,
 } from 'redux/selectors/collections';
 import * as SETTINGS from 'constants/settings';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
@@ -34,38 +34,12 @@ const select = (state, props) => {
   const playingUri = selectPlayingUri(state);
   const collectionId = urlParams.get(COLLECTIONS_CONSTS.COLLECTION_ID) || (playingUri && playingUri.collectionId);
   const isMarkdownOrComment = playingUri && (playingUri.source === 'markdown' || playingUri.source === 'comment');
-  const isClaimPlayable = (uri) => {
-    const claim = makeSelectClaimForUri(uri)(state);
-    // $FlowFixMe
-    return (
-      claim &&
-      // $FlowFixMe
-      claim.value &&
-      // $FlowFixMe
-      claim.value.stream_type &&
-      // $FlowFixMe
-      (claim.value.stream_type === 'audio' || claim.value.stream_type === 'video')
-    );
-  };
-  const nextUriInCollection = (fromUri) => {
-    return makeSelectNextUrlForCollectionAndUrl(collectionId, fromUri)(state);
-  };
-  const prevUriInCollection = (fromUri) => {
-    return makeSelectPreviousUrlForCollectionAndUrl(collectionId, fromUri)(state);
-  };
 
   let nextRecommendedUri;
   let previousListUri;
   if (collectionId) {
-    nextRecommendedUri = uri;
-    previousListUri = uri;
-    // Find previous and next playable item in the collection.
-    do {
-      nextRecommendedUri = nextUriInCollection(nextRecommendedUri);
-    } while (nextRecommendedUri && !isClaimPlayable(nextRecommendedUri));
-    do {
-      previousListUri = prevUriInCollection(previousListUri);
-    } while (previousListUri && !isClaimPlayable(previousListUri));
+    nextRecommendedUri = makeSelectNextPlayableUrlFromCollectionAndUrl(collectionId, uri)(state);
+    previousListUri = makeSelectPrevPlayableUrlFromCollectionAndUrl(collectionId, uri)(state);
   } else {
     const recommendedContent = selectRecommendedContentForUri(state, uri);
     nextRecommendedUri = recommendedContent && recommendedContent[0];

--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -3,6 +3,7 @@ import fromEntries from '@ungap/from-entries';
 import { createSelector } from 'reselect';
 import { selectMyCollectionIds, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { parseURI } from 'util/lbryURI';
+import { isClaimPlayable } from 'util/claim';
 
 const selectState = (state: { collections: CollectionState }) => state.collections;
 
@@ -216,7 +217,7 @@ export const makeSelectNextUrlForCollectionAndUrl = (id: string, url: string) =>
 
       if (index > -1) {
         const listUrls = shuffleUrls || urls;
-        // We'll get the next playble url
+        // We'll get the next playable url
         let remainingUrls = listUrls.slice(index + 1);
         if (!remainingUrls.length && loopList) {
           remainingUrls = listUrls.slice(0);
@@ -226,6 +227,34 @@ export const makeSelectNextUrlForCollectionAndUrl = (id: string, url: string) =>
       } else {
         return null;
       }
+    }
+  );
+
+export const makeSelectPrevPlayableUrlFromCollectionAndUrl = (collectionId: string, url: string) =>
+  createSelector(
+    (state) => state,
+    (state) => {
+      let prevUrl = url;
+      let prevPlayableClaim;
+      do {
+        prevUrl = makeSelectPreviousUrlForCollectionAndUrl(collectionId, prevUrl)(state);
+        prevPlayableClaim = makeSelectClaimForUri(prevUrl)(state);
+      } while (prevUrl && !isClaimPlayable(prevPlayableClaim));
+      return prevUrl;
+    }
+  );
+
+export const makeSelectNextPlayableUrlFromCollectionAndUrl = (collectionId: string, url: string) =>
+  createSelector(
+    (state) => state,
+    (state) => {
+      let nextUrl = url;
+      let nextPlayableClaim;
+      do {
+        nextUrl = makeSelectNextUrlForCollectionAndUrl(collectionId, nextUrl)(state);
+        nextPlayableClaim = makeSelectClaimForUri(nextUrl)(state);
+      } while (nextUrl && !isClaimPlayable(nextPlayableClaim));
+      return nextUrl;
     }
   );
 

--- a/ui/util/claim.js
+++ b/ui/util/claim.js
@@ -108,3 +108,12 @@ export function getChannelFromClaim(claim: ?Claim) {
     ? claim.signing_channel
     : null;
 }
+
+export function isClaimPlayable(claim: ?Claim) {
+  // $FlowFixMe
+  if (!claim || !claim.value || !claim.value.stream_type) {
+    return false;
+  }
+  // $FlowFixMe
+  return ['audio', 'video'].includes(claim.value.stream_type);
+}


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/7575

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Only videos and audio can be added to playlists.

## What is the new behavior?

All types of claims can be included in the playlists.

When played:
- If the first claim of the playlist is not a video/audio, the claim URL will be loaded.
- If the first claim of the playlist is video/audio, it will play, and when finished, it will jump to the next playable item.

![image](https://user-images.githubusercontent.com/1719111/167135962-53fa19cd-b695-4103-968e-16afb9e33411.png)

When played, all the items will be displayed in the claim list. The reason for this is to show the user the content of the list and not confuse the user as to what the list contains.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
