### PR TITLE
use default path in windows when choosing a file

### DIFF
--- a/ui/component/common/file-selector.jsx
+++ b/ui/component/common/file-selector.jsx
@@ -47,10 +47,10 @@ class FileSelector extends React.PureComponent<Props> {
   };
 
   handleDirectoryInputSelection = () => {
-    var defaultPath;
-    var properties;
-    var isWin = process.platform === 'win32';
-    var type = this.props.type;
+    let defaultPath;
+    let properties;
+    let isWin = process.platform === 'win32';
+    let type = this.props.type;
 
     if (isWin === true) {
       defaultPath = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;

--- a/ui/component/common/file-selector.jsx
+++ b/ui/component/common/file-selector.jsx
@@ -47,7 +47,24 @@ class FileSelector extends React.PureComponent<Props> {
   };
 
   handleDirectoryInputSelection = () => {
-    remote.dialog.showOpenDialog({ properties: ['openDirectory'] }).then((result) => {
+    var defaultPath;
+    var properties;
+    var isWin = process.platform === 'win32';
+    var type = this.props.type;
+
+    if (isWin === true) {
+      defaultPath = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+    }
+
+    if (type === 'openFile') {
+      properties = ['openFile'];
+    }
+
+    if (type === 'openDirectory') {
+      properties = ['openDirectory'];
+    }
+
+    remote.dialog.showOpenDialog({ properties, defaultPath }).then((result) => {
       const path = result && result.filePaths[0];
       if (path) {
         // $FlowFixMe
@@ -82,7 +99,11 @@ class FileSelector extends React.PureComponent<Props> {
               autoFocus={autoFocus}
               button="primary"
               disabled={disabled}
-              onClick={type === 'openDirectory' ? this.handleDirectoryInputSelection : this.fileInputButton}
+              onClick={
+                type === 'openDirectory' || type === 'openFile'
+                  ? this.handleDirectoryInputSelection
+                  : this.fileInputButton
+              }
               label={__('Browse')}
             />
           }

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -325,6 +325,7 @@ function PublishFile(props: Props) {
           {showFileUpload && (
             <>
               <FileSelector
+                type="openFile"
                 label={__('File')}
                 disabled={disabled}
                 currentPath={currentFile}


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/1811

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
Currently the "Choose File" button opens the root folder of the program and not "My documents" or "My computer" which generates confusion in new users,  this error only happens in windows.

## What is the new behavior?
Clicking on the "Choose File" button opens the user's root folder.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
