### PR TITLE
Playback rate popup triggered by click.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
 ### Fixed
  - Playback rate popup triggered by click. ([#7750](https://github.com/lbryio/lbry-desktop/pull/7750))
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Fixed
+ - Playback rate popup triggered by click. ([#7750](https://github.com/lbryio/lbry-desktop/pull/7750))
+ 
 ## [0.53.9] - [2023-2-8]
  
 ### Changed

--- a/ui/component/viewers/videoViewer/internal/videojs-events.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs-events.jsx
@@ -258,6 +258,23 @@ const VideoJsEvents = ({
       document.querySelector('.vjs-big-play-button').style.setProperty('display', 'none', 'important');
     });
     // player.on('ended', onEnded);
+    const PlaybackRateComponent = player.controlBar.playbackRateMenuButton;
+    const playbackRateBtn = document.querySelector('button.vjs-playback-rate');
+    const playbackRateDiv = playbackRateBtn && playbackRateBtn.parentElement;
+    const playbackRateMenu = document.querySelector('div.vjs-menu');
+    if (playbackRateBtn) {
+      // Remove all mouse events from playback-rate button
+      playbackRateBtn.style.pointerEvents = 'none';
+    }
+    // Set tooltip again
+    playbackRateDiv && playbackRateDiv.setAttribute('title', __('Playback Rate (<, >)'));
+    // Add click event to act same as ex-hover.
+    if (PlaybackRateComponent) {
+      PlaybackRateComponent.on('click', function () {
+        playbackRateDiv && playbackRateDiv.classList.add('vjs-hover');
+        playbackRateMenu && playbackRateMenu.classList.remove('vjs-hidden');
+      });
+    }
   }
 
   return {


### PR DESCRIPTION
## Fixes

Issue Number: #5715 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
- Playback-rate menu opens by mouse hover.
## What is the new behavior?
- Playback-rate menu opens by mouse click, only.
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
