### PR TITLE
Fix viewer position and shape in mobile mode

### DIFF
--- a/ui/component/fileRenderFloating/view.jsx
+++ b/ui/component/fileRenderFloating/view.jsx
@@ -21,7 +21,6 @@ import AutoplayCountdown from 'component/autoplayCountdown';
 // scss/init/vars.scss
 // --header-height
 const HEADER_HEIGHT = 60;
-const HEADER_HEIGHT_MOBILE = 60;
 
 const IS_DESKTOP_MAC = typeof process === 'object' ? process.platform === 'darwin' : false;
 const DEBOUNCE_WINDOW_RESIZE_HANDLER_MS = 100;
@@ -356,7 +355,7 @@ export default function FileRenderFloating(props: Props) {
                 top:
                   fileViewerRect.windowOffset +
                   fileViewerRect.top -
-                  (isMobile ? HEADER_HEIGHT_MOBILE : HEADER_HEIGHT) -
+                  (isMobile ? 0 : HEADER_HEIGHT) -
                   (IS_DESKTOP_MAC ? 24 : 0),
               }
             : {}

--- a/ui/scss/component/_content.scss
+++ b/ui/scss/component/_content.scss
@@ -3,6 +3,10 @@
   position: absolute;
   top: var(--spacing-s);
   border-radius: var(--border-radius);
+
+  @media (max-width: $breakpoint-small) {
+    border-radius: 0;
+  }
 }
 
 .content__viewer--disable-click {
@@ -174,6 +178,10 @@
   &:-webkit-full-screen {
     width: 100%;
     height: 100%;
+  }
+
+  @media (max-width: $breakpoint-small) {
+    border-radius: 0;
   }
 }
 


### PR DESCRIPTION
## Fixes

Issue Number:

## What is the current behavior?
When the screen is narrow enough, the video is not render at the same location than the cover.
Because it's rather on the top of the window, the top of the video is hidden by the header.

## What is the new behavior?
The video is played at the exact same location than the cover, and is fully visible.
As well, because that area has then no margin with the border of the window, I removed the rounded border (seems to already be a pattern).

## Other information

This is a very minor change.

(On narrow window, it may look even better with an overlay scrollbar.)
Anyway, it may not be the best fix, but it solves my problem. Thank you for making lbry.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
