### PR TITLE
Hide watched progress if claim is being played.

### DIFF
--- a/ui/component/fileThumbnail/index.js
+++ b/ui/component/fileThumbnail/index.js
@@ -1,16 +1,25 @@
 import { connect } from 'react-redux';
 import { doResolveUri } from 'redux/actions/claims';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
-import { makeSelectContentWatchedPercentageForUri } from 'redux/selectors/content';
+import { selectPrimaryUri, makeSelectContentWatchedPercentageForUri } from 'redux/selectors/content';
 import CardMedia from './view';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
 import * as SETTINGS from 'constants/settings';
 
 const select = (state, props) => {
+  const claimUriBeingPlayed = selectPrimaryUri(state);
+  let isBeingPlayed = false;
+
+  if (claimUriBeingPlayed) {
+    const claim = makeSelectClaimForUri(props.uri)(state);
+    const claimBeingPlayed = makeSelectClaimForUri(claimUriBeingPlayed)(state);
+    isBeingPlayed = claim.claim_id === claimBeingPlayed.claim_id;
+  }
+
   return {
     watchedPercentage: makeSelectContentWatchedPercentageForUri(props.uri)(state),
     claim: makeSelectClaimForUri(props.uri)(state),
-    showPercentage: makeSelectClientSetting(SETTINGS.PERSIST_WATCH_TIME)(state),
+    showPercentage: !isBeingPlayed && makeSelectClientSetting(SETTINGS.PERSIST_WATCH_TIME)(state),
   };
 };
 


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/7582

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
The watch progress gets displayed when playing a collection/claim

## What is the new behavior?
The watch progress is hidden if the claim is being played.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
