### PR TITLE
Allow only images in modal image uploader.

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -20,6 +20,7 @@ import path from 'path';
 import { diskSpaceLinux, diskSpaceWindows, diskSpaceMac } from '../ui/util/diskspace';
 
 const { download } = require('electron-dl');
+const mime = require('mime');
 const remote = require('@electron/remote/main');
 const os = require('os');
 const sudo = require('sudo-prompt');
@@ -318,6 +319,7 @@ ipcMain.handle('get-file-from-path', (event, path) => {
       const fileName = folders[folders.length - 1];
       resolve({
         name: fileName,
+        mime: mime.getType(fileName) || undefined,
         path: path,
         buffer: data,
       });

--- a/electron/index.js
+++ b/electron/index.js
@@ -299,6 +299,32 @@ app.on('before-quit', () => {
   appState.isQuitting = true;
 });
 
+// Get the content of a file as a raw buffer of bytes.
+// Useful to convert a file path to a File instance.
+// Example:
+// const result = await ipcMain.invoke('get-file-from-path', 'path/to/file');
+// const file = new File([result.buffer], result.name);
+ipcMain.handle('get-file-from-path', (event, path) => {
+  return new Promise((resolve, reject) => {
+    // Encoding null ensures data results in a Buffer.
+    fs.readFile(path, { encoding: null }, (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      // Separate folders considering "\" and "/"
+      // as separators (cross platform)
+      const folders = path.split(/[\\/]/);
+      const fileName = folders[folders.length - 1];
+      resolve({
+        name: fileName,
+        path: path,
+        buffer: data,
+      });
+    });
+  });
+});
+
 ipcMain.on('get-disk-space', async (event) => {
   try {
     const { data_dir } = await Lbry.settings_get();

--- a/flow-typed/file-with-path.js
+++ b/flow-typed/file-with-path.js
@@ -1,0 +1,9 @@
+// @flow
+
+declare type FileWithPath = {
+  file: File,
+  // The full path will only be available in
+  // the application. For browser, the name
+  // of the file will be used.
+  path: string,
+}

--- a/flow-typed/web-file.js
+++ b/flow-typed/web-file.js
@@ -1,6 +1,0 @@
-// @flow
-
-declare type WebFile = File & {
-  path?: string,
-  title?: string,
-}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "humanize-duration": "^3.27.0",
     "if-env": "^1.0.4",
     "match-sorter": "^6.3.0",
+    "mime": "^3.0.0",
     "node-html-parser": "^5.1.0",
     "parse-duration": "^1.0.0",
     "proxy-polyfill": "0.1.6",

--- a/ui/component/channelForm/view.jsx
+++ b/ui/component/channelForm/view.jsx
@@ -325,7 +325,6 @@ function ChannelForm(props: Props) {
               uri={uri}
               thumbnailPreview={thumbnailPreview}
               allowGifs
-              showDelayedMessage={isUpload.thumbnail}
               setThumbUploadError={setThumbError}
               thumbUploadError={thumbError}
             />

--- a/ui/component/common/file-list.jsx
+++ b/ui/component/common/file-list.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { useRadioState, Radio, RadioGroup } from 'reakit/Radio';
 
 type Props = {
-  files: Array<WebFile>,
-  onChange: (WebFile | void) => void,
+  files: Array<File>,
+  onChange: (File | void) => void,
 };
 
 type RadioProps = {
@@ -26,7 +26,7 @@ function FileList(props: Props) {
 
   const getFile = (value?: string) => {
     if (files && files.length) {
-      return files.find((file: WebFile) => file.name === value);
+      return files.find((file: File) => file.name === value);
     }
   };
 
@@ -46,12 +46,12 @@ function FileList(props: Props) {
 
         if (radio.state) {
           // Find selected element
-          const stop = radio.stops.find(item => item.id === radio.currentId);
+          const stop = radio.stops.find((item) => item.id === radio.currentId);
           const element = stop && stop.ref.current;
           // Only update state if new item is selected
           if (element && element.value !== radio.state) {
             const file = getFile(element.value);
-            // Sselect new file and update state
+            // Select new file and update state
             onChange(file);
             radio.setState(element.value);
           }

--- a/ui/component/common/file-list.jsx
+++ b/ui/component/common/file-list.jsx
@@ -31,11 +31,11 @@ function FileList(props: Props) {
   };
 
   React.useEffect(() => {
-    if (radio.stops.length) {
+    if (radio.items.length) {
       if (!radio.currentId) {
         radio.first();
       } else {
-        const first = radio.stops[0].ref.current;
+        const first = radio.items[0].ref.current;
         // First auto-selection
         if (first && first.id === radio.currentId && !radio.state) {
           const file = getFile(first.value);
@@ -46,7 +46,7 @@ function FileList(props: Props) {
 
         if (radio.state) {
           // Find selected element
-          const stop = radio.stops.find((item) => item.id === radio.currentId);
+          const stop = radio.items.find((item) => item.id === radio.currentId);
           const element = stop && stop.ref.current;
           // Only update state if new item is selected
           if (element && element.value !== radio.state) {

--- a/ui/component/common/file-selector.jsx
+++ b/ui/component/common/file-selector.jsx
@@ -83,7 +83,16 @@ class FileSelector extends React.PureComponent<Props> {
         if (!result) {
           return;
         }
-        const file = new File([result.buffer], result.name);
+        const file = new File([result.buffer], result.name, {
+          type: result.mime,
+        });
+        // "path" is a read only property so we have to use this
+        // hack to overcome the limitation.
+        // $FlowFixMe
+        Object.defineProperty(file, 'path', {
+          value: result.path,
+          writable: false,
+        });
         this.props.onFileChosen(file);
       });
   };

--- a/ui/component/common/file-selector.jsx
+++ b/ui/component/common/file-selector.jsx
@@ -77,7 +77,6 @@ class FileSelector extends React.PureComponent<Props> {
         if (path) {
           return ipcRenderer.invoke('get-file-from-path', path);
         }
-        return undefined;
       })
       .then((result) => {
         if (!result) {

--- a/ui/component/common/file-selector.jsx
+++ b/ui/component/common/file-selector.jsx
@@ -8,7 +8,7 @@ import { FormField } from 'component/common/form';
 type Props = {
   type: string,
   currentPath?: ?string,
-  onFileChosen: (WebFile) => void,
+  onFileChosen: (FileWithPath) => void,
   label?: string,
   placeholder?: string,
   accept?: string,
@@ -43,7 +43,7 @@ class FileSelector extends React.PureComponent<Props> {
     const file = files[0];
 
     if (this.props.onFileChosen) {
-      this.props.onFileChosen(file);
+      this.props.onFileChosen({ file, path: file.path || file.name });
     }
     this.fileInput.current.value = null; // clear the file input
   };
@@ -86,14 +86,7 @@ class FileSelector extends React.PureComponent<Props> {
         const file = new File([result.buffer], result.name, {
           type: result.mime,
         });
-        // "path" is a read only property so we have to use this
-        // hack to overcome the limitation.
-        // $FlowFixMe
-        Object.defineProperty(file, 'path', {
-          value: result.path,
-          writable: false,
-        });
-        this.props.onFileChosen(file);
+        this.props.onFileChosen({ file, path: result.path });
       });
   };
 

--- a/ui/component/fileDrop/view.jsx
+++ b/ui/component/fileDrop/view.jsx
@@ -11,7 +11,7 @@ import Icon from 'component/common/icon';
 
 type Props = {
   modal: { id: string, modalProps: {} },
-  filePath: string | File,
+  filePath: File,
   clearPublish: () => void,
   updatePublishForm: ({}) => void,
   openModal: (id: string, { files: Array<File> }) => void,

--- a/ui/component/fileDrop/view.jsx
+++ b/ui/component/fileDrop/view.jsx
@@ -11,7 +11,7 @@ import Icon from 'component/common/icon';
 
 type Props = {
   modal: { id: string, modalProps: {} },
-  filePath: File,
+  filePath: ?string,
   clearPublish: () => void,
   updatePublishForm: ({}) => void,
   openModal: (id: string, { files: Array<File> }) => void,
@@ -65,24 +65,29 @@ function FileDrop(props: Props) {
     }
   }, [history]);
 
-  // Delay hide and navigation for a smooth transition
-  const hideDropArea = React.useCallback(() => {
-    hideTimer.current = setTimeout(() => {
-      setFiles([]);
-      // Navigate to publish area
-      navigationTimer.current = setTimeout(() => {
-        navigateToPublish();
-      }, NAVIGATE_TIME_OUT);
-    }, HIDE_TIME_OUT);
-  }, [navigateToPublish]);
-
   // Handle file selection
   const handleFileSelected = React.useCallback(
     (selectedFile) => {
-      updatePublishForm({ filePath: selectedFile });
-      hideDropArea();
+      // Delay hide and navigation for a smooth transition
+      hideTimer.current = setTimeout(() => {
+        setFiles([]);
+        // Navigate to publish area
+        navigationTimer.current = setTimeout(() => {
+          // Navigate first, THEN assign filePath, otherwise
+          // the file selected will get reset (that's how the
+          // publish file view works, when the user switches to
+          // publish a file, the pathFile value gets reset to undefined)
+          navigateToPublish();
+          updatePublishForm({
+            filePath: selectedFile.path || selectedFile.name,
+            fileDur: 0,
+            fileSize: 0,
+            fileVid: false,
+          });
+        }, NAVIGATE_TIME_OUT);
+      }, HIDE_TIME_OUT);
     },
-    [updatePublishForm, hideDropArea]
+    [setFiles, navigateToPublish, updatePublishForm]
   );
 
   // Clear timers when unmounted

--- a/ui/component/fileDrop/view.jsx
+++ b/ui/component/fileDrop/view.jsx
@@ -11,10 +11,10 @@ import Icon from 'component/common/icon';
 
 type Props = {
   modal: { id: string, modalProps: {} },
-  filePath: string | WebFile,
+  filePath: string | File,
   clearPublish: () => void,
   updatePublishForm: ({}) => void,
-  openModal: (id: string, { files: Array<WebFile> }) => void,
+  openModal: (id: string, { files: Array<File> }) => void,
   // React router
   history: {
     entities: {}[],
@@ -37,7 +37,7 @@ function FileDrop(props: Props) {
   const { drag, dropData } = useDragDrop();
   const [files, setFiles] = React.useState([]);
   const [error, setError] = React.useState(false);
-  const [target, setTarget] = React.useState<?WebFile>(null);
+  const [target, setTarget] = React.useState<?File>(null);
   const hideTimer = React.useRef(null);
   const targetTimer = React.useRef(null);
   const navigationTimer = React.useRef(null);

--- a/ui/component/postEditor/view.jsx
+++ b/ui/component/postEditor/view.jsx
@@ -6,7 +6,7 @@ type Props = {
   uri: ?string,
   label: ?string,
   disabled: ?boolean,
-  filePath: string | WebFile,
+  filePath: string | File,
   fileText: ?string,
   fileMimeType: ?string,
   streamingUrl: ?string,

--- a/ui/component/postEditor/view.jsx
+++ b/ui/component/postEditor/view.jsx
@@ -6,7 +6,7 @@ type Props = {
   uri: ?string,
   label: ?string,
   disabled: ?boolean,
-  filePath: string | File,
+  filePath: File,
   fileText: ?string,
   fileMimeType: ?string,
   streamingUrl: ?string,

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -19,7 +19,7 @@ type Props = {
   mode: ?string,
   name: ?string,
   title: ?string,
-  filePath: ?File,
+  filePath: ?string,
   fileMimeType: ?string,
   isStillEditing: boolean,
   balance: number,
@@ -77,7 +77,7 @@ function PublishFile(props: Props) {
   const sizeInMB = Number(size) / 1000000;
   const secondsToProcess = sizeInMB / PROCESSING_MB_PER_SECOND;
   const ffmpegAvail = ffmpegStatus.available;
-  const [currentFile, setCurrentFile] = useState(null);
+  const currentFile = filePath;
   const [currentFileType, setCurrentFileType] = useState(null);
   const [optimizeAvail, setOptimizeAvail] = useState(false);
   const [userOptimize, setUserOptimize] = usePersistedState('publish-file-user-optimize', false);
@@ -86,22 +86,10 @@ function PublishFile(props: Props) {
   useEffect(() => {
     if (mode === PUBLISH_MODES.POST) {
       if (currentFileType !== 'text/markdown' && !isStillEditing) {
-        updatePublishForm({ filePath: undefined });
+        updatePublishForm({ filePath: '' });
       }
     }
   }, [currentFileType, mode, isStillEditing, updatePublishForm]);
-
-  useEffect(() => {
-    if (!filePath) {
-      setCurrentFile('');
-      updateFileInfo(0, 0, false);
-    } else {
-      // Update currentFile file
-      if (filePath.name !== currentFile) {
-        handleFileChange({ file: filePath, path: filePath.name });
-      }
-    }
-  }, [filePath, currentFile, handleFileChange, updateFileInfo]);
 
   useEffect(() => {
     const isOptimizeAvail = currentFile && currentFile !== '' && isVid && ffmpegAvail;
@@ -215,14 +203,14 @@ function PublishFile(props: Props) {
     // select file, start to select a new one, then cancel
     if (!fileWithPath) {
       if (isStillEditing || !clearName) {
-        updatePublishForm({ filePath: undefined });
+        updatePublishForm({ filePath: '' });
       } else {
-        updatePublishForm({ filePath: undefined, name: '' });
+        updatePublishForm({ filePath: '', name: '' });
       }
       return;
     }
 
-    // if video, extract duration so we can warn about bitrateif (typeof file !== 'string') {
+    // if video, extract duration so we can warn about bitrate if (typeof file !== 'string')
     const file = fileWithPath.file;
     const contentType = file.type && file.type.split('/');
     const isVideo = contentType && contentType[0] === 'video';
@@ -271,8 +259,8 @@ function PublishFile(props: Props) {
       setPublishMode(PUBLISH_MODES.FILE);
     }
 
-    const publishFormParams: { filePath: File, name?: string, optimize?: boolean } = {
-      filePath: file,
+    const publishFormParams: { filePath: string, name?: string, optimize?: boolean } = {
+      filePath: fileWithPath.path,
     };
     // Strip off extention and replace invalid characters
     let fileName = name || (file.name && file.name.substring(0, file.name.lastIndexOf('.'))) || '';
@@ -281,7 +269,6 @@ function PublishFile(props: Props) {
       publishFormParams.name = parseName(fileName);
     }
 
-    setCurrentFile(fileWithPath.path);
     updatePublishForm(publishFormParams);
   }
 

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -19,7 +19,7 @@ type Props = {
   mode: ?string,
   name: ?string,
   title: ?string,
-  filePath: string | WebFile,
+  filePath: string | File,
   fileMimeType: ?string,
   isStillEditing: boolean,
   balance: number,
@@ -97,8 +97,8 @@ function PublishFile(props: Props) {
       updateFileInfo(0, 0, false);
     } else if (typeof filePath !== 'string') {
       // Update currentFile file
-      if (filePath.name !== currentFile && filePath.path !== currentFile) {
-        handleFileChange(filePath);
+      if (filePath.name !== currentFile) {
+        handleFileChange({ file: filePath, path: filePath.name });
       }
     }
   }, [filePath, currentFile, handleFileChange, updateFileInfo]);
@@ -209,11 +209,11 @@ function PublishFile(props: Props) {
     }
   }
 
-  function handleFileChange(file: WebFile, clearName = true) {
+  function handleFileChange(fileWithPath: FileWithPath, clearName = true) {
     window.URL = window.URL || window.webkitURL;
 
     // select file, start to select a new one, then cancel
-    if (!file) {
+    if (!fileWithPath) {
       if (isStillEditing || !clearName) {
         updatePublishForm({ filePath: '' });
       } else {
@@ -223,6 +223,7 @@ function PublishFile(props: Props) {
     }
 
     // if video, extract duration so we can warn about bitrateif (typeof file !== 'string') {
+    const file = fileWithPath.file;
     const contentType = file.type && file.type.split('/');
     const isVideo = contentType && contentType[0] === 'video';
     const isMp4 = contentType && contentType[1] === 'mp4';
@@ -270,10 +271,10 @@ function PublishFile(props: Props) {
       setPublishMode(PUBLISH_MODES.FILE);
     }
 
-    const publishFormParams: { filePath: string | WebFile, name?: string, optimize?: boolean } = {
+    const publishFormParams: { filePath: string | File, name?: string, optimize?: boolean } = {
       // if electron, we'll set filePath to the path string because SDK is handling publishing.
       // File.path will be undefined from web due to browser security, so it will default to the File Object.
-      filePath: file.path || file,
+      filePath: fileWithPath.path || file,
     };
     // Strip off extention and replace invalid characters
     let fileName = name || (file.name && file.name.substring(0, file.name.lastIndexOf('.'))) || '';
@@ -282,8 +283,7 @@ function PublishFile(props: Props) {
       publishFormParams.name = parseName(fileName);
     }
 
-    // File path is not supported on web for security reasons so we use the name instead.
-    setCurrentFile(file.path || file.name);
+    setCurrentFile(fileWithPath.path);
     updatePublishForm(publishFormParams);
   }
 

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -19,7 +19,7 @@ type Props = {
   mode: ?string,
   name: ?string,
   title: ?string,
-  filePath: string | File,
+  filePath: ?File,
   fileMimeType: ?string,
   isStillEditing: boolean,
   balance: number,
@@ -86,16 +86,16 @@ function PublishFile(props: Props) {
   useEffect(() => {
     if (mode === PUBLISH_MODES.POST) {
       if (currentFileType !== 'text/markdown' && !isStillEditing) {
-        updatePublishForm({ filePath: '' });
+        updatePublishForm({ filePath: undefined });
       }
     }
   }, [currentFileType, mode, isStillEditing, updatePublishForm]);
 
   useEffect(() => {
-    if (!filePath || filePath === '') {
+    if (!filePath) {
       setCurrentFile('');
       updateFileInfo(0, 0, false);
-    } else if (typeof filePath !== 'string') {
+    } else {
       // Update currentFile file
       if (filePath.name !== currentFile) {
         handleFileChange({ file: filePath, path: filePath.name });
@@ -215,9 +215,9 @@ function PublishFile(props: Props) {
     // select file, start to select a new one, then cancel
     if (!fileWithPath) {
       if (isStillEditing || !clearName) {
-        updatePublishForm({ filePath: '' });
+        updatePublishForm({ filePath: undefined });
       } else {
-        updatePublishForm({ filePath: '', name: '' });
+        updatePublishForm({ filePath: undefined, name: '' });
       }
       return;
     }
@@ -271,10 +271,8 @@ function PublishFile(props: Props) {
       setPublishMode(PUBLISH_MODES.FILE);
     }
 
-    const publishFormParams: { filePath: string | File, name?: string, optimize?: boolean } = {
-      // if electron, we'll set filePath to the path string because SDK is handling publishing.
-      // File.path will be undefined from web due to browser security, so it will default to the File Object.
-      filePath: fileWithPath.path || file,
+    const publishFormParams: { filePath: File, name?: string, optimize?: boolean } = {
+      filePath: file,
     };
     // Strip off extention and replace invalid characters
     let fileName = name || (file.name && file.name.substring(0, file.name.lastIndexOf('.'))) || '';

--- a/ui/component/publishFile/view.jsx
+++ b/ui/component/publishFile/view.jsx
@@ -233,7 +233,7 @@ function PublishFile(props: Props) {
       isTextPost = contentType[1] === 'plain' || contentType[1] === 'markdown';
       setCurrentFileType(contentType);
     } else if (file.name) {
-      // If user's machine is missign a valid content type registration
+      // If user's machine is missing a valid content type registration
       // for markdown content: text/markdown, file extension will be used instead
       const extension = file.name.split('.').pop();
       isTextPost = MARKDOWN_FILE_EXTENSIONS.includes(extension);

--- a/ui/component/publishForm/view.jsx
+++ b/ui/component/publishForm/view.jsx
@@ -35,8 +35,8 @@ import tempy from 'tempy';
 type Props = {
   disabled: boolean,
   tags: Array<Tag>,
-  publish: (source?: string | File, ?boolean) => void,
-  filePath: string | File,
+  publish: (source: ?File, ?boolean) => void,
+  filePath: ?File,
   fileText: string,
   bid: ?number,
   bidError: ?string,
@@ -373,9 +373,6 @@ function PublishForm(props: Props) {
     if (!output || output === '') {
       // Generate a temporary file:
       output = tempy.file({ name: 'post.md' });
-    } else if (typeof filePath === 'string') {
-      // Use current file
-      output = filePath;
     }
     // Create a temporary file and save file changes
     if (output && output !== '') {
@@ -447,7 +444,7 @@ function PublishForm(props: Props) {
   // with other properties such as name, title, etc.) for security reasons.
   useEffect(() => {
     if (mode === PUBLISH_MODES.FILE) {
-      updatePublishForm({ filePath: '', fileDur: 0, fileSize: 0 });
+      updatePublishForm({ filePath: undefined, fileDur: 0, fileSize: 0 });
     }
   }, [mode, updatePublishForm]);
 

--- a/ui/component/selectAsset/view.jsx
+++ b/ui/component/selectAsset/view.jsx
@@ -27,6 +27,14 @@ type Props = {
   // passed to the onUpdate function after the
   // upload service returns success.
   buildImagePreview?: boolean,
+  // File extension filtering. Files can be filtered
+  // but the "All Files" options always shows up. To
+  // avoid that, you can use the filters property.
+  // For example, to only accept images pass the
+  // following filter:
+  // { name: 'Images', extensions: ['jpg', 'png', 'gif'] },
+  filters?: Array<{ name: string, extension: string[] }>,
+  type?: string,
 };
 
 function filePreview(file) {
@@ -43,7 +51,8 @@ function filePreview(file) {
 }
 
 function SelectAsset(props: Props) {
-  const { onUpdate, onDone, assetName, currentValue, recommended, title, inline, buildImagePreview } = props;
+  const { onUpdate, onDone, assetName, currentValue, recommended, title, inline, buildImagePreview, filters, type } =
+    props;
   const [pathSelected, setPathSelected] = React.useState('');
   const [fileSelected, setFileSelected] = React.useState<any>(null);
   const [uploadStatus, setUploadStatus] = React.useState(SPEECH_READY);
@@ -121,6 +130,8 @@ function SelectAsset(props: Props) {
           />
         ) : (
           <FileSelector
+            filters={filters}
+            type={type}
             autoFocus
             disabled={uploadStatus === SPEECH_UPLOADING}
             label={fileSelectorLabel}

--- a/ui/component/selectAsset/view.jsx
+++ b/ui/component/selectAsset/view.jsx
@@ -137,12 +137,10 @@ function SelectAsset(props: Props) {
             label={fileSelectorLabel}
             name="assetSelector"
             currentPath={pathSelected}
-            onFileChosen={(file) => {
-              if (file.name) {
-                setFileSelected(file);
-                // what why? why not target=WEB this?
-                // file.path is undefined in web but available in electron
-                setPathSelected(file.name || file.path);
+            onFileChosen={(fileWithPath) => {
+              if (fileWithPath.file.name) {
+                setFileSelected(fileWithPath.file);
+                setPathSelected(fileWithPath.path);
               }
             }}
             accept={accept}

--- a/ui/component/selectThumbnail/view.jsx
+++ b/ui/component/selectThumbnail/view.jsx
@@ -160,9 +160,9 @@ function SelectThumbnail(props: Props) {
                     label={__('Thumbnail')}
                     placeholder={__('Choose an enticing thumbnail')}
                     accept={accept}
-                    onFileChosen={(file) =>
+                    onFileChosen={(fileWithPath) =>
                       openModal(MODALS.CONFIRM_THUMBNAIL_UPLOAD, {
-                        file,
+                        file: fileWithPath,
                         cb: (url) => updateThumbnailParams && updateThumbnailParams({ thumbnail_url: url }),
                       })
                     }

--- a/ui/component/settingSystem/view.jsx
+++ b/ui/component/settingSystem/view.jsx
@@ -130,7 +130,7 @@ export default function SettingSystem(props: Props) {
               <FileSelector
                 type="openDirectory"
                 currentPath={daemonSettings.download_dir}
-                onFileChosen={(newDirectory: WebFile) => {
+                onFileChosen={(newDirectory: FileWithPath) => {
                   setDaemonSetting('download_dir', newDirectory.path);
                 }}
               />
@@ -224,7 +224,7 @@ export default function SettingSystem(props: Props) {
                 type="openDirectory"
                 placeholder={__('A Folder containing FFmpeg')}
                 currentPath={ffmpegPath || daemonSettings.ffmpeg_path}
-                onFileChosen={(newDirectory: WebFile) => {
+                onFileChosen={(newDirectory: FileWithPath) => {
                   // $FlowFixMe
                   setDaemonSetting('ffmpeg_path', newDirectory.path);
                   findFFmpeg();

--- a/ui/modal/modalAutoGenerateThumbnail/view.jsx
+++ b/ui/modal/modalAutoGenerateThumbnail/view.jsx
@@ -4,7 +4,7 @@ import { Modal } from 'modal/modal';
 import { formatFileSystemPath } from 'util/url';
 
 type Props = {
-  upload: WebFile => void,
+  upload: (File) => void,
   filePath: string,
   closeModal: () => void,
   showToast: ({}) => void,

--- a/ui/modal/modalConfirmThumbnailUpload/index.js
+++ b/ui/modal/modalConfirmThumbnailUpload/index.js
@@ -5,7 +5,7 @@ import ModalConfirmThumbnailUpload from './view';
 
 const perform = (dispatch) => ({
   closeModal: () => dispatch(doHideModal()),
-  upload: (file, cb) => dispatch(doUploadThumbnail(null, file, null, null, file.path, cb)),
+  upload: (fileWithPath, cb) => dispatch(doUploadThumbnail(null, fileWithPath.file, null, null, fileWithPath.path, cb)),
   updatePublishForm: (value) => dispatch(doUpdatePublishForm(value)),
 });
 

--- a/ui/modal/modalConfirmThumbnailUpload/view.jsx
+++ b/ui/modal/modalConfirmThumbnailUpload/view.jsx
@@ -4,8 +4,8 @@ import { Modal } from 'modal/modal';
 import { DOMAIN } from 'config';
 
 type Props = {
-  file: WebFile,
-  upload: (WebFile, (string) => void) => void,
+  file: FileWithPath,
+  upload: (FileWithPath, (string) => void) => void,
   cb: (string) => void,
   closeModal: () => void,
   updatePublishForm: ({}) => void,
@@ -23,7 +23,7 @@ class ModalConfirmThumbnailUpload extends React.PureComponent<Props> {
 
   render() {
     const { closeModal, file } = this.props;
-    const filePath = file && (file.path || file.name);
+    const filePath = file && file.path;
 
     return (
       <Modal

--- a/ui/modal/modalFileSelection/view.jsx
+++ b/ui/modal/modalFileSelection/view.jsx
@@ -9,12 +9,12 @@ import Button from 'component/button';
 import FileList from 'component/common/file-list';
 
 type Props = {
-  files: Array<WebFile>,
+  files: Array<File>,
   hideModal: () => void,
   updatePublishForm: ({}) => void,
   history: {
     location: { pathname: string },
-    push: string => void,
+    push: (string) => void,
   },
 };
 
@@ -43,7 +43,7 @@ const ModalFileSelection = (props: Props) => {
     navigateToPublish();
   }
 
-  const handleFileChange = (file?: WebFile) => {
+  const handleFileChange = (file?: File) => {
     // $FlowFixMe
     setSelectedFile(file);
   };

--- a/ui/modal/modalImageUpload/view.jsx
+++ b/ui/modal/modalImageUpload/view.jsx
@@ -14,10 +14,13 @@ type Props = {
 
 function ModalImageUpload(props: Props) {
   const { closeModal, currentValue, title, assetName, helpText, onUpdate } = props;
+  const filters = React.useMemo(() => [{ name: 'Images', extensions: ['jpg', 'png', 'gif'] }]);
 
   return (
     <Modal isOpen type="card" onAborted={closeModal} contentLabel={title}>
       <SelectAsset
+        filters={filters}
+        type="openFile"
         onUpdate={onUpdate}
         currentValue={currentValue}
         assetName={assetName}

--- a/ui/modal/modalImageUpload/view.jsx
+++ b/ui/modal/modalImageUpload/view.jsx
@@ -14,7 +14,7 @@ type Props = {
 
 function ModalImageUpload(props: Props) {
   const { closeModal, currentValue, title, assetName, helpText, onUpdate } = props;
-  const filters = React.useMemo(() => [{ name: 'Images', extensions: ['jpg', 'png', 'gif'] }]);
+  const filters = React.useMemo(() => [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'gif', 'svg'] }]);
 
   return (
     <Modal isOpen type="card" onAborted={closeModal} contentLabel={title}>

--- a/ui/modal/modalPublishPreview/view.jsx
+++ b/ui/modal/modalPublishPreview/view.jsx
@@ -15,7 +15,7 @@ import Icon from 'component/common/icon';
 import { NO_FILE } from 'redux/actions/publish';
 
 type Props = {
-  filePath: string | File,
+  filePath: ?File,
   isMarkdownPost: boolean,
   optimize: boolean,
   title: ?string,
@@ -104,16 +104,11 @@ const ModalPublishPreview = (props: Props) => {
     // @endif
   }
 
-  function getFilePathName(filePath: string | File) {
+  function getFilePathName(filePath: ?File) {
     if (!filePath) {
       return NO_FILE;
     }
-
-    if (typeof filePath === 'string') {
-      return filePath;
-    } else {
-      return filePath.name;
-    }
+    return filePath.name;
   }
 
   function createRow(label: string, value: any) {
@@ -127,7 +122,7 @@ const ModalPublishPreview = (props: Props) => {
 
   const txFee = previewResponse ? previewResponse['total_fee'] : null;
   //   $FlowFixMe add outputs[0] etc to PublishResponse type
-  const isOptimizeAvail = filePath && filePath !== '' && isVid && ffmpegStatus.available;
+  const isOptimizeAvail = filePath && isVid && ffmpegStatus.available;
   let modalTitle;
   if (isStillEditing) {
     modalTitle = __('Confirm Edit');

--- a/ui/modal/modalPublishPreview/view.jsx
+++ b/ui/modal/modalPublishPreview/view.jsx
@@ -15,7 +15,7 @@ import Icon from 'component/common/icon';
 import { NO_FILE } from 'redux/actions/publish';
 
 type Props = {
-  filePath: string | WebFile,
+  filePath: string | File,
   isMarkdownPost: boolean,
   optimize: boolean,
   title: ?string,
@@ -104,7 +104,7 @@ const ModalPublishPreview = (props: Props) => {
     // @endif
   }
 
-  function getFilePathName(filePath: string | WebFile) {
+  function getFilePathName(filePath: string | File) {
     if (!filePath) {
       return NO_FILE;
     }

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -18,7 +18,7 @@ import Lbry from 'lbry';
 import { isClaimNsfw } from 'util/claim';
 
 export const NO_FILE = '---';
-export const doPublishDesktop = (filePath: string, preview?: boolean) => (dispatch: Dispatch, getState: () => {}) => {
+export const doPublishDesktop = (filePath: ?File, preview?: boolean) => (dispatch: Dispatch, getState: () => {}) => {
   const publishPreview = (previewResponse) => {
     dispatch(
       doOpenModal(MODALS.PUBLISH_PREVIEW, {
@@ -138,335 +138,327 @@ export const doUpdatePublishForm = (publishFormValue: UpdatePublishFormData) => 
     data: { ...publishFormValue },
   });
 
-export const doUploadThumbnail = (
-  filePath?: string,
-  thumbnailBlob?: File,
-  fsAdapter?: any,
-  fs?: any,
-  path?: any,
-  cb?: (string) => void
-) => (dispatch: Dispatch) => {
-  const downMessage = __('Thumbnail upload service may be down, try again later.');
-  let thumbnail, fileExt, fileName, fileType;
+export const doUploadThumbnail =
+  (filePath?: string, thumbnailBlob?: File, fsAdapter?: any, fs?: any, path?: any, cb?: (string) => void) =>
+  (dispatch: Dispatch) => {
+    const downMessage = __('Thumbnail upload service may be down, try again later.');
+    let thumbnail, fileExt, fileName, fileType;
 
-  const makeid = () => {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 24; i += 1) text += possible.charAt(Math.floor(Math.random() * 62));
-    return text;
-  };
+    const makeid = () => {
+      let text = '';
+      const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+      for (let i = 0; i < 24; i += 1) text += possible.charAt(Math.floor(Math.random() * 62));
+      return text;
+    };
 
-  const uploadError = (error = '') => {
-    dispatch(
-      batchActions(
-        {
-          type: ACTIONS.UPDATE_PUBLISH_FORM,
-          data: {
-            uploadThumbnailStatus: THUMBNAIL_STATUSES.READY,
-            thumbnail: '',
-            nsfw: false,
+    const uploadError = (error = '') => {
+      dispatch(
+        batchActions(
+          {
+            type: ACTIONS.UPDATE_PUBLISH_FORM,
+            data: {
+              uploadThumbnailStatus: THUMBNAIL_STATUSES.READY,
+              thumbnail: '',
+              nsfw: false,
+            },
           },
-        },
-        doError(error)
-      )
-    );
-  };
+          doError(error)
+        )
+      );
+    };
 
-  dispatch({
-    type: ACTIONS.UPDATE_PUBLISH_FORM,
-    data: {
-      thumbnailError: undefined,
-    },
-  });
+    dispatch({
+      type: ACTIONS.UPDATE_PUBLISH_FORM,
+      data: {
+        thumbnailError: undefined,
+      },
+    });
 
-  const doUpload = (data) => {
-    return fetch(SPEECH_PUBLISH, {
-      method: 'POST',
-      body: data,
-    })
-      .then((res) => res.text())
-      .then((text) => (text.length ? JSON.parse(text) : {}))
-      .then((json) => {
-        if (!json.success) return uploadError(json.message || downMessage);
-        if (cb) {
-          cb(json.data.serveUrl);
-        }
-        return dispatch({
-          type: ACTIONS.UPDATE_PUBLISH_FORM,
-          data: {
-            uploadThumbnailStatus: THUMBNAIL_STATUSES.COMPLETE,
-            thumbnail: json.data.serveUrl,
-          },
-        });
+    const doUpload = (data) => {
+      return fetch(SPEECH_PUBLISH, {
+        method: 'POST',
+        body: data,
       })
-      .catch((err) => {
-        let message = err.message;
+        .then((res) => res.text())
+        .then((text) => (text.length ? JSON.parse(text) : {}))
+        .then((json) => {
+          if (!json.success) return uploadError(json.message || downMessage);
+          if (cb) {
+            cb(json.data.serveUrl);
+          }
+          return dispatch({
+            type: ACTIONS.UPDATE_PUBLISH_FORM,
+            data: {
+              uploadThumbnailStatus: THUMBNAIL_STATUSES.COMPLETE,
+              thumbnail: json.data.serveUrl,
+            },
+          });
+        })
+        .catch((err) => {
+          let message = err.message;
 
-        // This sucks but ¯\_(ツ)_/¯
-        if (message === 'Failed to fetch') {
-          message = downMessage;
-        }
-        const userInput = [fileName, fileExt, fileType, thumbnail];
-        uploadError(`${message}\nUser input:  ${userInput.join(', ')}`);
+          // This sucks but ¯\_(ツ)_/¯
+          if (message === 'Failed to fetch') {
+            message = downMessage;
+          }
+          const userInput = [fileName, fileExt, fileType, thumbnail];
+          uploadError(`${message}\nUser input:  ${userInput.join(', ')}`);
+        });
+    };
+
+    dispatch({
+      type: ACTIONS.UPDATE_PUBLISH_FORM,
+      data: { uploadThumbnailStatus: THUMBNAIL_STATUSES.IN_PROGRESS },
+    });
+
+    if (fsAdapter && fsAdapter.readFile && filePath) {
+      fsAdapter.readFile(filePath, 'base64').then((base64Image) => {
+        fileExt = 'png';
+        fileName = 'thumbnail.png';
+        fileType = 'image/png';
+
+        const data = new FormData();
+        const name = makeid();
+        data.append('name', name);
+        // $FlowFixMe
+        data.append('file', { uri: 'file://' + filePath, type: fileType, name: fileName });
+        return doUpload(data);
       });
-  };
-
-  dispatch({
-    type: ACTIONS.UPDATE_PUBLISH_FORM,
-    data: { uploadThumbnailStatus: THUMBNAIL_STATUSES.IN_PROGRESS },
-  });
-
-  if (fsAdapter && fsAdapter.readFile && filePath) {
-    fsAdapter.readFile(filePath, 'base64').then((base64Image) => {
-      fileExt = 'png';
-      fileName = 'thumbnail.png';
-      fileType = 'image/png';
+    } else {
+      if (filePath && fs && path) {
+        thumbnail = fs.readFileSync(filePath);
+        fileExt = path.extname(filePath);
+        fileName = path.basename(filePath);
+        fileType = `image/${fileExt.slice(1)}`;
+      } else if (thumbnailBlob) {
+        fileExt = `.${thumbnailBlob.type && thumbnailBlob.type.split('/')[1]}`;
+        fileName = thumbnailBlob.name;
+        fileType = thumbnailBlob.type;
+      } else {
+        return null;
+      }
 
       const data = new FormData();
       const name = makeid();
+      const file = thumbnailBlob || (thumbnail && new File([thumbnail], fileName, { type: fileType }));
       data.append('name', name);
       // $FlowFixMe
-      data.append('file', { uri: 'file://' + filePath, type: fileType, name: fileName });
+      data.append('file', file);
       return doUpload(data);
-    });
-  } else {
-    if (filePath && fs && path) {
-      thumbnail = fs.readFileSync(filePath);
-      fileExt = path.extname(filePath);
-      fileName = path.basename(filePath);
-      fileType = `image/${fileExt.slice(1)}`;
-    } else if (thumbnailBlob) {
-      fileExt = `.${thumbnailBlob.type && thumbnailBlob.type.split('/')[1]}`;
-      fileName = thumbnailBlob.name;
-      fileType = thumbnailBlob.type;
-    } else {
-      return null;
     }
-
-    const data = new FormData();
-    const name = makeid();
-    const file = thumbnailBlob || (thumbnail && new File([thumbnail], fileName, { type: fileType }));
-    data.append('name', name);
-    // $FlowFixMe
-    data.append('file', file);
-    return doUpload(data);
-  }
-};
-
-export const doPrepareEdit = (claim: StreamClaim, uri: string, fileInfo: FileListItem, fs: any) => (
-  dispatch: Dispatch
-) => {
-  const { name, amount, value = {} } = claim;
-  const channelName = (claim && claim.signing_channel && claim.signing_channel.name) || null;
-  const {
-    author,
-    description,
-    // use same values as default state
-    // fee will be undefined for free content
-    fee = {
-      amount: '0',
-      currency: 'LBC',
-    },
-    languages,
-    release_time,
-    license,
-    license_url: licenseUrl,
-    thumbnail,
-    title,
-    tags,
-  } = value;
-
-  const publishData: UpdatePublishFormData = {
-    name,
-    bid: Number(amount),
-    contentIsFree: fee.amount === '0',
-    author,
-    description,
-    fee,
-    languages,
-    releaseTime: release_time,
-    releaseTimeEdited: undefined,
-    thumbnail: thumbnail ? thumbnail.url : null,
-    title,
-    uri,
-    uploadThumbnailStatus: thumbnail ? THUMBNAIL_STATUSES.MANUAL : undefined,
-    licenseUrl,
-    nsfw: isClaimNsfw(claim),
-    tags: tags ? tags.map((tag) => ({ name: tag })) : [],
   };
 
-  // Make sure custom licenses are mapped properly
-  // If the license isn't one of the standard licenses, map the custom license and description/url
-  if (!CC_LICENSES.some(({ value }) => value === license)) {
-    if (!license || license === NONE || license === PUBLIC_DOMAIN) {
+export const doPrepareEdit =
+  (claim: StreamClaim, uri: string, fileInfo: FileListItem, fs: any) => (dispatch: Dispatch) => {
+    const { name, amount, value = {} } = claim;
+    const channelName = (claim && claim.signing_channel && claim.signing_channel.name) || null;
+    const {
+      author,
+      description,
+      // use same values as default state
+      // fee will be undefined for free content
+      fee = {
+        amount: '0',
+        currency: 'LBC',
+      },
+      languages,
+      release_time,
+      license,
+      license_url: licenseUrl,
+      thumbnail,
+      title,
+      tags,
+    } = value;
+
+    const publishData: UpdatePublishFormData = {
+      name,
+      bid: Number(amount),
+      contentIsFree: fee.amount === '0',
+      author,
+      description,
+      fee,
+      languages,
+      releaseTime: release_time,
+      releaseTimeEdited: undefined,
+      thumbnail: thumbnail ? thumbnail.url : null,
+      title,
+      uri,
+      uploadThumbnailStatus: thumbnail ? THUMBNAIL_STATUSES.MANUAL : undefined,
+      licenseUrl,
+      nsfw: isClaimNsfw(claim),
+      tags: tags ? tags.map((tag) => ({ name: tag })) : [],
+    };
+
+    // Make sure custom licenses are mapped properly
+    // If the license isn't one of the standard licenses, map the custom license and description/url
+    if (!CC_LICENSES.some(({ value }) => value === license)) {
+      if (!license || license === NONE || license === PUBLIC_DOMAIN) {
+        publishData.licenseType = license;
+      } else if (license && !licenseUrl && license !== NONE) {
+        publishData.licenseType = COPYRIGHT;
+      } else {
+        publishData.licenseType = OTHER;
+      }
+
+      publishData.otherLicenseDescription = license;
+    } else {
       publishData.licenseType = license;
-    } else if (license && !licenseUrl && license !== NONE) {
-      publishData.licenseType = COPYRIGHT;
-    } else {
-      publishData.licenseType = OTHER;
+    }
+    if (channelName) {
+      publishData['channel'] = channelName;
     }
 
-    publishData.otherLicenseDescription = license;
-  } else {
-    publishData.licenseType = license;
-  }
-  if (channelName) {
-    publishData['channel'] = channelName;
-  }
-
-  dispatch({ type: ACTIONS.DO_PREPARE_EDIT, data: publishData });
-};
-
-export const doPublish = (success: Function, fail: Function, preview: Function) => (
-  dispatch: Dispatch,
-  getState: () => {}
-) => {
-  if (!preview) {
-    dispatch({ type: ACTIONS.PUBLISH_START });
-  }
-
-  const state = getState();
-  const myClaimForUri = selectMyClaimForUri(state);
-  const myChannels = selectMyChannelClaims(state);
-  // const myClaims = selectMyClaimsWithoutChannels(state);
-  // get redux publish form
-  const publishData = selectPublishFormValues(state);
-
-  // destructure the data values
-  const {
-    name,
-    bid,
-    filePath,
-    description,
-    language,
-    releaseTimeEdited,
-    // license,
-    licenseUrl,
-    useLBRYUploader,
-    licenseType,
-    otherLicenseDescription,
-    thumbnail,
-    channel,
-    title,
-    contentIsFree,
-    fee,
-    tags,
-    // locations,
-    optimize,
-  } = publishData;
-
-  // Handle scenario where we have a claim that has the same name as a channel we are publishing with.
-  const myClaimForUriEditing = myClaimForUri && myClaimForUri.name === name ? myClaimForUri : null;
-
-  let publishingLicense;
-  switch (licenseType) {
-    case COPYRIGHT:
-    case OTHER:
-      publishingLicense = otherLicenseDescription;
-      break;
-    default:
-      publishingLicense = licenseType;
-  }
-
-  // get the claim id from the channel name, we will use that instead
-  const namedChannelClaim = myChannels ? myChannels.find((myChannel) => myChannel.name === channel) : null;
-  const channelId = namedChannelClaim ? namedChannelClaim.claim_id : '';
-
-  const publishPayload: {
-    name: ?string,
-    bid: string,
-    description?: string,
-    channel_id?: string,
-    file_path?: string,
-    license_url?: string,
-    license?: string,
-    thumbnail_url?: string,
-    release_time?: number,
-    fee_currency?: string,
-    fee_amount?: string,
-    languages?: Array<string>,
-    tags: Array<string>,
-    locations?: Array<any>,
-    blocking: boolean,
-    optimize_file?: boolean,
-    preview?: boolean,
-    remote_url?: string,
-  } = {
-    name,
-    title,
-    description,
-    locations: [],
-    bid: creditsToString(bid),
-    languages: [language],
-    tags: tags && tags.map((tag) => tag.name),
-    thumbnail_url: thumbnail,
-    blocking: true,
-    preview: false,
+    dispatch({ type: ACTIONS.DO_PREPARE_EDIT, data: publishData });
   };
-  // Temporary solution to keep the same publish flow with the new tags api
-  // Eventually we will allow users to enter their own tags on publish
 
-  if (publishingLicense) {
-    publishPayload.license = publishingLicense;
-  }
+export const doPublish =
+  (success: Function, fail: Function, preview: Function) => (dispatch: Dispatch, getState: () => {}) => {
+    if (!preview) {
+      dispatch({ type: ACTIONS.PUBLISH_START });
+    }
 
-  if (licenseUrl) {
-    publishPayload.license_url = licenseUrl;
-  }
+    const state = getState();
+    const myClaimForUri = selectMyClaimForUri(state);
+    const myChannels = selectMyChannelClaims(state);
+    // const myClaims = selectMyClaimsWithoutChannels(state);
+    // get redux publish form
+    const publishData = selectPublishFormValues(state);
 
-  if (thumbnail) {
-    publishPayload.thumbnail_url = thumbnail;
-  }
+    // destructure the data values
+    const {
+      name,
+      bid,
+      filePath,
+      description,
+      language,
+      releaseTimeEdited,
+      // license,
+      licenseUrl,
+      useLBRYUploader,
+      licenseType,
+      otherLicenseDescription,
+      thumbnail,
+      channel,
+      title,
+      contentIsFree,
+      fee,
+      tags,
+      // locations,
+      optimize,
+    } = publishData;
 
-  if (useLBRYUploader) {
-    publishPayload.tags.push('lbry-first');
-  }
+    // Handle scenario where we have a claim that has the same name as a channel we are publishing with.
+    const myClaimForUriEditing = myClaimForUri && myClaimForUri.name === name ? myClaimForUri : null;
 
-  // Set release time to curret date. On edits, keep original release/transaction time as release_time
-  if (releaseTimeEdited) {
-    publishPayload.release_time = releaseTimeEdited;
-  } else if (myClaimForUriEditing && myClaimForUriEditing.value.release_time) {
-    publishPayload.release_time = Number(myClaimForUri.value.release_time);
-  } else if (myClaimForUriEditing && myClaimForUriEditing.timestamp) {
-    publishPayload.release_time = Number(myClaimForUriEditing.timestamp);
-  } else {
-    publishPayload.release_time = Number(Math.round(Date.now() / 1000));
-  }
+    let publishingLicense;
+    switch (licenseType) {
+      case COPYRIGHT:
+      case OTHER:
+        publishingLicense = otherLicenseDescription;
+        break;
+      default:
+        publishingLicense = licenseType;
+    }
 
-  if (channelId) {
-    publishPayload.channel_id = channelId;
-  }
+    // get the claim id from the channel name, we will use that instead
+    const namedChannelClaim = myChannels ? myChannels.find((myChannel) => myChannel.name === channel) : null;
+    const channelId = namedChannelClaim ? namedChannelClaim.claim_id : '';
 
-  if (myClaimForUriEditing && myClaimForUriEditing.value && myClaimForUriEditing.value.locations) {
-    publishPayload.locations = myClaimForUriEditing.value.locations;
-  }
+    const publishPayload: {
+      name: ?string,
+      bid: string,
+      description?: string,
+      channel_id?: string,
+      file_path?: string,
+      license_url?: string,
+      license?: string,
+      thumbnail_url?: string,
+      release_time?: number,
+      fee_currency?: string,
+      fee_amount?: string,
+      languages?: Array<string>,
+      tags: Array<string>,
+      locations?: Array<any>,
+      blocking: boolean,
+      optimize_file?: boolean,
+      preview?: boolean,
+      remote_url?: string,
+    } = {
+      name,
+      title,
+      description,
+      locations: [],
+      bid: creditsToString(bid),
+      languages: [language],
+      tags: tags && tags.map((tag) => tag.name),
+      thumbnail_url: thumbnail,
+      blocking: true,
+      preview: false,
+    };
+    // Temporary solution to keep the same publish flow with the new tags api
+    // Eventually we will allow users to enter their own tags on publish
 
-  if (!contentIsFree && fee && fee.currency && Number(fee.amount) > 0) {
-    publishPayload.fee_currency = fee.currency;
-    publishPayload.fee_amount = creditsToString(fee.amount);
-  }
+    if (publishingLicense) {
+      publishPayload.license = publishingLicense;
+    }
 
-  if (optimize) {
-    publishPayload.optimize_file = true;
-  }
+    if (licenseUrl) {
+      publishPayload.license_url = licenseUrl;
+    }
 
-  // Only pass file on new uploads, not metadata only edits.
-  // The sdk will figure it out
-  if (filePath) publishPayload.file_path = filePath;
+    if (thumbnail) {
+      publishPayload.thumbnail_url = thumbnail;
+    }
 
-  if (preview) {
-    publishPayload.preview = true;
-    publishPayload.optimize_file = false;
+    if (useLBRYUploader) {
+      publishPayload.tags.push('lbry-first');
+    }
 
-    return Lbry.publish(publishPayload).then((previewResponse: PublishResponse) => {
-      return preview(previewResponse);
+    // Set release time to curret date. On edits, keep original release/transaction time as release_time
+    if (releaseTimeEdited) {
+      publishPayload.release_time = releaseTimeEdited;
+    } else if (myClaimForUriEditing && myClaimForUriEditing.value.release_time) {
+      publishPayload.release_time = Number(myClaimForUri.value.release_time);
+    } else if (myClaimForUriEditing && myClaimForUriEditing.timestamp) {
+      publishPayload.release_time = Number(myClaimForUriEditing.timestamp);
+    } else {
+      publishPayload.release_time = Number(Math.round(Date.now() / 1000));
+    }
+
+    if (channelId) {
+      publishPayload.channel_id = channelId;
+    }
+
+    if (myClaimForUriEditing && myClaimForUriEditing.value && myClaimForUriEditing.value.locations) {
+      publishPayload.locations = myClaimForUriEditing.value.locations;
+    }
+
+    if (!contentIsFree && fee && fee.currency && Number(fee.amount) > 0) {
+      publishPayload.fee_currency = fee.currency;
+      publishPayload.fee_amount = creditsToString(fee.amount);
+    }
+
+    if (optimize) {
+      publishPayload.optimize_file = true;
+    }
+
+    // Only pass file on new uploads, not metadata only edits.
+    // The sdk will figure it out
+    if (filePath) publishPayload.file_path = filePath;
+
+    if (preview) {
+      publishPayload.preview = true;
+      publishPayload.optimize_file = false;
+
+      return Lbry.publish(publishPayload).then((previewResponse: PublishResponse) => {
+        return preview(previewResponse);
+      }, fail);
+    }
+
+    return Lbry.publish(publishPayload).then((response: PublishResponse) => {
+      return success(response);
     }, fail);
-  }
-
-  return Lbry.publish(publishPayload).then((response: PublishResponse) => {
-    return success(response);
-  }, fail);
-};
+  };
 
 // Calls file_list until any reflecting files are done
 export const doCheckReflectingFiles = () => (dispatch: Dispatch, getState: GetState) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11549,6 +11549,7 @@ __metadata:
     lodash-es: ^4.17.21
     mammoth: ^1.4.16
     match-sorter: ^6.3.0
+    mime: ^3.0.0
     moment: ^2.29.2
     node-abi: ^2.5.1
     node-fetch: ^2.6.7
@@ -12573,6 +12574,15 @@ __metadata:
   bin:
     mime: cli.js
   checksum: 1497ba7b9f6960694268a557eae24b743fd2923da46ec392b042469f4b901721ba0adcf8b0d3c2677839d0e243b209d76e5edcbd09cfdeffa2dfb6bb4df4b862
+  languageName: node
+  linkType: hard
+
+"mime@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mime@npm:3.0.0"
+  bin:
+    mime: cli.js
+  checksum: f43f9b7bfa64534e6b05bd6062961681aeb406a5b53673b53b683f27fcc4e739989941836a355eef831f4478923651ecc739f4a5f6e20a76487b432bfd4db928
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/7646

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Even though a file filter is being used, the "All Files"
option allows users to select any file when uploading 
an image.

## What is the new behavior?

The electron filter is being used so the "All Files" 
option is no longer displayed.

![image](https://user-images.githubusercontent.com/1719111/184208937-a89cea19-cdcb-436e-85a6-eab8309687eb.png)


## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
